### PR TITLE
feat: establish content-first framework contract and rollout charter

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -96,3 +96,17 @@
 - [x] E-004 add integration and unit tests for skills and maintenance behavior.
 - [x] E-005 enforce allowlist/pinning validation hard-fail logic in sync path.
 - [x] E-006 wire approved maintenance reports to optional automated PR command flow.
+
+## Phase F Execution Log
+
+- Rationale: establish a single canonical product contract and adoption strategy for the content-first rebuild.
+- Expected gain: removes ambiguity on scope, migration decisions, and rollout sequence.
+- Potential impact: legacy implementation assumptions are superseded by contract-first guidance.
+
+- [x] F-001 add `context/product/framework-contract.md` with finalized non-negotiable product contract.
+- [x] F-002 add `context/product/framework-adoption-map.md` mapping legacy assets (keep/adapt/drop).
+- [x] F-003 add `context/product/rebuild-rollout-charter.md` with milestones, validation plan, and readiness gates.
+- [x] F-004 fix CLI `Literal` compatibility regression and restore JSON command behavior.
+- [x] F-005 pin `click` compatibility for Typer 0.12 runtime stability.
+- [x] F-006 run full local quality gate validation (`ruff`, `pytest`, `ty`, `pip-audit`).
+- [ ] F-007 execute full implementation of charter workstreams W1-W5.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -125,3 +125,22 @@ Status:
 - Blockers: none.
 - Decisions: keep trust enforcement fail-closed; unknown source hosts and checksum mismatches are treated as sync failures.
 - Next step: optional post-MVP hardening (cross-OS CI matrix, deeper command E2E with remote integration).
+
+### 2026-02-08 - Phase F / Contract Consolidation
+
+- Work completed: added three product-level governance artifacts: framework contract, legacy adoption map, and rebuild rollout charter.
+- Changed modules: `.ai-engineering/context/product/framework-contract.md`, `.ai-engineering/context/product/framework-adoption-map.md`, `.ai-engineering/context/product/rebuild-rollout-charter.md`, plus backlog synchronization.
+- Validation run: markdown structure review and contract consistency pass against agreed command model, ownership model, and enforcement constraints.
+- Blockers: none.
+- Decisions: formalize content-first architecture and constrain Python runtime to install/update/doctor/add-remove operations.
+- Next step: execute charter workstreams W1-W5 and validate with full quality and E2E suite before merge.
+
+### 2026-02-08 - Phase F / Validation Hardening
+
+- Work completed: fixed CLI option compatibility issue (`Literal` + Typer) by validating string mode values in CLI and casting only after validation.
+- Work completed: pinned `click` to `<8.2` to avoid Typer 0.12 runtime incompatibility and restored stable JSON option behavior.
+- Changed modules: `src/ai_engineering/cli.py`, `pyproject.toml`.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: prefer compatibility pinning over broad CLI refactors for MVP stability.
+- Next step: proceed with PR packaging and review.

