### PR TITLE
feat: integrate legacy content pack into installer templates

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -110,3 +110,16 @@
 - [x] F-005 pin `click` compatibility for Typer 0.12 runtime stability.
 - [x] F-006 run full local quality gate validation (`ruff`, `pytest`, `ty`, `pip-audit`).
 - [ ] F-007 execute full implementation of charter workstreams W1-W5.
+
+## Phase G Execution Log
+
+- Rationale: begin legacy adoption execution while preserving content-first architecture and minimal Python runtime scope.
+- Expected gain: recover high-value legacy work without reintroducing runtime complexity.
+- Potential impact: installer now syncs canonical templates into target repositories when files are missing.
+
+- [x] G-001 add bundled quality standards templates (Sonar-like + SonarLint-like + Python profile).
+- [x] G-002 add bundled utility/validation skill templates from legacy concepts (platform detection, git helpers, install readiness).
+- [x] G-003 add compact multi-assistant project templates (`CLAUDE.md`, `codex.md`, Copilot instructions).
+- [x] G-004 implement template sync during `ai install` with ownership-safe create-only behavior.
+- [x] G-005 add integration tests for template creation and team-owned file preservation.
+- [x] G-006 run full local quality suite and record evidence.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -144,3 +144,13 @@ Status:
 - Blockers: none.
 - Decisions: prefer compatibility pinning over broad CLI refactors for MVP stability.
 - Next step: proceed with PR packaging and review.
