### PR TITLE
feat(gates): enforce native hooks and auto-remediate missing tools

### DIFF
--- a/.ai-engineering/context/backlog/tasks.md
+++ b/.ai-engineering/context/backlog/tasks.md
@@ -64,3 +64,7 @@
 - [x] R-001 add automated docs contract check to governance pre-commit gates.
 - [x] R-002 add CLI command to run docs contract check directly (`ai gate docs`).
 - [x] R-003 add unit tests for docs contract gate behavior.
+- [x] S-001 enforce framework-managed native `.git/hooks` scripts and remove lefthook dependency from hook runtime.
+- [x] S-002 harden hook runtime scripts with fail-closed cross-OS python launcher fallback.
+- [x] S-003 add gate auto-remediation for missing mandatory tools and re-run checks.
+- [x] S-004 add install/doctor and unit tests covering lefthook wrapper replacement and hook readiness conflict detection.

--- a/.ai-engineering/context/delivery/implementation.md
+++ b/.ai-engineering/context/delivery/implementation.md
@@ -294,3 +294,19 @@ Status:
 - Blockers: none.
 - Decisions: enforce docs contract on active backlog/delivery files only; deprecated historical snapshots remain out of the mandatory set.
 - Next step: optionally add a dedicated docs-check step to CI reporting for clearer visibility separate from pre-commit output.
+
+### 2026-02-09 - Phase S / Native Hook Hardening + Tool Auto-Remediation
+
+- Rationale: enforce non-bypassable local gates without lefthook dependency and guarantee that missing mandatory tools trigger remediation-before-retry behavior.
+- Expected gain: deterministic `.git/hooks` behavior, stronger cross-OS hook reliability, and lower false success rates when local tooling is missing.
+- Potential impact: commit/push operations now attempt auto-install for missing mandatory tools and fail closed if remediation cannot complete.
+- Work completed: hardened managed hook scripts to use fail-closed execution with cross-OS python launcher fallback (`.venv/bin/python`, `.venv/Scripts/python.exe`, `python3`, `python`, then `ai`).
+- Work completed: expanded hook readiness to detect external wrapper conflicts (including lefthook wrappers) and expose managed/integrity/conflict status details.
+- Work completed: added optional `ai doctor --fix-hooks` repair flow to reinstall framework-managed hooks before readiness checks.
+- Work completed: implemented gate-level missing-tool auto-remediation with re-run behavior for Python baseline tools and `gitleaks` package-manager install attempts.
+- Work completed: clarified contract and standards text so agents must remediate missing tools locally before continuing.
+- Changed modules: `src/ai_engineering/hooks/manager.py`, `src/ai_engineering/policy/gates.py`, `src/ai_engineering/doctor/service.py`, `src/ai_engineering/cli_commands/core.py`, `tests/integration/test_cli_install_doctor.py`, `tests/unit/test_gate_policy.py`, `tests/unit/test_hooks_manager.py`, `.ai-engineering/context/product/framework-contract.md`, `.ai-engineering/standards/framework/core.md`, `.ai-engineering/context/delivery/review.md`, template mirrors under `src/ai_engineering/templates/.ai-engineering/**`, and delivery/backlog phase logs.
+- Validation run: `.venv/bin/ruff check src tests` and `.venv/bin/python -m pytest`.
+- Blockers: none.
+- Decisions: keep operation blocked when remediation cannot complete (permissions/network/auth constraints) and return explicit manual remediation steps.
+- Next step: add CI visibility split for pre-commit vs pre-push gate subsets to make remediation failures easier to triage.

--- a/.ai-engineering/context/delivery/planning.md
+++ b/.ai-engineering/context/delivery/planning.md
@@ -77,6 +77,7 @@ If branch is not pushed:
 | Phase P | Structure reorganization (indexes, status board, active-vs-history split) | Completed |
 | Phase Q | Documentation hardening (metadata normalization and pre-merge checklist) | Completed |
 | Phase R | Automated docs contract enforcement (gate + CLI + tests) | Completed |
+| Phase S | Native hook hardening and missing-tool auto-remediation | Completed |
 
 ## Phase Status Alignment Notes
 

--- a/.ai-engineering/context/delivery/review.md
+++ b/.ai-engineering/context/delivery/review.md
@@ -56,4 +56,5 @@ When policy weakening is requested:
 - active-vs-history separation respected: no phase execution logs added to active backlog catalogs.
 - stale snapshot handling respected: historical snapshots are archived or explicitly marked deprecated.
 - required quality/security gate statement present for code-affecting work: `unit`, `integration`, `e2e`, `ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`.
+- missing mandatory tooling was auto-remediated and checks re-run, or operation stayed blocked with explicit manual remediation steps.
 - references updated: `backlog/index.md`, `delivery/index.md`, and `backlog/status.md` reflect current state.

