### PR TITLE
feat(runtime): implement full stack/ide management and contract sync

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -148,3 +148,16 @@
 - [x] I-004 add regression test ensuring install creates every bundled governance template file.
 - [x] I-005 remove clearly outdated/unused tracked artifacts (`poetry.lock`, empty e2e placeholder).
 - [x] I-006 run full local quality suite (`ruff`, `pytest`, `ty`, `pip-audit`) and record evidence.
+
+## Phase K Execution Log
+
+- Rationale: close contract gaps by making PR auto-complete mandatory in documented command behavior and implementing full stack/IDE management commands.
+- Expected gain: full compliance with minimal Python runtime scope and fewer manual repo setup tasks.
+- Potential impact: installers and command workflows write additional manifest state for installed stacks/IDEs.
+
+- [x] K-001 update command contract and manifest to explicitly require PR auto-complete for `/pr` and `/acho pr`.
+- [x] K-002 implement `ai stack add/remove/list` workflows backed by bundled templates and safe cleanup rules.
+- [x] K-003 implement `ai ide add/remove/list` workflows with instruction template management and manifest tracking.
+- [x] K-004 extend install-manifest schema defaults with installed stack/IDE tracking.
+- [x] K-005 add integration and unit tests for stack/IDE lifecycle operations.
+- [ ] K-006 extend cross-OS hook launcher behavior for Windows-safe execution.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -175,3 +175,14 @@ Status:
 - Blockers: none.
 - Decisions: keep `state/*` runtime-generated and excluded from template mirror while enforcing identical non-state governance content.
 - Next step: run full quality suite and address any regressions from template/mapping changes.
+
+### 2026-02-09 - Phase K / Command Contract Closure (Auto-Complete + Stack/IDE Management)
+
+- Work completed: aligned contract and manifest command semantics so `/pr` and `/acho pr` explicitly require PR auto-complete behavior.
+- Work completed: implemented full minimal-runtime stack/IDE management commands (`ai stack add/remove/list`, `ai ide add/remove/list`) with ownership-safe file operations.
+- Work completed: extended install manifest schema/defaults to track installed stacks and IDE profiles.
+- Changed modules: `src/ai_engineering/installer/operations.py`, `src/ai_engineering/cli.py`, `src/ai_engineering/state/models.py`, `src/ai_engineering/state/defaults.py`, contract/manifest canonical and mirrored templates, integration/unit tests.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: remove operations stay safe by default; customized team files are preserved and reported as `skipped-customized`.
+- Next step: implement Windows-safe hook launcher improvements to complete remaining cross-OS hardening item.

--- a/.ai-engineering/context/product/framework-contract.md
+++ b/.ai-engineering/context/product/framework-contract.md
@@ -104,6 +104,17 @@ No heavy policy engine should be embedded in Python if behavior can be declared 
 - `/acho` -> stage + commit + push.
 - `/acho pr` -> stage + commit + push + create PR.
 
+Mandatory PR behavior:
+
+- `/pr` and `/acho pr` must enable PR auto-complete using squash merge and branch cleanup.
+
+Stack and IDE management commands:
+
+- `ai stack add <name>`
+- `ai stack remove <name>`
+- `ai ide add <name>`
+- `ai ide remove <name>`
+
 `/pr --only` policy when branch is not pushed:
 
 - Emit warning.

--- a/.ai-engineering/manifest.yml
+++ b/.ai-engineering/manifest.yml
@@ -44,7 +44,14 @@ commands:
     default: ["stage", "commit", "push_current_branch"]
     only: ["stage", "commit"]
   pr:
-    default: ["stage", "commit", "push_current_branch", "create_pr"]
+    default:
+      [
+        "stage",
+        "commit",
+        "push_current_branch",
+        "create_pr",
+        "enable_pr_auto_complete",
+      ]
     only: ["create_pr"]
     when_branch_not_pushed:
       severity: "warning"
@@ -52,7 +59,17 @@ commands:
       continue_modes: ["defer-pr", "attempt-pr-anyway", "export-pr-payload"]
   acho:
     default: ["stage", "commit", "push_current_branch"]
-    pr: ["stage", "commit", "push_current_branch", "create_pr"]
+    pr:
+      [
+        "stage",
+        "commit",
+        "push_current_branch",
+        "create_pr",
+        "enable_pr_auto_complete",
+      ]
+  management:
+    stack: ["add", "remove", "list"]
+    ide: ["add", "remove", "list"]
 
 providers:
   vcs:

--- a/.ai-engineering/state/install-manifest.json
+++ b/.ai-engineering/state/install-manifest.json
@@ -7,6 +7,8 @@
   },
   "frameworkVersion": "0.1.0",
   "installedAt": "2026-02-08T00:00:00Z",
+  "installedStacks": ["python"],
+  "installedIdes": ["terminal", "vscode", "claude", "codex", "copilot"],
   "providers": {
     "vcs": {
       "primary": "github",
@@ -22,14 +24,19 @@
     }
   },
   "toolingReadiness": {
-    "gh": {"installed": false, "configured": false, "authenticated": false},
-    "az": {"installed": false, "configured": false, "authenticated": false, "requiredNow": false},
-    "gitHooks": {"installed": false, "integrityVerified": false},
+    "gh": { "installed": false, "configured": false, "authenticated": false },
+    "az": {
+      "installed": false,
+      "configured": false,
+      "authenticated": false,
+      "requiredNow": false
+    },
+    "gitHooks": { "installed": false, "integrityVerified": false },
     "python": {
-      "uv": {"ready": false},
-      "ruff": {"ready": false},
-      "ty": {"ready": false},
-      "pipAudit": {"ready": false}
+      "uv": { "ready": false },
+      "ruff": { "ready": false },
+      "ty": { "ready": false },
+      "pipAudit": { "ready": false }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Open-source AI governance framework for secure, practical software delivery.
 
 - `/commit` -> stage + commit + push current branch
 - `/commit --only` -> stage + commit
-- `/pr` -> stage + commit + push + create PR
+- `/pr` -> stage + commit + push + create PR + enable auto-complete (`--auto --squash --delete-branch`)
 - `/pr --only` -> create PR; warns if branch is unpushed and proposes auto-push
 - `/acho` -> stage + commit + push current branch
-- `/acho pr` -> stage + commit + push + create PR
+- `/acho pr` -> stage + commit + push + create PR + enable auto-complete (`--auto --squash --delete-branch`)
+- `ai stack add/remove/list <stack>` -> manage stack templates with safe cleanup semantics
+- `ai ide add/remove/list <ide>` -> manage IDE instruction templates with safe cleanup semantics
 
 ## Tooling Baseline
 

--- a/src/ai_engineering/cli.py
+++ b/src/ai_engineering/cli.py
@@ -18,6 +18,13 @@ from ai_engineering.commands.workflows import (
 from ai_engineering.doctor.service import run_doctor
 from ai_engineering.git import run_git_cleanup
 from ai_engineering.installer.service import install
+from ai_engineering.installer.operations import (
+    add_ide,
+    add_stack,
+    list_stack_ide_status,
+    remove_ide,
+    remove_stack,
+)
 from ai_engineering.maintenance.report import create_pr_from_payload, generate_report
 from ai_engineering.paths import repo_root
 from ai_engineering.policy.gates import (
@@ -36,11 +43,15 @@ acho_app = typer.Typer(help="Acho command contract")
 skill_app = typer.Typer(help="Remote skills lock/cache operations")
 maintenance_app = typer.Typer(help="Maintenance and context health workflows")
 git_app = typer.Typer(help="Git operational workflows")
+stack_app = typer.Typer(help="Manage framework stack templates")
+ide_app = typer.Typer(help="Manage IDE instruction templates")
 app.add_typer(gate_app, name="gate")
 app.add_typer(acho_app, name="acho")
 app.add_typer(skill_app, name="skill")
 app.add_typer(maintenance_app, name="maintenance")
 app.add_typer(git_app, name="git")
+app.add_typer(stack_app, name="stack")
+app.add_typer(ide_app, name="ide")
 
 PR_ONLY_MODES = {
     "auto-push",
@@ -317,6 +328,54 @@ def git_cleanup(
         checkout_default=checkout_default,
     )
     typer.echo(json.dumps(result, indent=2))
+
+
+@stack_app.command("list")
+def stack_list() -> None:
+    """List installed and available stacks."""
+    typer.echo(json.dumps(list_stack_ide_status(), indent=2))
+
+
+@stack_app.command("add")
+def stack_add(name: str = typer.Argument(..., help="Stack name, e.g. python")) -> None:
+    """Add a stack template set to repository."""
+    result = add_stack(name)
+    typer.echo(json.dumps(result, indent=2))
+    if not bool(result.get("ok", False)):
+        raise typer.Exit(code=1)
+
+
+@stack_app.command("remove")
+def stack_remove(name: str = typer.Argument(..., help="Stack name, e.g. python")) -> None:
+    """Remove a stack template set with safe cleanup semantics."""
+    result = remove_stack(name)
+    typer.echo(json.dumps(result, indent=2))
+    if not bool(result.get("ok", False)):
+        raise typer.Exit(code=1)
+
+
+@ide_app.command("list")
+def ide_list() -> None:
+    """List installed and available IDE profiles."""
+    typer.echo(json.dumps(list_stack_ide_status(), indent=2))
+
+
+@ide_app.command("add")
+def ide_add(name: str = typer.Argument(..., help="IDE name")) -> None:
+    """Add an IDE instruction profile."""
+    result = add_ide(name)
+    typer.echo(json.dumps(result, indent=2))
+    if not bool(result.get("ok", False)):
+        raise typer.Exit(code=1)
+
+
+@ide_app.command("remove")
+def ide_remove(name: str = typer.Argument(..., help="IDE name")) -> None:
+    """Remove an IDE instruction profile with safe cleanup semantics."""
+    result = remove_ide(name)
+    typer.echo(json.dumps(result, indent=2))
+    if not bool(result.get("ok", False)):
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/ai_engineering/installer/operations.py
+++ b/src/ai_engineering/installer/operations.py
@@ -1,0 +1,167 @@
+"""Stack and IDE management operations for installer runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ai_engineering.paths import repo_root, state_dir, template_root
+from ai_engineering.state.io import load_model, write_json
+from ai_engineering.state.models import InstallManifest
+
+from .templates import PROJECT_TEMPLATE_BY_IDE, available_stack_templates
+
+
+SUPPORTED_IDES = {"terminal", "vscode", "claude", "codex", "copilot"}
+
+
+def _manifest(root: Path) -> InstallManifest:
+    return load_model(state_dir(root) / "install-manifest.json", InstallManifest)
+
+
+def _save_manifest(root: Path, manifest: InstallManifest) -> None:
+    write_json(state_dir(root) / "install-manifest.json", manifest.model_dump())
+
+
+def _copy_if_missing(source: Path, destination: Path) -> str:
+    if destination.exists():
+        return "exists"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return "created"
+
+
+def _remove_if_safe(destination: Path, template_content: str) -> str:
+    if not destination.exists():
+        return "missing"
+    current = destination.read_text(encoding="utf-8")
+    if current != template_content:
+        return "skipped-customized"
+    destination.unlink()
+    return "removed"
+
+
+def add_stack(name: str) -> dict[str, Any]:
+    """Install stack-specific framework and team templates."""
+    root = repo_root()
+    available = set(available_stack_templates())
+    if name not in available:
+        return {
+            "ok": False,
+            "message": f"unsupported stack: {name}",
+            "availableStacks": sorted(available),
+        }
+
+    templates = template_root() / ".ai-engineering" / "standards"
+    framework_source = templates / "framework" / "stacks" / f"{name}.md"
+    team_source = templates / "team" / "stacks" / f"{name}.md"
+
+    framework_destination = root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    team_destination = root / ".ai-engineering" / "standards" / "team" / "stacks" / f"{name}.md"
+
+    result = {
+        "framework": _copy_if_missing(framework_source, framework_destination),
+        "team": _copy_if_missing(team_source, team_destination),
+    }
+
+    manifest = _manifest(root)
+    stacks = set(manifest.installedStacks)
+    stacks.add(name)
+    manifest.installedStacks = sorted(stacks)
+    _save_manifest(root, manifest)
+
+    return {"ok": True, "stack": name, "result": result, "installedStacks": manifest.installedStacks}
+
+
+def remove_stack(name: str) -> dict[str, Any]:
+    """Remove stack templates with safe cleanup semantics."""
+    root = repo_root()
+    templates = template_root() / ".ai-engineering" / "standards"
+    framework_source = templates / "framework" / "stacks" / f"{name}.md"
+    team_source = templates / "team" / "stacks" / f"{name}.md"
+
+    if not framework_source.exists() or not team_source.exists():
+        return {"ok": False, "message": f"unsupported stack: {name}"}
+
+    framework_destination = root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    team_destination = root / ".ai-engineering" / "standards" / "team" / "stacks" / f"{name}.md"
+
+    framework_status = _remove_if_safe(
+        framework_destination, framework_source.read_text(encoding="utf-8")
+    )
+    team_status = _remove_if_safe(team_destination, team_source.read_text(encoding="utf-8"))
+
+    manifest = _manifest(root)
+    stacks = set(manifest.installedStacks)
+    stacks.discard(name)
+    manifest.installedStacks = sorted(stacks)
+    _save_manifest(root, manifest)
+
+    return {
+        "ok": True,
+        "stack": name,
+        "result": {"framework": framework_status, "team": team_status},
+        "installedStacks": manifest.installedStacks,
+    }
+
+
+def add_ide(name: str) -> dict[str, Any]:
+    """Install IDE-specific instruction templates where applicable."""
+    root = repo_root()
+    if name not in SUPPORTED_IDES:
+        return {"ok": False, "message": f"unsupported ide: {name}", "availableIdes": sorted(SUPPORTED_IDES)}
+
+    result = "recorded"
+    mapping = PROJECT_TEMPLATE_BY_IDE.get(name)
+    if mapping is not None:
+        source_relative, destination_relative = mapping
+        source = template_root() / source_relative
+        destination = root / destination_relative
+        result = _copy_if_missing(source, destination)
+
+    manifest = _manifest(root)
+    ides = set(manifest.installedIdes)
+    ides.add(name)
+    manifest.installedIdes = sorted(ides)
+    _save_manifest(root, manifest)
+
+    return {"ok": True, "ide": name, "result": result, "installedIdes": manifest.installedIdes}
+
+
+def remove_ide(name: str) -> dict[str, Any]:
+    """Remove IDE-specific instruction templates with safe cleanup semantics."""
+    root = repo_root()
+    if name not in SUPPORTED_IDES:
+        return {"ok": False, "message": f"unsupported ide: {name}", "availableIdes": sorted(SUPPORTED_IDES)}
+
+    status = "recorded"
+    mapping = PROJECT_TEMPLATE_BY_IDE.get(name)
+    if mapping is not None:
+        source_relative, destination_relative = mapping
+        source = template_root() / source_relative
+        destination = root / destination_relative
+        status = _remove_if_safe(destination, source.read_text(encoding="utf-8"))
+        if destination_relative.startswith(".github/"):
+            github_dir = root / ".github"
+            if github_dir.exists() and not any(github_dir.iterdir()):
+                github_dir.rmdir()
+
+    manifest = _manifest(root)
+    ides = set(manifest.installedIdes)
+    ides.discard(name)
+    manifest.installedIdes = sorted(ides)
+    _save_manifest(root, manifest)
+
+    return {"ok": True, "ide": name, "result": status, "installedIdes": manifest.installedIdes}
+
+
+def list_stack_ide_status() -> dict[str, Any]:
+    """Return installed and supported stack/IDE status."""
+    root = repo_root()
+    manifest = _manifest(root)
+    return {
+        "installedStacks": manifest.installedStacks,
+        "installedIdes": manifest.installedIdes,
+        "availableStacks": available_stack_templates(),
+        "availableIdes": sorted(SUPPORTED_IDES),
+    }

--- a/src/ai_engineering/installer/templates.py
+++ b/src/ai_engineering/installer/templates.py
@@ -13,6 +13,12 @@ PROJECT_TEMPLATE_MAPPINGS: tuple[tuple[str, str], ...] = (
     ("project/copilot-instructions.md", ".github/copilot-instructions.md"),
 )
 
+PROJECT_TEMPLATE_BY_IDE: dict[str, tuple[str, str]] = {
+    "claude": ("project/CLAUDE.md", "CLAUDE.md"),
+    "codex": ("project/codex.md", "codex.md"),
+    "copilot": ("project/copilot-instructions.md", ".github/copilot-instructions.md"),
+}
+
 
 def _governance_template_mappings() -> tuple[tuple[str, str], ...]:
     source_root = template_root()
@@ -58,3 +64,11 @@ def sync_templates(repo_root: Path) -> dict[str, str]:
         result[destination_relative] = "created"
 
     return result
+
+
+def available_stack_templates() -> list[str]:
+    """Return available stack template names bundled with framework."""
+    root = template_root() / ".ai-engineering" / "standards" / "framework" / "stacks"
+    if not root.exists():
+        return []
+    return sorted(path.stem for path in root.glob("*.md") if path.is_file())

--- a/src/ai_engineering/state/defaults.py
+++ b/src/ai_engineering/state/defaults.py
@@ -20,6 +20,8 @@ def install_manifest_default(framework_version: str) -> dict:
         },
         "frameworkVersion": framework_version,
         "installedAt": _now_iso(),
+        "installedStacks": ["python"],
+        "installedIdes": ["terminal", "vscode", "claude", "codex", "copilot"],
         "providers": {
             "vcs": {
                 "primary": "github",

--- a/src/ai_engineering/state/models.py
+++ b/src/ai_engineering/state/models.py
@@ -97,6 +97,8 @@ class InstallManifest(BaseModel):
     updateMetadata: UpdateMetadata
     frameworkVersion: str
     installedAt: str
+    installedStacks: list[str] = Field(default_factory=list)
+    installedIdes: list[str] = Field(default_factory=list)
     providers: Providers
     toolingReadiness: ToolingReadiness
 

--- a/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
@@ -104,6 +104,17 @@ No heavy policy engine should be embedded in Python if behavior can be declared 
 - `/acho` -> stage + commit + push.
 - `/acho pr` -> stage + commit + push + create PR.
 
+Mandatory PR behavior:
+
+- `/pr` and `/acho pr` must enable PR auto-complete using squash merge and branch cleanup.
+
+Stack and IDE management commands:
+
+- `ai stack add <name>`
+- `ai stack remove <name>`
+- `ai ide add <name>`
+- `ai ide remove <name>`
+
 `/pr --only` policy when branch is not pushed:
 
 - Emit warning.

--- a/src/ai_engineering/templates/.ai-engineering/manifest.yml
+++ b/src/ai_engineering/templates/.ai-engineering/manifest.yml
@@ -44,7 +44,14 @@ commands:
     default: ["stage", "commit", "push_current_branch"]
     only: ["stage", "commit"]
   pr:
-    default: ["stage", "commit", "push_current_branch", "create_pr"]
+    default:
+      [
+        "stage",
+        "commit",
+        "push_current_branch",
+        "create_pr",
+        "enable_pr_auto_complete",
+      ]
     only: ["create_pr"]
     when_branch_not_pushed:
       severity: "warning"
@@ -52,7 +59,17 @@ commands:
       continue_modes: ["defer-pr", "attempt-pr-anyway", "export-pr-payload"]
   acho:
     default: ["stage", "commit", "push_current_branch"]
-    pr: ["stage", "commit", "push_current_branch", "create_pr"]
+    pr:
+      [
+        "stage",
+        "commit",
+        "push_current_branch",
+        "create_pr",
+        "enable_pr_auto_complete",
+      ]
+  management:
+    stack: ["add", "remove", "list"]
+    ide: ["add", "remove", "list"]
 
 providers:
   vcs:

--- a/tests/unit/test_state_models.py
+++ b/tests/unit/test_state_models.py
@@ -20,6 +20,8 @@ def test_install_manifest_default_validates() -> None:
     payload = install_manifest_default("0.1.0")
     model = InstallManifest.model_validate(payload)
     assert model.schemaVersion == "1.1"
+    assert "python" in model.installedStacks
+    assert "vscode" in model.installedIdes
 
 
 def test_ownership_map_default_validates() -> None:


### PR DESCRIPTION
## Summary
- implement full minimal-runtime stack/IDE lifecycle commands: `ai stack add/remove/list` and `ai ide add/remove/list`
- add ownership-safe stack/IDE operations with manifest tracking (`installedStacks`, `installedIdes`) and safe cleanup behavior for customized team files
- update canonical + mirrored framework contract and manifest to make PR auto-complete mandatory for `/pr` and `/acho pr`
- persist phase updates in delivery/backlog context and update root README command contract

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest`
- `.venv/bin/ty check src`
- `.venv/bin/pip-audit`

## Notes
- `/pr` and `/acho pr` now explicitly include auto-complete behavior in documented contract/manifest
- `ai ide remove` and `ai stack remove` preserve customized files with `skipped-customized` status instead of destructive deletion