--- a/.ai-engineering/context/product/framework-adoption-map.md
+++ b/.ai-engineering/context/product/framework-adoption-map.md
@@ -1,0 +1,98 @@
+# Framework Adoption Map (Legacy -> New Contract)
+
+## Purpose
+
+This document maps legacy assets to the new ai-engineering contract.
+Each candidate is evaluated as Keep, Adapt, or Drop based on:
+
+- contract compliance,
+- simplicity and maintainability,
+- security/governance alignment,
+- token/context efficiency,
+- cross-OS and interoperability relevance.
+
+## Decision Rules
+
+- Keep: can be reused almost as-is without violating the contract.
+- Adapt: valuable concept, but requires scope reduction or contract alignment.
+- Drop: conflicts with non-negotiables, creates duplication, or adds unnecessary complexity.
+
+## Source Repositories
+
+1. `ai-engineering-dd1a6e55c8281f4a60013345bafbe72445938f5c` (legacy v1)
+2. `ai-engineering-e19924c4222cd21fba4ac64fafb367f4ff58833e` (legacy v2)
+
+## Adoption Matrix
+
+| ID  | Legacy Source                                   | Destination (New)                                    | Decision       | Why                                                                                 | Acceptance Check                                                     |
+| --- | ----------------------------------------------- | ---------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| A01 | `v1/scripts/install.sh`                         | Python install flow                                  | Adapt          | good readiness logic; convert to minimal Python runtime and ownership-safe behavior | `install` succeeds in empty/existing repo and preserves team/context |
+| A02 | `v1/scripts/hooks/pre-commit`                   | `.ai-engineering/hooks/pre-commit` template          | Adapt          | useful baseline; remove any bypass guidance                                         | hook blocks failing checks and contains no skip instructions         |
+| A03 | `v1/scripts/hooks/pre-push`                     | `.ai-engineering/hooks/pre-push` template            | Adapt          | keep gate orchestration intent; enforce non-bypass and stack-aware checks           | semgrep + dep-vuln + stack checks run and block on fail              |
+| A04 | `v1/standards/quality-gates.md`                 | `standards/framework/quality/core.md`                | Adapt          | strong quality concepts; align to Sonar-like content model                          | quality profile referenced by standards and command workflows        |
+| A05 | `v1/.claude/settings.json`                      | Claude template set                                  | Adapt          | keep safe defaults; reduce tool-specific overreach                                  | generated config includes read-safe defaults and governance hooks    |
+| A06 | `v1/.claude/skills/validate/SKILL.md`           | `skills/validation/*.md`                             | Adapt          | good validation flow; convert to content-first skill contracts                      | AI can execute validation checklist from content only                |
+| A07 | `v1/.claude/skills/utils/platform-detection.md` | `skills/utils/platform-detection.md`                 | Keep           | concise and useful guidance for GitHub/Azure detection                              | install/doctor classify provider correctly in tests                  |
+| A08 | `v1/.claude/skills/utils/git-helpers.md`        | `skills/utils/git-helpers.md`                        | Adapt          | useful helpers; trim to high-signal subset                                          | no duplicate commands and only contract-relevant helpers             |
+| A09 | `v1/.claude/hooks/block-dangerous.sh`           | runtime safety hook template                         | Adapt          | good safety patterns; simplify and keep cross-OS compatibility                      | destructive commands blocked in smoke tests                          |
+| A10 | `v1/.claude/hooks/version-check.sh`             | maintenance report skill + optional doctor extension | Adapt          | useful version/deprecation logic; keep report-first behavior                        | no startup disruption and report-only by default                     |
+| A11 | `v1/.claude/skills/ship/SKILL.md`               | N/A                                                  | Drop           | deprecated command model conflicts with `/commit`, `/pr`, `/acho`                   | no `ship` references in standards/templates                          |
+| A12 | `v1/context/*.md`                               | `context/product/*` and `context/delivery/*`         | Adapt          | reuse lifecycle ideas and map to canonical structure                                | all lifecycle files exist and are linked                             |
+| A13 | `v2/src/updater/merge-strategy.ts`              | `state/ownership-map.json` + Python update policy    | Keep (concept) | strong ownership strategy for safe updates                                          | update modifies framework/system only and preserves team/project     |
+| A14 | `v2/src/updater/updater.ts`                     | Python `update` command                              | Adapt          | preserve dry-run/backup/rollback ideas but reduce complexity                        | deterministic dry-run and update report produced                     |
+| A15 | `v2/src/installer/platform-check.ts`            | Python doctor + install readiness                    | Adapt          | useful readiness matrix aligned to required tooling                                 | doctor verifies gh/az/hooks/uv/ruff/ty/pip-audit/semgrep/gitleaks    |
+| A16 | `v2/src/cli/commands/init.ts`                   | Python install CLI                                   | Adapt          | good sequencing; convert to content-first minimal runtime                           | install creates canonical `.ai-engineering` tree                     |
+| A17 | `v2/src/cli/commands/update.ts`                 | Python update CLI                                    | Adapt          | keep UX and dry-run behavior with strict ownership                                  | update never touches `standards/team/**` or `context/**`             |
+| A18 | `v2/templates/project/CLAUDE.md.hbs`            | root assistant file template                         | Adapt          | useful but too verbose; compress and reference canonical docs                       | token-lean output with canonical references                          |
+| A19 | `v2/templates/project/copilot-instructions.hbs` | `.github/copilot-instructions.md` template           | Adapt          | keep interoperability; remove duplicated policy blocks                              | file points to canonical standards in `.ai-engineering`              |
+| A20 | `v2/templates/project/codex.md.hbs`             | `codex.md` template                                  | Adapt          | keep interoperability and command contract                                          | commands match `/commit`, `/pr`, `/acho`                             |
+| A21 | `v2/src/compiler/targets/claude-code.ts`        | N/A (heavy compiler)                                 | Drop           | over-engineered for content-first scope                                             | no heavy compile pipeline required                                   |
+| A22 | `v2/skills/git/ship.md`                         | N/A                                                  | Drop           | deprecated `ship` semantics                                                         | no ship command in docs/templates/skills                             |
+| A23 | `v2/skills/sdlc/plan.md`                        | `skills/sdlc/plan.md`                                | Adapt          | good lifecycle framing; align to canonical phase contract                           | planning skill references canonical context files                    |
+| A24 | `v2/agents/_base.md`                            | `agents/base.md` (optional)                          | Adapt          | useful baseline rules; must be concise and platform-agnostic                        | no duplicate standards text and compact size                         |
+| A25 | `v2/.ai-engineering/knowledge/*.md`             | `context/learnings.md`                               | Adapt          | keep learning concept but collapse to single file                                   | learnings retained and never overwritten                             |
+| A26 | `v2/lefthook.yml`                               | root `lefthook.yml` template (optional)              | Adapt          | practical hook orchestrator; align to non-bypass posture                            | hooks reproducible on Windows/macOS/Linux                            |
+| A27 | `v2/.gitleaks.toml`                             | root `.gitleaks.toml` template                       | Keep           | directly aligned with mandatory enforcement                                         | leak fixture blocked in pre-commit test                              |
+| A28 | `v2/schemas/config.schema.json`                 | state manifest + ownership schemas                   | Adapt          | strong schema discipline; evolve to provider-agnostic model                         | schema validates GitHub and ADO extension placeholders               |
+| A29 | `v2/test/updater/merge-strategy.test.ts`        | Python tests for ownership-safe update               | Adapt          | preserve test intent and rewrite in Python                                          | no-overwrite regression tests pass                                   |
+| A30 | `v2/test/installer/platform-check.test.ts`      | Python readiness tests                               | Adapt          | preserve readiness assertions and matrix intent                                     | readiness tests pass in CI matrix                                    |
+
+## Content to Explicitly Exclude
+
+The following must not be imported unchanged:
+
+- any `ship` command artifacts,
+- any bypass or skip-hook recommendation,
+- large duplicated instruction blocks across assistant files,
+- heavy runtime/compiler logic that can be replaced by static templates + minimal installer.
+
+## Required New Artifacts (Not Reused Directly)
+
+These are mandatory in the new contract even if not present in legacy form:
+
+- `state/decision-store.json`,
+- `state/audit-log.ndjson`,
+- strict ownership map and migration contract,
+- compact command contract docs for `/commit`, `/pr`, `/acho`,
+- Sonar-like and SonarLint-like quality profiles (content-driven).
+
+## Migration Sequence (Adoption Workstream)
+
+1. Import and normalize high-value content templates.
+2. Implement ownership-safe update contract and schemas.
+3. Wire minimal Python install/update/doctor/add-remove runtime.
+4. Harden hooks and enforce local mandatory checks.
+5. Add assistant file templates (Claude/Codex/Copilot) with canonical references only.
+6. Dogfood in this repo and run full E2E matrix.
+7. Freeze v1 contract and release.
+
+## Exit Criteria for Adoption Completion
+
+Adoption is complete when:
+
+- all Keep/Adapt items are mapped and validated,
+- all Drop items are absent from generated outputs,
+- update safety is proven (no team/context overwrite),
+- mandatory local gates run and block correctly,
+- command contract is consistent across assistant targets,
+- documentation remains concise and high-signal.