--- a/.ai-engineering/context/product/framework-contract.md
+++ b/.ai-engineering/context/product/framework-contract.md
@@ -78,6 +78,9 @@ No heavy policy engine should be embedded in Python if behavior can be declared 
   - dependency vulnerability checks
   - formatter/linter/security checks by detected stack
 - No skip guidance. Failures must be fixed locally.
+- If a mandatory tool is missing or not operational, agents must attempt local remediation in-order:
+  detect -> install -> configure/authenticate when applicable -> re-run failing check.
+- If remediation still fails due to environment constraints, operation remains blocked and explicit manual remediation steps are required.
 
 ### 6) Install and Bootstrap Behavior
 

--- a/.ai-engineering/standards/framework/core.md
+++ b/.ai-engineering/standards/framework/core.md
@@ -22,6 +22,8 @@ Framework-owned baseline standards for every installed instance.
 
 - All mandatory checks run locally before commit/push operations.
 - Failing mandatory checks block the operation.
+- Missing mandatory tools must be auto-remediated locally before retrying checks.
+- Auto-remediation order: detect -> install -> configure/authenticate if applicable -> re-run check.
 - Team or project layers may add stricter rules, but cannot weaken this file.
 
 ## Command Governance

--- a/src/ai_engineering/cli_commands/core.py
+++ b/src/ai_engineering/cli_commands/core.py
@@ -38,9 +38,14 @@ def register(app: typer.Typer) -> None:
     @app.command()
     def doctor(
         json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+        fix_hooks: bool = typer.Option(
+            False,
+            "--fix-hooks",
+            help="Repair framework-managed git hooks before readiness checks",
+        ),
     ) -> None:
         """Run readiness diagnostics."""
-        result = run_doctor()
+        result = run_doctor(fix_hooks=fix_hooks)
         if json_output:
             typer.echo(json.dumps(result, indent=2))
             return

--- a/src/ai_engineering/doctor/service.py
+++ b/src/ai_engineering/doctor/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ai_engineering.detector.readiness import detect_az, detect_gh, detect_python_tools
-from ai_engineering.hooks.manager import detect_hook_readiness
+from ai_engineering.hooks.manager import detect_hook_readiness, install_placeholder_hooks
 from ai_engineering.paths import ai_engineering_root, repo_root
 from ai_engineering.policy.gates import current_branch, discover_protected_branches
 from ai_engineering.state.io import load_model
@@ -36,9 +36,11 @@ def _validate_state_files(ae_root: Path) -> dict[str, bool]:
     return result
 
 
-def run_doctor() -> dict[str, object]:
+def run_doctor(*, fix_hooks: bool = False) -> dict[str, object]:
     """Run readiness checks and return machine-readable status."""
     root = repo_root()
+    if fix_hooks:
+        install_placeholder_hooks(root)
     ae_root = ai_engineering_root(root)
     state_checks = _validate_state_files(ae_root)
     hook_checks = detect_hook_readiness(root)

--- a/src/ai_engineering/installer/operations.py
+++ b/src/ai_engineering/installer/operations.py
@@ -56,7 +56,9 @@ def add_stack(name: str) -> dict[str, Any]:
     framework_source = templates / "framework" / "stacks" / f"{name}.md"
     team_source = templates / "team" / "stacks" / f"{name}.md"
 