+
+### 2026-02-08 - Phase G / Legacy Content Adoption Pack
+
+- Work completed: implemented first execution slice of legacy adoption with content-first constraints by bundling quality profiles, utility skill docs, install-readiness guidance, and compact assistant templates.
+- Work completed: installer now syncs bundled templates into target repos with create-only semantics to preserve existing team/project customization.
+- Changed modules: `src/ai_engineering/installer/service.py`, `src/ai_engineering/installer/templates.py`, `src/ai_engineering/paths.py`, `src/ai_engineering/templates/**`, `tests/integration/test_cli_install_doctor.py`, `pyproject.toml` build include.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: import legacy value as compact templates only; reject direct runtime migration from TypeScript compiler/orchestration paths.
+- Next step: continue legacy adoption with updater ownership strategy enhancements and deeper provider/IDE detection coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ addopts = "-v --cov=src --cov-report=term-missing"
 [build-system]
 requires = ["hatchling>=1.25.0"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ai_engineering"]
+include = [
+  "src/ai_engineering/templates/**/*.md",
+]

--- a/src/ai_engineering/installer/service.py
+++ b/src/ai_engineering/installer/service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ai_engineering.__version__ import __version__
 from ai_engineering.hooks.manager import install_placeholder_hooks
 from ai_engineering.paths import ai_engineering_root, repo_root, state_dir
+from ai_engineering.installer.templates import sync_templates
 from ai_engineering.state.defaults import (
     decision_store_default,
     install_manifest_default,
@@ -24,7 +25,10 @@ def ensure_layout(root: Path) -> Path:
         "context/delivery",
         "context/backlog",
         "standards/framework/stacks",
+        "standards/framework/quality",
         "standards/team/stacks",
+        "skills/utils",
+        "skills/validation",
         "state",
     ):
         (ae_root / relative).mkdir(parents=True, exist_ok=True)
@@ -70,9 +74,11 @@ def install() -> dict[str, object]:
     root = repo_root()
     ae_root = ensure_layout(root)
     created_state = bootstrap_state_files(root)
+    template_result = sync_templates(root)
     install_placeholder_hooks(root)
     return {
         "repo": str(root),
         "aiEngineeringRoot": str(ae_root),
         "state": created_state,
+        "templates": template_result,
     }

--- a/src/ai_engineering/installer/templates.py
+++ b/src/ai_engineering/installer/templates.py
@@ -1,0 +1,75 @@
+"""Template synchronization for installer bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_engineering.paths import template_root
+
+
+TEMPLATE_MAPPINGS: tuple[tuple[str, str], ...] = (
+    (
+        ".ai-engineering/standards/framework/quality/core.md",
+        ".ai-engineering/standards/framework/quality/core.md",
+    ),
+    (
+        ".ai-engineering/standards/framework/quality/python.md",
+        ".ai-engineering/standards/framework/quality/python.md",
+    ),
+    (
+        ".ai-engineering/standards/framework/quality/sonarlint.md",
+        ".ai-engineering/standards/framework/quality/sonarlint.md",
+    ),
+    (
+        ".ai-engineering/skills/utils/platform-detection.md",
+        ".ai-engineering/skills/utils/platform-detection.md",
+    ),
+    (
+        ".ai-engineering/skills/utils/git-helpers.md",
+        ".ai-engineering/skills/utils/git-helpers.md",
+    ),
+    (
+        ".ai-engineering/skills/validation/install-readiness.md",
+        ".ai-engineering/skills/validation/install-readiness.md",
+    ),
+    (
+        "project/CLAUDE.md",
+        "CLAUDE.md",
+    ),
+    (
+        "project/codex.md",
+        "codex.md",
+    ),
+    (
+        "project/copilot-instructions.md",
+        ".github/copilot-instructions.md",
+    ),
+)
+
+
+def sync_templates(repo_root: Path) -> dict[str, str]:
+    """Copy bundled templates into repository when missing.
+
+    Existing files are preserved to respect ownership and team customization.
+    """
+
+    result: dict[str, str] = {}
+    source_root = template_root()
+
+    for source_relative, destination_relative in TEMPLATE_MAPPINGS:
+        source = source_root / source_relative
+        destination = repo_root / destination_relative
+
+        if not source.exists():
+            result[destination_relative] = "missing-template"
+            continue
+
+        if destination.exists():
+            result[destination_relative] = "exists"
+            continue
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        result[destination_relative] = "created"
+
+    return result

--- a/src/ai_engineering/paths.py
+++ b/src/ai_engineering/paths.py
@@ -27,3 +27,13 @@ def ai_engineering_root(root: Path) -> Path:
 def state_dir(root: Path) -> Path:
     """Return state directory path."""
     return ai_engineering_root(root) / "state"
+
+
+def package_root() -> Path:
+    """Return package root directory path."""
+    return Path(__file__).resolve().parent
+
+
+def template_root() -> Path:
+    """Return bundled template root directory path."""
+    return package_root() / "templates"

--- a/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
@@ -1,0 +1,43 @@
+# Git Helpers Utility
+
+## Purpose
+
+Provide compact, safe git helper patterns used by governed command workflows.
+
+## Protected Branch Check
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+  echo "protected branch"
+fi
+```
+
+## Upstream Check
+
+```bash
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+## Push Current Branch with Tracking
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+## Default Branch Detection
+
+```bash
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+```
+
+Fallbacks:
+
+- prefer `main`, then `master`.
+- provider CLI lookup if symbolic ref is missing.
+
+## Governance Notes
+
+- Do not suggest `--no-verify`.
+- Do not force push.
+- Do not bypass mandatory checks.

--- a/src/ai_engineering/templates/.ai-engineering/skills/utils/platform-detection.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/utils/platform-detection.md
@@ -1,0 +1,40 @@
+# Platform Detection Utility
+
+## Purpose
+
+Detect repository hosting platform and readiness using deterministic local checks.
+
+## Detection Sequence
+
+1. Read remote URL:
+
+```bash
+git remote get-url origin
+```
+
+2. Classify provider:
+
+- contains `github.com` -> `github`
+- contains `dev.azure.com` or `visualstudio.com` -> `azure-devops`
+- otherwise -> `unknown`
+
+3. Validate provider CLI and auth:
+
+```bash
+gh --version
+gh auth status
+
+az --version
+az account show
+```
+
+## Output Contract
+
+- provider: `github` | `azure-devops` | `unknown`
+- tooling: installed/configured/authenticated/operational per provider
+- remediation: command suggestions for missing prerequisites
+
+## Governance Notes
+
+- GitHub is runtime priority in current phase.
+- Azure DevOps constraints must remain represented in manifest schema.

--- a/src/ai_engineering/templates/.ai-engineering/skills/validation/install-readiness.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/validation/install-readiness.md
@@ -1,0 +1,38 @@
+# Install Readiness Validation
+
+## Purpose
+
+Validate that ai-engineering is operational after install/update.
+
+## Required Checks
+
+### Structure
+
+- `.ai-engineering/` exists.
+- required state files exist:
+  - `install-manifest.json`
+  - `ownership-map.json`
+  - `sources.lock.json`
+  - `decision-store.json`
+  - `audit-log.ndjson`
+
+### Hooks
+
+- `pre-commit`, `commit-msg`, and `pre-push` exist and are executable.
+- hooks are framework-managed and integrity-verified.
+
+### Tooling
+
+- `gitleaks`, `semgrep`, `pip-audit`, `ruff`, `ty`, and test runner are available.
+- `gh` and `az` status are evaluated and reported.
+
+### Provider and Auth
+
+- remote provider is detected from git remote URL.
+- provider CLI authentication status is reported.
+
+## Output Requirements
+
+- machine-readable JSON summary for automation,
+- concise human-readable remediation steps,
+- no bypass recommendations.

--- a/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/core.md
+++ b/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/core.md
@@ -1,0 +1,41 @@
+# Framework Quality Profile (Sonar-like)
+
+## Update Metadata
+
+- Rationale: provide measurable quality gates without requiring local SonarQube server setup.
+- Expected gain: consistent quality thresholds across assistants and repositories.
+- Potential impact: pull requests may fail until tests, complexity, and duplication targets are met.
+
+## Enforcement Scope
+
+- This profile applies to new and changed code by default.
+- Team standards may add stricter checks but cannot relax this baseline.
+
+## Required Quality Gates
+
+- Coverage on changed code: at least 80 percent.
+- Duplicated lines on changed code: at most 3 percent.
+- Reliability: no critical or blocker issues.
+- Security: no critical or blocker issues.
+- Maintainability: no critical debt items on changed code.
+
+## Pull Request Rules
+
+- PR must include evidence of local checks:
+  - lint/format,
+  - tests,
+  - type checks,
+  - security scans.
+- Any accepted risk must be recorded in `state/decision-store.json` and `state/audit-log.ndjson`.
+
+## Severity Policy
+
+- blocker: merge is blocked.
+- critical: merge is blocked unless explicit risk acceptance exists.
+- major: fix before merge unless owner approves and logs rationale.
+- minor/info: track and resolve incrementally.
+
+## References
+
+- `.ai-engineering/standards/framework/core.md`
+- `.ai-engineering/standards/framework/stacks/python.md`

--- a/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/python.md
+++ b/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/python.md
@@ -1,0 +1,33 @@
+# Framework Quality Profile (Python)
+
+## Update Metadata
+
+- Rationale: keep Python quality checks deterministic and local-first.
+- Expected gain: predictable quality outcomes in commit and push workflows.
+- Potential impact: missing tools or failing checks block governed operations.
+
+## Mandatory Local Checks
+
+- `ruff format --check`
+- `ruff check`
+- `ty check src`
+- `pytest`
+- `pip-audit`
+
+## Test and Coverage Policy
+
+- Minimum overall coverage target: 80 percent.
+- Governance-critical paths (install, update safety, hooks, command workflows): target 90 percent.
+- New behavior requires at least one unit or integration test.
+
+## Complexity and Maintainability
+
+- Keep functions focused and small.
+- Prefer explicit branch handling over implicit side effects.
+- Avoid introducing stack-specific behavior outside declared standards.
+
+## Security Rules
+
+- No secrets in source or committed artifacts.
+- Dependencies must be audited locally before push.
+- Security findings are fixed locally; bypass guidance is prohibited.

--- a/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/sonarlint.md
+++ b/src/ai_engineering/templates/.ai-engineering/standards/framework/quality/sonarlint.md
@@ -1,0 +1,26 @@
+# SonarLint-like Local Profile
+
+## Update Metadata
+
+- Rationale: provide editor-friendly local quality guidance aligned with framework gates.
+- Expected gain: earlier feedback before pre-commit and pre-push checks.
+- Potential impact: developers may need to tune editor rules to avoid noise while preserving severity.
+
+## Rule Families
+
+- correctness and reliability issues,
+- maintainability and complexity issues,
+- security-sensitive coding patterns,
+- duplication and readability issues.
+
+## Recommended Policy
+
+- Treat blocker and critical findings as errors.
+- Treat major findings as warnings that must be resolved before merge.
+- Treat minor/info findings as backlog improvements.
+
+## Integration Guidance
+
+- Use this profile as local coding baseline in IDE diagnostics.
+- Keep server-side Sonar integration optional; do not require local SonarQube server.
+- Preserve parity with framework quality profile in `quality/core.md`.

--- a/src/ai_engineering/templates/project/CLAUDE.md
+++ b/src/ai_engineering/templates/project/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+Project instructions are canonical in `.ai-engineering/`.
+
+## Required References
+
+- `.ai-engineering/context/product/framework-contract.md`
+- `.ai-engineering/standards/framework/core.md`
+- `.ai-engineering/standards/framework/stacks/python.md`
+- `.ai-engineering/standards/team/core.md`
+- `.ai-engineering/context/delivery/planning.md`
+- `.ai-engineering/context/backlog/tasks.md`
+
+## Command Contract
+
+- `/commit` -> stage + commit + push
+- `/commit --only` -> stage + commit
+- `/pr` -> stage + commit + push + create PR
+- `/pr --only` -> create PR
+- `/acho` -> stage + commit + push
+- `/acho pr` -> stage + commit + push + create PR
+
+## Non-Negotiables
+
+- mandatory local gates cannot be bypassed,
+- no direct commits to protected branches,
+- update safety must preserve team/project-owned content.

--- a/src/ai_engineering/templates/project/codex.md
+++ b/src/ai_engineering/templates/project/codex.md
@@ -1,0 +1,20 @@
+# Codex Project Instructions
+
+Use `.ai-engineering/` as the only governance and context source.
+
+## Read First
+
+- `.ai-engineering/context/product/framework-contract.md`
+- `.ai-engineering/standards/framework/core.md`
+- `.ai-engineering/context/backlog/tasks.md`
+
+## Command Behavior
+
+- `/commit` and `/acho` push current branch after governed checks.
+- `/pr --only` warns on unpushed branch and proposes auto-push, then continues by selected mode.
+
+## Security and Quality
+
+- run local mandatory checks,
+- fix failures locally,
+- avoid bypass flags.

--- a/src/ai_engineering/templates/project/copilot-instructions.md
+++ b/src/ai_engineering/templates/project/copilot-instructions.md
@@ -1,0 +1,24 @@
+# GitHub Copilot Instructions
+
+Use `.ai-engineering/` as canonical project policy and context.
+
+## Must Follow
+
+- `.ai-engineering/standards/framework/core.md`
+- `.ai-engineering/standards/framework/stacks/python.md`
+- `.ai-engineering/context/delivery/planning.md`
+
+## Workflow Contract
+
+- use governed `/commit`, `/pr`, and `/acho` flows,
+- do not suggest bypass of hooks,
+- keep updates ownership-safe.
+
+## Validation Reminder
+
+Before proposing merge:
+
+- lint/format,
+- tests,
+- type checks,
+- security scans.

--- a/tests/integration/test_cli_install_doctor.py
+++ b/tests/integration/test_cli_install_doctor.py
@@ -32,6 +32,24 @@ def test_install_creates_required_state_files(temp_repo: Path) -> None:
         assert hook_path.exists()
         assert "ai-engineering managed hook" in hook_path.read_text(encoding="utf-8")
 
+    assert (temp_repo / ".ai-engineering" / "standards" / "framework" / "quality" / "core.md").exists()
+    assert (temp_repo / ".ai-engineering" / "skills" / "utils" / "platform-detection.md").exists()
+    assert (temp_repo / "CLAUDE.md").exists()
+    assert (temp_repo / "codex.md").exists()
+    assert (temp_repo / ".github" / "copilot-instructions.md").exists()
+
+
+def test_install_preserves_existing_team_owned_files(temp_repo: Path) -> None:
+    (temp_repo / ".git").mkdir()
+    team_core = temp_repo / ".ai-engineering" / "standards" / "team" / "core.md"
+    team_core.parent.mkdir(parents=True, exist_ok=True)
+    team_core.write_text("custom team content\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["install"])
+
+    assert result.exit_code == 0
+    assert team_core.read_text(encoding="utf-8") == "custom team content\n"
+
 
 def test_doctor_json_reports_expected_sections(temp_repo: Path) -> None:
     (temp_repo / ".git").mkdir()


### PR DESCRIPTION
## Summary
- add a legacy adoption content pack under `src/ai_engineering/templates/**` with compact Sonar-like quality profiles, platform/git utility docs, install-readiness guidance, and assistant instruction templates
- wire installer template sync (`create-only`) so `ai install` populates missing canonical files while preserving existing project/team-owned content
- persist execution updates in context tracking files to keep rollout traceability aligned with the framework contract

## Why
This captures high-value work from the two legacy repositories while preserving the current content-first architecture and minimal Python runtime scope defined in `.ai-engineering/context/product/framework-contract.md`.

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest`
- `.venv/bin/ty check src`
- `.venv/bin/pip-audit`

## Notes
- added integration coverage for template creation and preservation of existing team-owned files during install
- build config now includes markdown template assets in wheel packaging