--- a/.ai-engineering/context/product/framework-contract.md
+++ b/.ai-engineering/context/product/framework-contract.md
@@ -1,0 +1,302 @@
+# ai-engineering Framework Contract (v1)
+
+## Purpose
+
+ai-engineering is an open-source governance framework for AI-assisted software delivery.
+It is designed to be simple, efficient, practical, robust, secure, and highly usable across teams and environments.
+
+This contract defines non-negotiable product behavior, architecture boundaries, and rollout rules.
+
+## Mission
+
+Provide a context-first, governance-first framework that ensures consistent quality, security, and delivery discipline when working with AI coding assistants.
+
+The framework must:
+
+- guide AI behavior through explicit standards and context,
+- enforce local quality/security gates,
+- preserve project/team ownership boundaries,
+- stay easy for humans to understand and maintain.
+
+## Product Model (Content-First)
+
+ai-engineering is primarily a content framework:
+
+- Markdown, YAML, JSON, and Bash define behavior and governance.
+- `.ai-engineering/` is the canonical source of truth.
+
+Python is intentionally minimal and operational.
+
+### Minimal Python Runtime Scope
+
+Python is used only for:
+
+1. `install` - copy templates, set up hooks, run readiness checks.
+2. `update` - ownership-safe updates and migrations.
+3. `doctor` - verify installed/configured/authenticated/ready state.
+4. `add/remove stack|ide` - safe template operations and cleanup.
+
+No heavy policy engine should be embedded in Python if behavior can be declared in governance content.
+
+## Product Principles (Non-Negotiable)
+
+### 1) Core Philosophy
+
+- Simple, efficient, practical, robust, secure.
+- Quality and security by default.
+- Strong governance to prevent AI drift/hallucination.
+- Lifecycle enforced:
+  Discovery -> Architecture -> Planning -> Implementation -> Review -> Verification -> Testing -> Iteration.
+
+### 2) Interoperability and Execution Targets
+
+- Native workflows for Claude, Codex, and GitHub Copilot.
+- Governed parallel execution support.
+- Cross-OS from day one: Windows, macOS, Linux.
+- VCS detection: GitHub first, Azure DevOps next phase.
+
+### 3) Single Source of Truth
+
+- No duplication across standards/context/skills/agent config.
+- `.ai-engineering/` is canonical.
+- Keep artifacts concise and high-signal.
+
+### 4) Tech Stack Baseline
+
+- Primary language: Python (minimal runtime only).
+- Supporting formats: Markdown, YAML, JSON, Bash.
+- Toolchain baseline: `uv`, `ruff`, `ty`.
+- Dependency vulnerability baseline (Python): `uv` + `pip-audit`.
+- Future documentation site: Nextra.
+
+### 5) Mandatory Local Enforcement
+
+- Git hooks always enabled and non-bypassable.
+- Mandatory checks include:
+  - `gitleaks`
+  - `semgrep` (OWASP-oriented SAST)
+  - dependency vulnerability checks
+  - formatter/linter/security checks by detected stack
+- No skip guidance. Failures must be fixed locally.
+
+### 6) Install and Bootstrap Behavior
+
+- Existing repo: detect stack/IDE/platform and adapt.
+- Empty repo: guided initialization wizard.
+- Installer must ensure first-commit readiness.
+- Support add/remove stack and add/remove IDE with safe cleanup.
+- Operational readiness means each required tool is:
+  installed + configured + authenticated (when applicable) + operational.
+
+### 7) Framework vs Installed Instance
+
+- Distinguish clearly:
+  - Framework: OSS core product maintained by maintainers.
+  - Installed instance: per-repo `.ai-engineering/`.
+- Must be explicit in architecture and updates.
+
+### 8) Command Contract (Skills Behavior)
+
+- `/commit` -> stage + commit + push.
+- `/commit --only` -> stage + commit.
+- `/pr` -> stage + commit + push + create PR.
+- `/pr --only` -> create PR.
+- `/acho` -> stage + commit + push.
+- `/acho pr` -> stage + commit + push + create PR.
+
+`/pr --only` policy when branch is not pushed:
+
+- Emit warning.
+- Propose auto-push.
+- If declined, do not hard-fail; continue with engineer-selected PR handling mode.
+
+### 9) Agentic Model
+
+- Governed parallel execution is required.
+- Governance must define safe delegation, verification, and merge-back outcomes.
+- Assistant-internal implementation details are not mandated by this contract.
+
+### 10) Product Management and DevEx
+
+- Treat ai-engineering as a product: roadmap, KPIs, release channels, UX quality.
+- Continuous DevEx improvement is first-class.
+- OSS telemetry must be strict opt-in.
+
+### 11) Context and Token Efficiency
+
+- Optimize token usage and context footprint.
+- Managed files must be concise, purpose-driven, and high-signal.
+- Every managed update includes: rationale, expected gain, potential impact.
+- Periodic simplification is mandatory, preserving functionality and governance.
+- Maintenance workflow: local report first; PR only after explicit acceptance.
+
+## Canonical Ownership Model
+
+### Ownership Boundaries in `.ai-engineering/`
+
+- framework-managed (updatable):
+  - `standards/framework/**`
+- team-managed (never overwritten by framework update):
+  - `standards/team/**`
+- project-managed (never overwritten by framework update):
+  - `context/**`
+- system-managed:
+  - `state/install-manifest.json`
+  - `state/ownership-map.json`
+  - `state/sources.lock.json`
+  - `state/decision-store.json`
+  - `state/audit-log.ndjson`
+
+### Update Rules
+
+- Installer creates missing folders/files safely.
+- Updater modifies only framework-managed and system-managed paths.
+- Team/project content is always preserved.
+- Schema/version migrations are explicit, idempotent, and auditable.
+
+### Standards Layering Precedence
+
+1. `standards/framework/core.md`
+2. `standards/framework/stacks/<stack>.md`
+3. `standards/team/core.md`
+4. `standards/team/stacks/<stack>.md`
+
+## Target Installed Structure
+
+```text
+.ai-engineering/
+  standards/
+    framework/
+      core.md
+      stacks/
+        python.md
+    team/
+      core.md
+      stacks/
+        python.md
+  context/
+    product/
+      vision.md
+      roadmap.md
+    delivery/
+      discovery.md
+      architecture.md
+      planning.md
+      implementation.md
+      review.md
+      verification.md
+      testing.md
+      iteration.md
+    backlog/
+      epics.md
+      features.md
+      user-stories.md
+      tasks.md
+    learnings.md
+  state/
+    install-manifest.json
+    ownership-map.json
+    sources.lock.json
+    decision-store.json
+    audit-log.ndjson
+```
+
+## Remote Skills and Cache Model
+
+Default mode:
+
+- Remote ON with local cache.
+
+Initial sources:
+
+- `https://skills.sh/`
+- `https://www.aitmpl.com/skills`
+
+Required controls:
+
+- source allowlist,
+- lock pinning/versioning,
+- checksum validation,
+- signature metadata scaffolding,
+- cache TTL,
+- offline fallback,
+- no unsafe remote execution patterns.
+
+## AI Permissions Policy (DevEx + Security)
+
+- Default allow: read/list/get/search/inspect operations.
+- Guardrailed: write/execute/high-impact actions.
+- Restricted: destructive and sensitive operations.
+- Policies must never weaken local enforcement or governance controls.
+
+## Quality Model (Sonar-like without Local Sonar Server)
+
+Local SonarQube server is not required.
+Instead:
+
+- define Sonar-like quality gates in framework standards,
+- define SonarLint-like local coding profile in standards/skills,
+- enforce measurable local checks via hooks and stack tooling,
+- keep quality rules content-driven and versioned in `.ai-engineering/`.
+
+## Decision and Audit Contract
+
+When weakening non-negotiables is requested:
+
+1. warn,
+2. generate remediation patch suggestion,
+3. never auto-apply,
+4. require explicit risk acceptance if declined,
+5. persist decision in `decision-store.json`,
+6. append event to `audit-log.ndjson`.
+
+AI must check decision store first and avoid repeated prompts unless:
+
+- decision expired,
+- severity changed,
+- scope changed,
+- policy changed,
+- material context changed.
+
+## Rollout Plan (From Scratch)
+
+### Phase 0 - Rebuild Baseline
+
+- Create clean branch/worktree from `origin/main`.
+- Rebuild contract-first repository structure.
+- Keep runtime minimal.
+
+### Phase 1 - Content Core + Installability
+
+- Finalize canonical templates under `.ai-engineering/`.
+- Implement minimal Python install/update/doctor/add-remove.
+- Ensure non-bypass local hooks and readiness checks.
+
+### Phase 2 - Dogfooding + Hard Validation
+
+- Install framework into this framework repo itself.
+- Run full E2E validation across:
+  - empty/existing repos,
+  - GitHub detection paths,
+  - tool missing/present/authenticated states,
+  - Windows/macOS/Linux.
+
+### Phase 3 - Release Readiness
+
+- Freeze contract.
+- Validate migration behavior.
+- Publish release with clear versioning and upgrade notes.
+
+Merge to main only after full E2E success.
+
+## Definition of Done (Product-Level)
+
+ai-engineering is considered ready only when:
+
+- installation replicates canonical `.ai-engineering/` correctly,
+- updates preserve team/project ownership boundaries,
+- mandatory local gates are enforceable and non-bypassable,
+- command contract behaves as specified,
+- decision and audit files are operational,
+- cross-OS validation passes,
+- docs remain concise and understandable by humans and AI.

