### PR TITLE
feat(updater): implement ownership-safe update phase baseline

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -123,3 +123,15 @@
 - [x] G-004 implement template sync during `ai install` with ownership-safe create-only behavior.
 - [x] G-005 add integration tests for template creation and team-owned file preservation.
 - [x] G-006 run full local quality suite and record evidence.
+
+## Phase H Execution Log
+
+- Rationale: start ownership-safe updater phase to align update behavior with framework-managed vs team/project-managed boundaries.
+- Expected gain: deterministic dry-run/apply updates with explicit ownership enforcement.
+- Potential impact: update command now rewrites framework-managed files when apply mode is used.
+
+- [x] H-001 implement updater service with ownership-map rule evaluation and template diffing.
+- [x] H-002 add CLI `update` command with dry-run default and explicit `--apply` mode.
+- [x] H-003 extend ownership defaults to include framework template paths and assistant instruction files.
+- [x] H-004 add integration coverage for updater dry-run and ownership preservation behavior.
+- [ ] H-005 continue with advanced merge strategy and migration hooks from legacy updater model.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -154,3 +154,13 @@ Status:
 - Blockers: none.
 - Decisions: import legacy value as compact templates only; reject direct runtime migration from TypeScript compiler/orchestration paths.
 - Next step: continue legacy adoption with updater ownership strategy enhancements and deeper provider/IDE detection coverage.
+
+### 2026-02-08 - Phase H / Ownership-Safe Updater Start
+
+- Work completed: implemented updater service with ownership-map path matching, dry-run/apply execution, framework template synchronization, and update audit event emission.
+- Work completed: added `ai update` command (dry-run by default, `--apply` for mutation) and expanded ownership defaults for framework-managed templates and assistant instruction files.
+- Changed modules: `src/ai_engineering/updater/service.py`, `src/ai_engineering/updater/__init__.py`, `src/ai_engineering/cli.py`, `src/ai_engineering/state/defaults.py`, updater integration tests.
+- Validation run: full local quality suite executed after changes.
+- Blockers: none.
+- Decisions: keep updater deterministic and rule-driven; defer complex three-way merge to next slice.
+- Next step: add advanced merge conflict strategy and migration lifecycle hooks.

--- a/src/ai_engineering/cli.py
+++ b/src/ai_engineering/cli.py
@@ -26,6 +26,7 @@ from ai_engineering.policy.gates import (
     run_pre_push,
 )
 from ai_engineering.skills.service import export_sync_report_json, list_sources, sync_sources
+from ai_engineering.updater import run_update
 
 
 app = typer.Typer(help="ai-engineering governance CLI")
@@ -56,6 +57,15 @@ def version() -> None:
 def install_cmd() -> None:
     """Bootstrap .ai-engineering in current repository."""
     result = install()
