### PR TITLE
close Phase E with trusted skills sync and maintenance PR workflow

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -83,3 +83,16 @@
 - [x] D-005 integrate decision-store reuse and persistence for PR-only unpushed-branch behavior.
 - [x] D-006 add unit tests for command workflow policy paths.
 - [x] D-007 add deeper E2E command tests with real git branch/remote scenarios.
+
+## Phase E Execution Log
+
+- Rationale: make remote skills and maintenance workflow operational for sustained governance quality.
+- Expected gain: predictable source lock behavior and recurring context health visibility.
+- Potential impact: extra state outputs and new CLI command surfaces (`skill`, `maintenance`).
+
+- [x] E-001 implement remote skills sync/list service with cache and lock updates.
+- [x] E-002 add CLI commands for `skill list`, `skill sync` with offline mode.
+- [x] E-003 implement maintenance local report generation and optional PR payload draft.
+- [x] E-004 add integration and unit tests for skills and maintenance behavior.
+- [x] E-005 enforce allowlist/pinning validation hard-fail logic in sync path.
+- [x] E-006 wire approved maintenance reports to optional automated PR command flow.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -107,3 +107,21 @@ Status:
 - Blockers: none.
 - Decisions: keep PR-only mode default as `defer-pr` for safer non-destructive behavior when branch is unpushed.
 - Next step: begin Phase E remote skills lock/cache and maintenance workflow implementation.