-    framework_destination = root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    framework_destination = (
+        root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    )
     team_destination = root / ".ai-engineering" / "standards" / "team" / "stacks" / f"{name}.md"
 
     result = {
@@ -70,7 +72,12 @@ def add_stack(name: str) -> dict[str, Any]:
     manifest.installedStacks = sorted(stacks)
     _save_manifest(root, manifest)
 
-    return {"ok": True, "stack": name, "result": result, "installedStacks": manifest.installedStacks}
+    return {
+        "ok": True,
+        "stack": name,
+        "result": result,
+        "installedStacks": manifest.installedStacks,
+    }
 
 
 def remove_stack(name: str) -> dict[str, Any]:
@@ -83,7 +90,9 @@ def remove_stack(name: str) -> dict[str, Any]:
     if not framework_source.exists() or not team_source.exists():
         return {"ok": False, "message": f"unsupported stack: {name}"}
 
-    framework_destination = root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    framework_destination = (
+        root / ".ai-engineering" / "standards" / "framework" / "stacks" / f"{name}.md"
+    )
     team_destination = root / ".ai-engineering" / "standards" / "team" / "stacks" / f"{name}.md"
 
     framework_status = _remove_if_safe(
@@ -109,7 +118,11 @@ def add_ide(name: str) -> dict[str, Any]:
     """Install IDE-specific instruction templates where applicable."""
     root = repo_root()
     if name not in SUPPORTED_IDES:
-        return {"ok": False, "message": f"unsupported ide: {name}", "availableIdes": sorted(SUPPORTED_IDES)}
+        return {
+            "ok": False,
+            "message": f"unsupported ide: {name}",
+            "availableIdes": sorted(SUPPORTED_IDES),
+        }
 
     result = "recorded"
     mapping = PROJECT_TEMPLATE_BY_IDE.get(name)
@@ -132,7 +145,11 @@ def remove_ide(name: str) -> dict[str, Any]:
     """Remove IDE-specific instruction templates with safe cleanup semantics."""
     root = repo_root()
     if name not in SUPPORTED_IDES:
-        return {"ok": False, "message": f"unsupported ide: {name}", "availableIdes": sorted(SUPPORTED_IDES)}
+        return {
+            "ok": False,
+            "message": f"unsupported ide: {name}",
+            "availableIdes": sorted(SUPPORTED_IDES),
+        }
 
     status = "recorded"
     mapping = PROJECT_TEMPLATE_BY_IDE.get(name)

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/review.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/review.md
@@ -20,6 +20,12 @@
 - dependency vulnerability checks (`pip-audit` in Python baseline).
 - stack checks (`uv`, `ruff`, `ty`, tests).
 
+## Tool Remediation Rule
+
+- missing mandatory tools must be remediated locally before continuing.
+- remediation order: detect -> install -> configure/authenticate -> re-run failed checks.
+- if remediation cannot complete, keep operation blocked and provide explicit manual steps.
+
 ## Blocking Policies
 
 - no direct commits to `main` or `master`.

--- a/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
@@ -78,6 +78,9 @@ No heavy policy engine should be embedded in Python if behavior can be declared 
   - dependency vulnerability checks
   - formatter/linter/security checks by detected stack
 - No skip guidance. Failures must be fixed locally.
+- If a mandatory tool is missing or not operational, agents must attempt local remediation in-order:
+  detect -> install -> configure/authenticate when applicable -> re-run failing check.
+- If remediation still fails due to environment constraints, operation remains blocked and explicit manual remediation steps are required.
 
 ### 6) Install and Bootstrap Behavior
 

--- a/src/ai_engineering/templates/.ai-engineering/standards/framework/core.md
+++ b/src/ai_engineering/templates/.ai-engineering/standards/framework/core.md
@@ -22,6 +22,8 @@ Framework-owned baseline standards for every installed instance.
 
 - All mandatory checks run locally before commit/push operations.
 - Failing mandatory checks block the operation.
+- Missing mandatory tools must be auto-remediated locally before retrying checks.
+- Auto-remediation order: detect -> install -> configure/authenticate if applicable -> re-run check.
 - Team or project layers may add stricter rules, but cannot weaken this file.
 
 ## Command Governance

--- a/src/ai_engineering/updater/service.py
+++ b/src/ai_engineering/updater/service.py
@@ -26,7 +26,11 @@ def _candidate_paths(path: str) -> set[str]:
 def _matches(pattern: str, path: str) -> bool:
     path_candidates = _candidate_paths(path)
     pattern_candidates = _candidate_paths(pattern)
-    return any(fnmatch.fnmatch(candidate, candidate_pattern) for candidate in path_candidates for candidate_pattern in pattern_candidates)
+    return any(
+        fnmatch.fnmatch(candidate, candidate_pattern)
+        for candidate in path_candidates
+        for candidate_pattern in pattern_candidates
+    )
 
 
 def _rule_for_path(ownership: OwnershipMap, path: str) -> tuple[str, str] | None:

--- a/tests/unit/test_hooks_manager.py
+++ b/tests/unit/test_hooks_manager.py
@@ -1,0 +1,37 @@
+"""Unit tests for managed git hook generation and readiness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_engineering.hooks import manager
+
+
+def test_install_placeholder_hooks_writes_framework_managed_scripts(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+
+    manager.install_placeholder_hooks(repo)
+
+    for hook in manager.HOOKS:
+        hook_path = repo / ".git" / "hooks" / hook
+        assert hook_path.exists()
+        content = hook_path.read_text(encoding="utf-8")
+        assert "ai-engineering managed hook" in content
+        assert "lefthook" not in content
+
+
+def test_detect_hook_readiness_reports_conflict_for_lefthook_wrapper(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    hooks = repo / ".git" / "hooks"
+    hooks.mkdir(parents=True)
+    for hook in manager.HOOKS:
+        path = hooks / hook
+        path.write_text("#!/bin/sh\nlefthook run pre-commit\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    payload = manager.detect_hook_readiness(repo)
+
+    assert payload["installed"] is True
+    assert payload["managedByFramework"] is False
+    assert payload["conflictDetected"] is True


### PR DESCRIPTION
## Summary
- enforce framework-managed native `.git/hooks` scripts with fail-closed cross-OS runtime fallback and no `lefthook` dependency.
- add gate-level missing-tool auto-remediation, retry behavior, and `doctor --fix-hooks` hook repair support.
- expand tests and governance docs/template mirrors to codify remediation-first policy and hook integrity expectations.

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest`
- `.venv/bin/ty check src`
- `.venv/bin/pip-audit`
- `semgrep --config auto`
- `gitleaks protect --staged --redact`