--- a/.ai-engineering/context/product/rebuild-rollout-charter.md
+++ b/.ai-engineering/context/product/rebuild-rollout-charter.md
@@ -1,0 +1,142 @@
+# Rebuild Rollout Charter (v1)
+
+## Purpose
+
+Define the execution plan to rebuild ai-engineering from scratch using a content-first architecture, with strict governance, local enforcement, and ownership-safe lifecycle operations.
+
+## Scope
+
+In scope:
+
+- canonical contract and templates under `.ai-engineering/`,
+- minimal Python runtime (`install`, `update`, `doctor`, `add/remove stack|ide`),
+- mandatory local hooks and quality/security checks,
+- command contract (`/commit`, `/pr`, `/acho`),
+- readiness validation and update safety,
+- dogfooding and full E2E validation.
+
+Out of scope (for this charter):
+
+- deep Azure DevOps runtime operations,
+- heavy runtime compilers,
+- local SonarQube server integration,
+- non-essential feature expansion before MVP hardening.
+
+## Success Criteria
+
+1. Canonical `.ai-engineering/` contract is complete, concise, and auditable.
+2. Install reproduces framework content in target repos without ambiguity.
+3. Update preserves team/project ownership boundaries.
+4. Hooks and mandatory local gates are non-bypassable and deterministic.
+5. Command behavior matches the agreed contract.
+6. Cross-OS validation passes (Windows, macOS, Linux).
+7. Dogfooding succeeds in the ai-engineering repo itself.
+
+## Workstreams
+
+### W1 - Contract and Template Baseline
+
+- finalize framework contract,
+- finalize adoption map,
+- finalize canonical template set,
+- ensure no duplicated policy text.
+
+### W2 - Minimal Runtime and State
+
+- implement/install state manifests,
+- ownership-map enforcement,
+- decision and audit stores,
+- update migration contract.
+
+### W3 - Enforcement and Readiness
+
+- hooks install + integrity checks,
+- mandatory local checks (`gitleaks`, `semgrep`, dep-vuln, stack checks),
+- readiness checks for `gh`, `az`, hooks, and stack toolchain.
+
+### W4 - Command Contract
+
+- `/commit`, `/commit --only`,
+- `/pr`, `/pr --only` continuation policy,
+- `/acho`, `/acho pr`,
+- policy and decision-store integration.
+
+### W5 - Validation and Release
+
+- full local quality suite,
+- cross-OS matrix execution,
+- dogfooding cycle,
+- release readiness and PR/merge to main.
+
+## Milestones
+
+| Milestone               | Target Outcome                            | Exit Criteria                                         |
+| ----------------------- | ----------------------------------------- | ----------------------------------------------------- |
+| M0 Contract Freeze      | Content-first contract finalized          | Contract docs accepted and linked from context        |
+| M1 Installable Baseline | Minimal runtime installs canonical layout | install/doctor pass in empty + existing repo fixtures |
+| M2 Update Safety        | Ownership-safe updater is deterministic   | no overwrite regression tests pass                    |
+| M3 Enforced Workflows   | hooks and command contract fully governed | mandatory gates block correctly; command tests pass   |
+| M4 Dogfood and E2E      | framework validates itself                | full E2E matrix passes and release checklist complete |
+
+## Validation Plan
+
+### Functional Validation
+
+- install in empty repo,
+- install in existing repo with stack detection,
+- add/remove stack and IDE operations,
+- update dry-run and apply,
+- decision-store reuse behavior.
+
+### Enforcement Validation
+
+- verify hook integrity,
+- verify gate failure blocking,
+- verify no bypass messaging,
+- verify protected branch restrictions.
+
+### Cross-OS Validation
+
+- run test and hook flows on Windows/macOS/Linux,
+- verify path and shell compatibility,
+- verify tool installation and readiness diagnostics.
+
+### Product Validation
+
+- measure context size and duplication trend,
+- verify references remain canonical,
+- ensure docs are readable by humans and AI.
+
+## Risks and Mitigations
+
+| Risk                                        | Impact | Mitigation                                         |
+| ------------------------------------------- | ------ | -------------------------------------------------- |
+| Runtime complexity drifts upward            | high   | enforce minimal Python scope and review gate       |
+| Standards duplication increases token cost  | medium | canonical references + periodic compaction reviews |
+| Hook friction slows adoption                | medium | clear remediation output and deterministic checks  |
+| Ownership bugs overwrite project/team files | high   | strict ownership-map tests and dry-run previews    |
+| Cross-OS script variance                    | high   | matrix validation and shell-safe templates         |
+
+## Governance Rules
+
+- No direct commits to `main`/`master`.
+- No bypass guidance for mandatory checks.
+- Non-negotiable controls cannot be silently weakened.
+- Risk acceptances must be explicit and recorded.
+- Every contract change includes rationale, expected gain, potential impact.
+
+## Delivery Cadence
+
+- Weekly execution checkpoint in `context/delivery/implementation.md`.
+- Weekly backlog sync in `context/backlog/tasks.md`.
+- Maintenance report first, PR after explicit acceptance.
+
+## Release Readiness Checklist
+
+- [ ] contract and templates frozen for release,
+- [ ] runtime commands validated end-to-end,
+- [ ] update safety proven with regression tests,
+- [ ] mandatory local gates verified,
+- [ ] cross-OS matrix green,
+- [ ] dogfooding cycle complete,
+- [ ] release notes and migration notes prepared.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "typer[all]>=0.12.0,<0.13.0",
+  "click>=8.1.0,<8.2.0",
   "pyyaml>=6.0,<7.0",
   "pydantic>=2.0,<3.0",
 ]