+
+### 2026-02-08 - Phase E / Start
+
+- Work completed: implemented skills sync/list services with lock and cache update behavior, added maintenance report generation, and exposed new CLI commands.
+- Changed modules: `skills.service`, `maintenance.report`, `cli`, and tests for skills/maintenance workflows.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` executed with passing status after fixes.
+- Blockers: none.
+- Decisions: keep maintenance workflow local-report-first by default and only generate PR payload metadata when explicitly approved.
+- Next step: tighten source trust enforcement and close remaining Phase E tasks.
+
+### 2026-02-08 - Phase E / Closeout
+
+- Work completed: enforced allowlist and checksum pinning hard-fail behaviors in skill sync, and added `maintenance pr` command that opens PRs only from approved payload metadata.
+- Changed modules: `skills.service`, `maintenance.report`, `cli`, and tests for trust policy and approved PR flow.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: keep trust enforcement fail-closed; unknown source hosts and checksum mismatches are treated as sync failures.
+- Next step: optional post-MVP hardening (cross-OS CI matrix, deeper command E2E with remote integration).

--- a/.ai-engineering/context/delivery/planning.md
+++ b/.ai-engineering/context/delivery/planning.md
@@ -55,7 +55,7 @@ If branch is not pushed:
 | Phase B | App bootstrap: module scaffolding, state schemas, install/doctor base | Completed |
 | Phase C | Governance enforcement: hooks, mandatory checks, protected-branch blocking | Completed |
 | Phase D | Command runtime: `/commit`, `/pr`, `/acho`, `/pr --only` continuation modes | Completed |
-| Phase E | Remote skills lock/cache and maintenance-agent workflow | Pending |
+| Phase E | Remote skills lock/cache and maintenance-agent workflow | Completed |
 
 ## Phase B Progress Notes
 
@@ -83,3 +83,12 @@ If branch is not pushed:
 
 - Completed in this block: command workflow service, CLI `commit`/`pr`/`acho` commands, and PR-only continuation handling (`auto-push`, `defer-pr`, `attempt-pr-anyway`, `export-pr-payload`).
 - Completed in Phase D closeout: workflow coverage for real git scenarios (feature-branch commit path and PR-only defer decision persistence).
+
+## Phase E Progress Notes
+
+- Rationale: activate remote skills cache/lock behavior and context-maintenance loops for long-term governance health.
+- Expected gain: deterministic skill sourcing with offline fallback and regular context quality reports.
+- Potential impact: `.ai-engineering/state/` now includes maintenance and skills sync artifacts.
+
+- Completed in this block: skills sync/list services with cache and lock updates, maintenance report generation, and CLI entrypoints.
+- Completed in Phase E closeout: hard-fail trust enforcement (allowlist + checksum pinning validation) and approved maintenance payload PR command flow.

--- a/.ai-engineering/state/audit-log.ndjson
+++ b/.ai-engineering/state/audit-log.ndjson
@@ -28,3 +28,23 @@
 {"event": "gate_passed", "actor": "gate-engine", "details": {"stage": "pre-commit"}}
 {"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "commit-msg", "failures": ["commit message cannot be empty"]}}
 {"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "pre-push", "failures": ["semgrep: failure\nremediation: address findings or tune local code before push", "pip-audit: failure\nremediation: upgrade vulnerable dependencies and regenerate lockfiles", "pytest: failure\nremediation: fix failing tests and rerun '.venv/bin/python -m pytest'", "ty: failure\nremediation: fix type diagnostics and rerun '.venv/bin/ty check src'"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "commit", "branch": "main", "protectedBranches": ["main", "master"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "push", "branch": "master", "protectedBranches": ["main", "master"]}}
+{"event": "gate_passed", "actor": "gate-engine", "details": {"stage": "pre-commit"}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "commit-msg", "failures": ["commit message cannot be empty"]}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "pre-push", "failures": ["semgrep: failure\nremediation: address findings or tune local code before push", "pip-audit: failure\nremediation: upgrade vulnerable dependencies and regenerate lockfiles", "pytest: failure\nremediation: fix failing tests and rerun '.venv/bin/python -m pytest'", "ty: failure\nremediation: fix type diagnostics and rerun '.venv/bin/ty check src'"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "commit", "branch": "main", "protectedBranches": ["main", "master"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "push", "branch": "master", "protectedBranches": ["main", "master"]}}
+{"event": "gate_passed", "actor": "gate-engine", "details": {"stage": "pre-commit"}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "commit-msg", "failures": ["commit message cannot be empty"]}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "pre-push", "failures": ["semgrep: failure\nremediation: address findings or tune local code before push", "pip-audit: failure\nremediation: upgrade vulnerable dependencies and regenerate lockfiles", "pytest: failure\nremediation: fix failing tests and rerun '.venv/bin/python -m pytest'", "ty: failure\nremediation: fix type diagnostics and rerun '.venv/bin/ty check src'"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "commit", "branch": "main", "protectedBranches": ["main", "master"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "push", "branch": "master", "protectedBranches": ["main", "master"]}}
+{"event": "gate_passed", "actor": "gate-engine", "details": {"stage": "pre-commit"}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "commit-msg", "failures": ["commit message cannot be empty"]}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "pre-push", "failures": ["semgrep: failure\nremediation: address findings or tune local code before push", "pip-audit: failure\nremediation: upgrade vulnerable dependencies and regenerate lockfiles", "pytest: failure\nremediation: fix failing tests and rerun '.venv/bin/python -m pytest'", "ty: failure\nremediation: fix type diagnostics and rerun '.venv/bin/ty check src'"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "commit", "branch": "main", "protectedBranches": ["main", "master"]}}
+{"event": "gate_blocked_protected_branch", "actor": "gate-engine", "details": {"stage": "push", "branch": "master", "protectedBranches": ["main", "master"]}}
+{"event": "gate_passed", "actor": "gate-engine", "details": {"stage": "pre-commit"}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "commit-msg", "failures": ["commit message cannot be empty"]}}
+{"event": "gate_failed", "actor": "gate-engine", "details": {"stage": "pre-push", "failures": ["semgrep: failure\nremediation: address findings or tune local code before push", "pip-audit: failure\nremediation: upgrade vulnerable dependencies and regenerate lockfiles", "pytest: failure\nremediation: fix failing tests and rerun '.venv/bin/python -m pytest'", "ty: failure\nremediation: fix type diagnostics and rerun '.venv/bin/ty check src'"]}}

--- a/src/ai_engineering/cli.py
+++ b/src/ai_engineering/cli.py
@@ -17,6 +17,7 @@ from ai_engineering.commands.workflows import (
 )
 from ai_engineering.doctor.service import run_doctor
 from ai_engineering.installer.service import install
+from ai_engineering.maintenance.report import create_pr_from_payload, generate_report
 from ai_engineering.paths import repo_root
 from ai_engineering.policy.gates import (
     gate_requirements,
@@ -24,13 +25,18 @@ from ai_engineering.policy.gates import (
     run_pre_commit,
     run_pre_push,
 )
+from ai_engineering.skills.service import export_sync_report_json, list_sources, sync_sources
 
 
 app = typer.Typer(help="ai-engineering governance CLI")
 gate_app = typer.Typer(help="Run governance gate checks")
 acho_app = typer.Typer(help="Acho command contract")
+skill_app = typer.Typer(help="Remote skills lock/cache operations")
+maintenance_app = typer.Typer(help="Maintenance and context health workflows")
 app.add_typer(gate_app, name="gate")
 app.add_typer(acho_app, name="acho")
+app.add_typer(skill_app, name="skill")
+app.add_typer(maintenance_app, name="maintenance")
 
 
 @app.command()
@@ -208,6 +214,60 @@ def gate_list(json_output: bool = typer.Option(False, "--json", help="Print JSON
                         tool_raw = typed_check.get("tool")
                         tool = str(tool_raw) if tool_raw is not None else "unknown"
                         typer.echo(f"  - {tool}")
+
+
+@skill_app.command("list")
+def skill_list(json_output: bool = typer.Option(False, "--json", help="Print JSON output")) -> None:
+    """List configured skill sources from lock file."""
+    payload = list_sources()
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    sources = payload.get("sources", [])
+    if not isinstance(sources, list):
+        raise typer.Exit(code=1)
+    typer.echo(f"skill sources: {len(sources)}")
+    for item in sources:
+        if isinstance(item, dict):
+            url = item.get("url")
+            checksum = item.get("checksum")
+            typer.echo(f"- {url} (checksum: {checksum})")
+
+
+@skill_app.command("sync")
+def skill_sync(
+    offline: bool = typer.Option(False, "--offline", help="Use cache only and skip remote fetch"),
+) -> None:
+    """Sync skill sources and refresh lock metadata."""
+    result = sync_sources(offline=offline)
+    report_path = repo_root() / ".ai-engineering" / "state" / "skills_sync_report.json"
+    export_sync_report_json(report_path, result)
+    typer.echo(json.dumps(result, indent=2))
+    summary = result.get("summary", {})
+    if isinstance(summary, dict) and int(summary.get("failed", 0)) > 0:
+        raise typer.Exit(code=1)
+
+
+@maintenance_app.command("report")
+def maintenance_report(
+    approve_pr: bool = typer.Option(
+        False,
+        "--approve-pr",
+        help="If set, generate PR payload metadata after local report",
+    ),
+) -> None:
+    """Generate local maintenance report and optional PR payload draft."""
+    payload = generate_report(approve_pr=approve_pr)
+    typer.echo(json.dumps(payload, indent=2))
+
+
+@maintenance_app.command("pr")
+def maintenance_pr() -> None:
+    """Create PR from approved maintenance payload."""
+    ok, message = create_pr_from_payload()
+    typer.echo(message)
+    if not ok:
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/ai_engineering/maintenance/__init__.py
+++ b/src/ai_engineering/maintenance/__init__.py
@@ -1,0 +1,1 @@
+"""Maintenance package for context health reporting."""

--- a/src/ai_engineering/maintenance/report.py
+++ b/src/ai_engineering/maintenance/report.py
@@ -1,0 +1,181 @@
+"""Local maintenance report generation for context and governance health."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ai_engineering.paths import ai_engineering_root, repo_root
+
+
+STALE_DAYS_THRESHOLD = 90
+LARGE_FILE_LINES = 250
+
+
+@dataclass
+class ContextFileStat:
+    """Computed metrics for a single context file."""
+
+    path: Path
+    lines: int
+    chars: int
+    stale_days: int
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _file_stats(path: Path) -> ContextFileStat:
+    content = path.read_text(encoding="utf-8")
+    lines = content.count("\n") + 1
+    chars = len(content)
+    modified = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    stale_days = max(0, (_now() - modified).days)
+    return ContextFileStat(path=path, lines=lines, chars=chars, stale_days=stale_days)
+
+
+def _context_files(ae_root: Path) -> list[Path]:
+    context_root = ae_root / "context"
+    return sorted([p for p in context_root.rglob("*.md") if p.is_file()])
+
+
+def _report_markdown(
+    *,
+    generated_at: str,
+    files: list[ContextFileStat],
+    large_files: list[ContextFileStat],
+    stale_files: list[ContextFileStat],
+    approved_for_pr: bool,
+) -> str:
+    total_chars = sum(item.chars for item in files)
+    approx_tokens = total_chars // 4
+
+    lines: list[str] = []
+    lines.append("# Maintenance Report\n")
+    lines.append(f"Generated at: {generated_at}\n")
+    lines.append("## Summary\n")
+    lines.append(f"- Context files scanned: {len(files)}")
+    lines.append(f"- Approximate context tokens: {approx_tokens}")
+    lines.append(f"- Large files (> {LARGE_FILE_LINES} lines): {len(large_files)}")
+    lines.append(f"- Stale files (> {STALE_DAYS_THRESHOLD} days): {len(stale_files)}")
+    lines.append("")
+
+    if large_files:
+        lines.append("## Large Files\n")
+        for entry in large_files:
+            lines.append(f"- `{entry.path}` ({entry.lines} lines)")
+        lines.append("")
+
+    if stale_files:
+        lines.append("## Stale Files\n")
+        for entry in stale_files:
+            lines.append(f"- `{entry.path}` ({entry.stale_days} days since update)")
+        lines.append("")
+
+    lines.append("## Recommendations\n")
+    lines.append(
+        "- Reduce repeated policy text by linking canonical files instead of duplicating content."
+    )
+    lines.append("- Split or compress oversized context files that exceed line guidance.")
+    lines.append("- Review stale files and either refresh or archive with rationale.")
+    lines.append("")
+    lines.append("## PR Workflow\n")
+    lines.append(
+        "- Mode: "
+        + (
+            "approved for PR generation"
+            if approved_for_pr
+            else "local report only (default, approval pending)"
+        )
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_report(*, approve_pr: bool = False) -> dict[str, object]:
+    """Generate local maintenance report and optional PR payload draft."""
+    root = repo_root()
+    ae_root = ai_engineering_root(root)
+    files = [_file_stats(path) for path in _context_files(ae_root)]
+
+    large_files = [item for item in files if item.lines > LARGE_FILE_LINES]
+    stale_files = [item for item in files if item.stale_days > STALE_DAYS_THRESHOLD]
+
+    generated_at = _now().replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    report = _report_markdown(
+        generated_at=generated_at,
+        files=files,
+        large_files=large_files,
+        stale_files=stale_files,
+        approved_for_pr=approve_pr,
+    )
+
+    state_dir = ae_root / "state"
+    report_path = state_dir / "maintenance_report.md"
+    report_path.write_text(report + "\n", encoding="utf-8")
+
+    branch_proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    head_branch = branch_proc.stdout.strip() if branch_proc.returncode == 0 else "main"
+
+    payload_path = state_dir / "maintenance_pr_payload.json"
+    payload: dict[str, object] = {
+        "title": "maintenance: context compaction and governance alignment",
+        "body": "Generated from maintenance report. Review recommendations before opening PR.",
+        "base": "main",
+        "head": head_branch,
+        "approved": approve_pr,
+        "generatedAt": generated_at,
+    }
+    if approve_pr:
+        payload_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    return {
+        "reportPath": str(report_path),
+        "payloadPath": str(payload_path) if approve_pr else None,
+        "filesScanned": len(files),
+        "largeFileCount": len(large_files),
+        "staleFileCount": len(stale_files),
+        "approved": approve_pr,
+    }
+
+
+def create_pr_from_payload() -> tuple[bool, str]:
+    """Create PR from approved maintenance payload."""
+    root = repo_root()
+    payload_path = ai_engineering_root(root) / "state" / "maintenance_pr_payload.json"
+    if not payload_path.exists():
+        return (
+            False,
+            "missing maintenance_pr_payload.json; run maintenance report --approve-pr first",
+        )
+
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+    approved = bool(payload.get("approved"))
+    if not approved:
+        return False, "maintenance payload is not approved for PR creation"
+
+    title = str(payload.get("title", "maintenance update"))
+    body = str(payload.get("body", "maintenance report"))
+    base = str(payload.get("base", "main"))
+    head = str(payload.get("head", ""))
+
+    args = ["gh", "pr", "create", "--base", base]
+    if head:
+        args.extend(["--head", head])
+    args.extend(["--title", title, "--body", body])
+
+    proc = subprocess.run(args, cwd=root, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return False, proc.stderr.strip() or proc.stdout.strip() or "failed to create PR"
+    return True, proc.stdout.strip() or "PR created"

--- a/src/ai_engineering/skills/service.py
+++ b/src/ai_engineering/skills/service.py
@@ -1,0 +1,174 @@
+"""Remote skills lock and cache services."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from ai_engineering.paths import ai_engineering_root, repo_root, state_dir
+from ai_engineering.state.io import load_model, write_json
+from ai_engineering.state.models import SkillSource, SourcesLock
+
+
+ALLOWED_SKILL_HOSTS = {"skills.sh", "www.aitmpl.com"}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _cache_file_path(cache_dir: Path, url: str) -> Path:
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return cache_dir / f"{digest}.skill"
+
+
+def _fetch_url(url: str, timeout: int = 15) -> bytes:
+    with urlopen(url, timeout=timeout) as response:  # noqa: S310 - allowlisted by lock policy
+        return response.read()
+
+
+def _compute_checksum(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _is_allowlisted(url: str) -> bool:
+    host = urlparse(url).hostname
+    if host is None:
+        return False
+    return host in ALLOWED_SKILL_HOSTS
+
+
+def _sync_single_source(
+    source: SkillSource,
+    cache_dir: Path,
+    *,
+    offline: bool,
+    fetcher: Callable[[str], bytes],
+) -> tuple[SkillSource, dict[str, Any]]:
+    if not _is_allowlisted(source.url):
+        return source, {
+            "url": source.url,
+            "status": "allowlist-rejected",
+            "cached": False,
+            "error": "source host is not allowlisted",
+        }
+
+    cache_file = _cache_file_path(cache_dir, source.url)
+    if source.signatureMetadata is None:
+        return source, {
+            "url": source.url,
+            "status": "signature-metadata-missing",
+            "cached": False,
+            "error": "signature metadata scaffold is required",
+        }
+
+    if offline:
+        if cache_file.exists():
+            source.cache.lastFetchedAt = source.cache.lastFetchedAt or _now_iso()
+            return source, {"url": source.url, "status": "offline-cache", "cached": True}
+        return source, {"url": source.url, "status": "offline-miss", "cached": False}
+
+    try:
+        payload = fetcher(source.url)
+    except (URLError, TimeoutError, OSError) as exc:
+        if cache_file.exists():
+            source.cache.lastFetchedAt = source.cache.lastFetchedAt or _now_iso()
+            return source, {
+                "url": source.url,
+                "status": "network-fallback-cache",
+                "cached": True,
+                "error": str(exc),
+            }
+        return source, {
+            "url": source.url,
+            "status": "network-failed",
+            "cached": False,
+            "error": str(exc),
+        }
+
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    computed_checksum = _compute_checksum(payload)
+    if source.checksum is not None and source.checksum != computed_checksum:
+        return source, {
+            "url": source.url,
+            "status": "checksum-mismatch",
+            "cached": cache_file.exists(),
+            "error": "pinned checksum does not match fetched content",
+            "expected": source.checksum,
+            "actual": computed_checksum,
+        }
+
+    cache_file.write_bytes(payload)
+    source.checksum = computed_checksum
+    source.cache.lastFetchedAt = _now_iso()
+    return source, {
+        "url": source.url,
+        "status": "synced",
+        "cached": True,
+        "checksum": source.checksum,
+    }
+
+
+def list_sources() -> dict[str, Any]:
+    """Return sources and cache metadata from sources lock."""
+    root = repo_root()
+    lock = load_model(state_dir(root) / "sources.lock.json", SourcesLock)
+    return {
+        "schemaVersion": lock.schemaVersion,
+        "defaultRemoteEnabled": lock.defaultRemoteEnabled,
+        "sources": [source.model_dump(mode="json") for source in lock.sources],
+    }
+
+
+def sync_sources(*, offline: bool = False) -> dict[str, Any]:
+    """Sync remote sources and update lock file with cache metadata."""
+    root = repo_root()
+    lock_path = state_dir(root) / "sources.lock.json"
+    lock = load_model(lock_path, SourcesLock)
+
+    cache_dir = ai_engineering_root(root) / ".cache" / "skills"
+    results: list[dict[str, Any]] = []
+    updated_sources: list[SkillSource] = []
+    for source in lock.sources:
+        updated, result = _sync_single_source(
+            source, cache_dir, offline=offline, fetcher=_fetch_url
+        )
+        updated_sources.append(updated)
+        results.append(result)
+
+    lock.sources = updated_sources
+    lock.generatedAt = _now_iso()
+    write_json(lock_path, lock.model_dump(mode="json"))
+
+    summary = {
+        "synced": len([item for item in results if item["status"] == "synced"]),
+        "fallback": len([item for item in results if item["status"] == "network-fallback-cache"]),
+        "offlineCache": len([item for item in results if item["status"] == "offline-cache"]),
+        "failed": len(
+            [
+                item
+                for item in results
+                if item["status"]
+                in {
+                    "network-failed",
+                    "offline-miss",
+                    "allowlist-rejected",
+                    "checksum-mismatch",
+                    "signature-metadata-missing",
+                }
+            ]
+        ),
+    }
+    return {"offline": offline, "summary": summary, "results": results}
+
+
+def export_sync_report_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write sync report payload for troubleshooting and audit."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/tests/unit/test_maintenance_report.py
+++ b/tests/unit/test_maintenance_report.py
@@ -1,0 +1,82 @@
+"""Unit tests for maintenance report generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_engineering.maintenance.report import create_pr_from_payload, generate_report
+
+
+def test_generate_report_creates_local_report(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    (temp_repo / ".ai-engineering" / "context" / "delivery").mkdir(parents=True)
+    (temp_repo / ".ai-engineering" / "context" / "delivery" / "planning.md").write_text(
+        "# Planning\n", encoding="utf-8"
+    )
+    (temp_repo / ".ai-engineering" / "state").mkdir(parents=True)
+
+    monkeypatch.setattr("ai_engineering.maintenance.report.repo_root", lambda: temp_repo)
+
+    payload = generate_report(approve_pr=False)
+
+    assert payload["approved"] is False
+    report_path = Path(str(payload["reportPath"]))
+    assert report_path.exists()
+
+
+def test_generate_report_writes_pr_payload_when_approved(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    (temp_repo / ".ai-engineering" / "context" / "product").mkdir(parents=True)
+    (temp_repo / ".ai-engineering" / "context" / "product" / "vision.md").write_text(
+        "# Vision\n", encoding="utf-8"
+    )
+    (temp_repo / ".ai-engineering" / "state").mkdir(parents=True)
+
+    monkeypatch.setattr("ai_engineering.maintenance.report.repo_root", lambda: temp_repo)
+
+    payload = generate_report(approve_pr=True)
+
+    assert payload["approved"] is True
+    pr_payload = Path(str(payload["payloadPath"]))
+    assert pr_payload.exists()
+
+
+def test_create_pr_from_payload_requires_approval(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state = temp_repo / ".ai-engineering" / "state"
+    state.mkdir(parents=True)
+    (state / "maintenance_pr_payload.json").write_text(
+        '{"approved": false, "title": "x", "body": "y", "base": "main", "head": "feature/x"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ai_engineering.maintenance.report.repo_root", lambda: temp_repo)
+
+    ok, message = create_pr_from_payload()
+
+    assert not ok
+    assert "not approved" in message
+
+
+def test_create_pr_from_payload_invokes_gh_when_approved(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state = temp_repo / ".ai-engineering" / "state"
+    state.mkdir(parents=True)
+    (state / "maintenance_pr_payload.json").write_text(
+        '{"approved": true, "title": "x", "body": "y", "base": "main", "head": "feature/x"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("ai_engineering.maintenance.report.repo_root", lambda: temp_repo)
+
+    class Proc:
+        returncode = 0
+        stdout = "https://github.com/org/repo/pull/1"
+        stderr = ""
+
+    monkeypatch.setattr(
+        "ai_engineering.maintenance.report.subprocess.run", lambda *args, **kwargs: Proc()
+    )
+
+    ok, message = create_pr_from_payload()
+
+    assert ok
+    assert "pull" in message

--- a/tests/unit/test_skills_service.py
+++ b/tests/unit/test_skills_service.py
@@ -1,0 +1,75 @@
+"""Unit tests for remote skills lock/cache services."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_engineering.skills import service
+from ai_engineering.state.defaults import sources_lock_default
+from ai_engineering.state.io import write_json
+
+
+def test_sync_sources_updates_checksum_and_cache(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state_root = temp_repo / ".ai-engineering" / "state"
+    state_root.mkdir(parents=True)
+    write_json(state_root / "sources.lock.json", sources_lock_default())
+    cache_root = temp_repo / ".ai-engineering" / ".cache" / "skills"
+    cache_root.mkdir(parents=True)
+
+    monkeypatch.setattr(service, "repo_root", lambda: temp_repo)
+    monkeypatch.setattr(service, "_fetch_url", lambda _url: b"skill-content")
+
+    result = service.sync_sources(offline=False)
+
+    assert result["summary"]["synced"] >= 1
+    assert any(item["status"] == "synced" for item in result["results"])
+
+
+def test_sync_sources_offline_uses_cache(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state_root = temp_repo / ".ai-engineering" / "state"
+    state_root.mkdir(parents=True)
+    write_json(state_root / "sources.lock.json", sources_lock_default())
+    monkeypatch.setattr(service, "repo_root", lambda: temp_repo)
+
+    # First sync online to seed cache.
+    monkeypatch.setattr(service, "_fetch_url", lambda _url: b"seed")
+    service.sync_sources(offline=False)
+
+    # Then force offline mode.
+    result = service.sync_sources(offline=True)
+
+    assert result["offline"] is True
+    assert result["summary"]["offlineCache"] >= 1
+
+
+def test_sync_sources_rejects_non_allowlisted_url(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state_root = temp_repo / ".ai-engineering" / "state"
+    state_root.mkdir(parents=True)
+    lock = sources_lock_default()
+    lock["sources"][0]["url"] = "https://evil.example/skills"
+    write_json(state_root / "sources.lock.json", lock)
+    monkeypatch.setattr(service, "repo_root", lambda: temp_repo)
+
+    result = service.sync_sources(offline=False)
+
+    assert result["summary"]["failed"] >= 1
+    assert any(item["status"] == "allowlist-rejected" for item in result["results"])
+
+
+def test_sync_sources_detects_checksum_mismatch(temp_repo: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    (temp_repo / ".git").mkdir()
+    state_root = temp_repo / ".ai-engineering" / "state"
+    state_root.mkdir(parents=True)
+    lock = sources_lock_default()
+    lock["sources"][0]["checksum"] = "sha256:deadbeef"
+    write_json(state_root / "sources.lock.json", lock)
+    monkeypatch.setattr(service, "repo_root", lambda: temp_repo)
+    monkeypatch.setattr(service, "_fetch_url", lambda _url: b"different-content")
+
+    result = service.sync_sources(offline=False)
+
+    assert result["summary"]["failed"] >= 1
+    assert any(item["status"] == "checksum-mismatch" for item in result["results"])


### PR DESCRIPTION
## Summary
- Complete Phase E by implementing remote skills sync/list services with cache support, offline fallback, and strict trust enforcement (allowlist + checksum pinning fail-closed).
- Add maintenance workflows that generate local reports first and only allow PR creation from an explicitly approved payload.
- Extend unit/integration coverage and update `.ai-engineering` planning, backlog, and implementation logs to mark Phase E complete.