+    typer.echo(json.dumps(result, indent=2))
+
+
+@app.command("update")
+def update_cmd(
+    apply: bool = typer.Option(False, "--apply", help="Apply updates (default is dry-run)"),
+) -> None:
+    """Run ownership-safe framework update."""
+    result = run_update(apply=apply)
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/src/ai_engineering/state/defaults.py
+++ b/src/ai_engineering/state/defaults.py
@@ -64,42 +64,62 @@ def ownership_map_default() -> dict:
         },
         "paths": [
             {
-                "pattern": "standards/framework/**",
+                "pattern": ".ai-engineering/standards/framework/**",
                 "owner": "framework-managed",
                 "frameworkUpdate": "allow",
             },
             {
-                "pattern": "standards/team/**",
+                "pattern": ".ai-engineering/standards/team/**",
                 "owner": "team-managed",
                 "frameworkUpdate": "deny",
             },
             {
-                "pattern": "context/**",
+                "pattern": ".ai-engineering/context/**",
                 "owner": "project-managed",
                 "frameworkUpdate": "deny",
             },
             {
-                "pattern": "state/install-manifest.json",
+                "pattern": ".ai-engineering/skills/**",
+                "owner": "framework-managed",
+                "frameworkUpdate": "allow",
+            },
+            {
+                "pattern": "CLAUDE.md",
+                "owner": "framework-managed",
+                "frameworkUpdate": "allow",
+            },
+            {
+                "pattern": "codex.md",
+                "owner": "framework-managed",
+                "frameworkUpdate": "allow",
+            },
+            {
+                "pattern": ".github/copilot-instructions.md",
+                "owner": "framework-managed",
+                "frameworkUpdate": "allow",
+            },
+            {
+                "pattern": ".ai-engineering/state/install-manifest.json",
                 "owner": "system-managed",
                 "frameworkUpdate": "allow",
             },
             {
-                "pattern": "state/ownership-map.json",
+                "pattern": ".ai-engineering/state/ownership-map.json",
                 "owner": "system-managed",
                 "frameworkUpdate": "allow",
             },
             {
-                "pattern": "state/sources.lock.json",
+                "pattern": ".ai-engineering/state/sources.lock.json",
                 "owner": "system-managed",
                 "frameworkUpdate": "allow",
             },
             {
-                "pattern": "state/decision-store.json",
+                "pattern": ".ai-engineering/state/decision-store.json",
                 "owner": "system-managed",
                 "frameworkUpdate": "allow",
             },
             {
-                "pattern": "state/audit-log.ndjson",
+                "pattern": ".ai-engineering/state/audit-log.ndjson",
                 "owner": "system-managed",
                 "frameworkUpdate": "append-only",
             },

--- a/src/ai_engineering/updater/__init__.py
+++ b/src/ai_engineering/updater/__init__.py
@@ -1,1 +1,5 @@
-"""Updater package (Phase B scaffold)."""
+"""Updater package interface."""
+
+from ai_engineering.updater.service import run_update
+
+__all__ = ["run_update"]

--- a/src/ai_engineering/updater/service.py
+++ b/src/ai_engineering/updater/service.py
@@ -1,0 +1,121 @@
+"""Ownership-safe updater for framework-managed content."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Any
+
+from ai_engineering.__version__ import __version__
+from ai_engineering.installer.templates import TEMPLATE_MAPPINGS
+from ai_engineering.paths import repo_root, state_dir
+from ai_engineering.state.io import append_ndjson, load_model
+from ai_engineering.state.models import InstallManifest, OwnershipMap
+
+
+def _candidate_paths(path: str) -> set[str]:
+    candidates = {path}
+    prefix = ".ai-engineering/"
+    if path.startswith(prefix):
+        candidates.add(path[len(prefix) :])
+    else:
+        candidates.add(prefix + path)
+    return candidates
+
+
+def _matches(pattern: str, path: str) -> bool:
+    path_candidates = _candidate_paths(path)
+    pattern_candidates = _candidate_paths(pattern)
+    return any(fnmatch.fnmatch(candidate, candidate_pattern) for candidate in path_candidates for candidate_pattern in pattern_candidates)
+
+
+def _rule_for_path(ownership: OwnershipMap, path: str) -> tuple[str, str] | None:
+    for rule in ownership.paths:
+        if _matches(rule.pattern, path):
+            return rule.owner, rule.frameworkUpdate
+    return None
+
+
+def run_update(*, apply: bool) -> dict[str, Any]:
+    """Run framework-managed update process.
+
+    Updates only files allowed by ownership-map rules.
+    """
+
+    root = repo_root()
+    st = state_dir(root)
+    ownership = load_model(st / "ownership-map.json", OwnershipMap)
+    manifest = load_model(st / "install-manifest.json", InstallManifest)
+
+    entries: list[dict[str, str]] = []
+    summary = {
+        "updated": 0,
+        "created": 0,
+        "unchanged": 0,
+        "skippedDenied": 0,
+        "missingTemplate": 0,
+    }
+
+    for source_relative, destination_relative in TEMPLATE_MAPPINGS:
+        source = Path(__file__).resolve().parent.parent / "templates" / source_relative
+        destination = root / destination_relative
+        rule = _rule_for_path(ownership, destination_relative)
+
+        if not source.exists():
+            summary["missingTemplate"] += 1
+            entries.append({"path": destination_relative, "status": "missing-template"})
+            continue
+
+        if rule is None:
+            summary["skippedDenied"] += 1
+            entries.append({"path": destination_relative, "status": "skipped-no-rule"})
+            continue
+
+        owner, mode = rule
+        if mode == "deny":
+            summary["skippedDenied"] += 1
+            entries.append({"path": destination_relative, "status": f"skipped-{owner}"})
+            continue
+
+        source_content = source.read_text(encoding="utf-8")
+        if destination.exists():
+            current_content = destination.read_text(encoding="utf-8")
+            if current_content == source_content:
+                summary["unchanged"] += 1
+                entries.append({"path": destination_relative, "status": "unchanged"})
+                continue
+            if apply:
+                destination.write_text(source_content, encoding="utf-8")
+            summary["updated"] += 1
+            entries.append({"path": destination_relative, "status": "updated"})
+        else:
+            if apply:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(source_content, encoding="utf-8")
+            summary["created"] += 1
+            entries.append({"path": destination_relative, "status": "created"})
+
+    if apply:
+        manifest.frameworkVersion = __version__
+        manifest_path = st / "install-manifest.json"
+        manifest_path.write_text(manifest.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+        append_ndjson(
+            st / "audit-log.ndjson",
+            {
+                "event": "framework_update_applied",
+                "actor": "updater",
+                "details": {
+                    "frameworkVersion": __version__,
+                    "summary": summary,
+                },
+            },
+        )
+
+    return {
+        "repo": str(root),
+        "apply": apply,
+        "frameworkVersion": __version__,
+        "summary": summary,
+        "entries": entries,
+    }


### PR DESCRIPTION
## Summary
- add a new ownership-safe updater service with dry-run and apply modes, rule-driven path evaluation, and framework template synchronization
- add CLI `ai update` command (dry-run by default, `--apply` for mutations)
- expand ownership defaults to include framework-managed template paths and assistant instruction files while preserving team/project paths
- persist phase progress in context backlog and implementation logs

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest`
- `.venv/bin/ty check src`
- `.venv/bin/pip-audit`

## Tests Added
- updater dry-run reports pending framework-managed changes without writing files
- updater apply mode preserves team-owned content while updating allowed framework-managed files