--- a/src/ai_engineering/cli.py
+++ b/src/ai_engineering/cli.py
@@ -38,6 +38,13 @@ app.add_typer(acho_app, name="acho")
 app.add_typer(skill_app, name="skill")
 app.add_typer(maintenance_app, name="maintenance")
 
+PR_ONLY_MODES = {
+    "auto-push",
+    "defer-pr",
+    "attempt-pr-anyway",
+    "export-pr-payload",
+}
+
 
 @app.command()
 def version() -> None:
@@ -104,7 +111,7 @@ def pr_cmd(
     body: str = typer.Option(
         "Automated PR via ai-engineering command flow.", "--body", help="PR body"
     ),
-    on_unpushed_branch: PrOnlyMode = typer.Option(
+    on_unpushed_branch: str = typer.Option(
         "defer-pr",
         "--on-unpushed-branch",
         help="Mode for unpushed branch: auto-push|defer-pr|attempt-pr-anyway|export-pr-payload",
@@ -112,10 +119,16 @@ def pr_cmd(
 ) -> None:
     """Run governed PR workflow."""
     if only:
+        if on_unpushed_branch not in PR_ONLY_MODES:
+            typer.echo(
+                "invalid --on-unpushed-branch value. "
+                "expected: auto-push|defer-pr|attempt-pr-anyway|export-pr-payload"
+            )
+            raise typer.Exit(code=1)
         ok, notes = run_pr_only_workflow(
             title=title,
             body=body,
-            mode=on_unpushed_branch,
+            mode=cast(PrOnlyMode, on_unpushed_branch),
             record_decision=True,
         )
     else:


### PR DESCRIPTION
## Summary
- add canonical product governance artifacts under `.ai-engineering/context/product`: framework contract, legacy adoption map, and rebuild rollout charter
- update delivery/backlog execution logs with Phase F rationale, impact, and completion tracking for contract consolidation and validation hardening
- fix CLI `--on-unpushed-branch` compatibility by validating string values before casting, and pin `click` for Typer 0.12 runtime stability

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest`
- `.venv/bin/ty check src`
- `.venv/bin/pip-audit`