### PR TITLE
feat(governance): close contract parity and risk decision flows

### DIFF
--- a/.ai-engineering/context/product/framework-contract.md
+++ b/.ai-engineering/context/product/framework-contract.md
@@ -29,14 +29,17 @@ Python is intentionally minimal and operational.
 
 ### Minimal Python Runtime Scope
 
-Python is used only for:
+Python runtime is intentionally limited to operational workflows:
 
 1. `install` - copy templates, set up hooks, run readiness checks.
 2. `update` - ownership-safe updates and migrations.
 3. `doctor` - verify installed/configured/authenticated/ready state.
 4. `add/remove stack|ide` - safe template operations and cleanup.
+5. governed command workflows (`/commit`, `/pr`, `/acho`) and local gate execution.
+6. risk acceptance persistence/reuse checks with append-only audit events.
+7. remote skills sync/lock/cache enforcement and maintenance report generation.
 
-No heavy policy engine should be embedded in Python if behavior can be declared in governance content.
+Policy and standards remain content-first; Python orchestration must stay thin, deterministic, and test-covered.
 
 ## Product Principles (Non-Negotiable)
 

--- a/.ai-engineering/manifest.yml
+++ b/.ai-engineering/manifest.yml
@@ -104,6 +104,7 @@ enforcement:
       - "ruff-format"
       - "ruff-lint"
       - "gitleaks"
+      - "docs-contract"
     pre_push:
       - "semgrep"
       - "pip-audit"

--- a/.github/workflows/governance-ci.yml
+++ b/.github/workflows/governance-ci.yml
@@ -1,0 +1,38 @@
+name: Governance CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  cross-os-validation:
+    name: Cross-OS Validation (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e ".[dev]"
+
+      - name: Lint and format checks
+        run: ruff format --check src tests && ruff check src tests
+
+      - name: Type checks
+        run: ty check src
+
+      - name: Unit and integration governance tests
+        run: pytest tests/unit/test_gate_policy.py tests/unit/test_decision_logic.py tests/integration/test_cli_install_doctor.py::test_install_creates_required_state_files tests/integration/test_cli_install_doctor.py::test_gate_risk_accept_persists_decision_and_audit tests/integration/test_cli_install_doctor.py::test_gate_risk_check_reports_scope_change_reason

--- a/src/ai_engineering/policy/risk_acceptance.py
+++ b/src/ai_engineering/policy/risk_acceptance.py
@@ -1,0 +1,132 @@
+"""Risk acceptance helpers for explicit governance decisions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from ai_engineering.state.decision_logic import append_decision, context_hash, evaluate_reuse
+from ai_engineering.state.io import append_ndjson, load_model
+from ai_engineering.state.models import DecisionStore
+
+
+Severity = Literal["low", "medium", "high", "critical"]
+
+
+def remediation_suggestion(policy_id: str) -> str:
+    """Return a human-readable remediation suggestion for a policy."""
+    suggestions = {
+        "PR_ONLY_UNPUSHED_BRANCH_MODE": "Use auto-push mode and create PR with upstream branch tracked.",
+        "NO_DIRECT_COMMIT_PROTECTED_BRANCH": "Create a feature branch and use /pr flow instead of direct commit.",
+        "MANDATORY_TOOLING_ENFORCEMENT": "Install missing tools locally and re-run gate checks before retrying.",
+    }
+    return suggestions.get(policy_id, "Apply the documented governance baseline for this policy.")
+
+
+def parse_context_payload(raw: str) -> dict[str, Any]:
+    """Parse JSON context payload from CLI input."""
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid context JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("context JSON must be an object")
+    return payload
+
+
+def record_acceptance(
+    *,
+    root: Path,
+    policy_id: str,
+    decision: str,
+    rationale: str,
+    severity: Severity,
+    context_payload: dict[str, Any],
+    path_pattern: str | None,
+    created_by: str,
+) -> dict[str, Any]:
+    """Persist risk acceptance decision and emit append-only audit event."""
+    state_root = root / ".ai-engineering" / "state"
+    decision_store_path = state_root / "decision-store.json"
+    if not decision_store_path.exists():
+        raise FileNotFoundError("missing decision-store.json; run 'ai install' first")
+
+    hashed_context = context_hash(context_payload)
+    record = append_decision(
+        decision_store_path,
+        policy_id=policy_id,
+        repo_name=root.name,
+        decision=decision,
+        rationale=rationale,
+        context_hash_value=hashed_context,
+        severity=severity,
+        created_by=created_by,
+    )
+    if path_pattern is not None:
+        store = load_model(decision_store_path, DecisionStore)
+        store.decisions[-1].scope.pathPattern = path_pattern
+        (state_root / "decision-store.json").write_text(
+            store.model_dump_json(indent=2) + "\n", encoding="utf-8"
+        )
+
+    suggestion = remediation_suggestion(policy_id)
+    append_ndjson(
+        state_root / "audit-log.ndjson",
+        {
+            "event": "risk_acceptance_recorded",
+            "actor": "gate-cli",
+            "details": {
+                "policyId": policy_id,
+                "decision": decision,
+                "severity": severity,
+                "contextHash": hashed_context,
+                "pathPattern": path_pattern,
+                "remediationSuggestion": suggestion,
+            },
+        },
+    )
+    return {
+        "policyId": policy_id,
+        "decision": record.decision,
+        "severity": record.severity,
+        "contextHash": record.contextHash,
+        "createdAt": record.createdAt,
+        "reused": False,
+        "remediationSuggestion": suggestion,
+    }
+
+
+def check_reuse(
+    *,
+    root: Path,
+    policy_id: str,
+    severity: Severity,
+    context_payload: dict[str, Any],
+    path_pattern: str | None,
+    expected_decision: str | None,
+) -> dict[str, Any]:
+    """Check whether an existing decision can be reused."""
+    state_root = root / ".ai-engineering" / "state"
+    decision_store_path = state_root / "decision-store.json"
+    if not decision_store_path.exists():
+        raise FileNotFoundError("missing decision-store.json; run 'ai install' first")
+
+    store = load_model(decision_store_path, DecisionStore)
+    hashed_context = context_hash(context_payload)
+    evaluation = evaluate_reuse(
+        store,
+        policy_id=policy_id,
+        repo_name=root.name,
+        context_hash_value=hashed_context,
+        severity=severity,
+        path_pattern=path_pattern,
+        expected_decision=expected_decision,
+    )
+    record_id = evaluation.record.id if evaluation.record is not None else None
+    return {
+        "reusable": evaluation.reusable,
+        "reason": evaluation.reason,
+        "contextHash": hashed_context,
+        "recordId": record_id,
+    }

--- a/src/ai_engineering/state/decision_logic.py
+++ b/src/ai_engineering/state/decision_logic.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 from ai_engineering.state.io import load_model, write_json
 from ai_engineering.state.models import DecisionRecord, DecisionScope, DecisionStore
@@ -58,6 +58,50 @@ def find_valid_decision(
     return None
 
 
+class DecisionReuseResult(NamedTuple):
+    """Result of evaluating whether a prior decision can be reused."""
+
+    reusable: bool
+    reason: str
+    record: DecisionRecord | None
+
+
+def evaluate_reuse(
+    store: DecisionStore,
+    *,
+    policy_id: str,
+    repo_name: str,
+    context_hash_value: str,
+    severity: Literal["low", "medium", "high", "critical"],
+    path_pattern: str | None = None,
+    expected_decision: str | None = None,
+) -> DecisionReuseResult:
+    """Evaluate whether prior decision can be reused or requires re-prompt."""
+    candidates = [
+        record
+        for record in store.decisions
+        if record.scope.policyId == policy_id and record.scope.repo == repo_name
+    ]
+    if not candidates:
+        return DecisionReuseResult(False, "no_prior_decision", None)
+
+    candidates.sort(key=lambda record: record.createdAt, reverse=True)
+    latest = candidates[0]
+    expires = _parse_time(latest.expiresAt)
+    now = _now_utc()
+    if expires is not None and expires <= now:
+        return DecisionReuseResult(False, "decision_expired", latest)
+    if latest.scope.pathPattern != path_pattern:
+        return DecisionReuseResult(False, "scope_changed", latest)
+    if latest.severity != severity:
+        return DecisionReuseResult(False, "severity_changed", latest)
+    if latest.contextHash != context_hash_value:
+        return DecisionReuseResult(False, "material_context_hash_changed", latest)
+    if expected_decision is not None and latest.decision != expected_decision:
+        return DecisionReuseResult(False, "decision_changed", latest)
+    return DecisionReuseResult(True, "reused", latest)
+
+
 def append_decision(
     decision_store_path: Path,
     *,
@@ -68,6 +112,7 @@ def append_decision(
     context_hash_value: str,
     severity: Literal["low", "medium", "high", "critical"] = "medium",
     created_by: str | None = None,
+    expires_at: str | None = None,
 ) -> DecisionRecord:
     """Append decision record and persist decision store."""
     store = load_model(decision_store_path, DecisionStore)
@@ -84,6 +129,7 @@ def append_decision(
         rationale=rationale,
         createdAt=now,
         createdBy=created_by,
+        expiresAt=expires_at,
     )
     store.decisions.append(record)
     write_json(decision_store_path, store.model_dump(mode="json"))

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/archive/phase-j.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/archive/phase-j.md
@@ -1,0 +1,27 @@
+# Archive - Phase J (Historical)
+
+## Document Metadata
+
+- Doc ID: BL-ARCHIVE-PHASE-J
+- Owner: project-managed (backlog/archive)
+- Status: archived
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/archive/phase-j.md`
+
+## Original Scope Snapshot
+
+- J-001 enable PR auto-complete in governed PR workflows.
+- J-002 add safe `ai git cleanup` command (dry-run default).
+- J-003 add optional remote cleanup mode and branch protection rules.
+- J-004 persist cleanup JSON report and append audit events.
+- J-005 add unit tests for PR auto-complete and cleanup behavior.
+- J-006 run full local quality and security gates.
+
+## Supersession Notes
+
+- Phase K formalized mandatory PR auto-complete behavior in the command contract.
+- Phase L removed non-contractual `ai git cleanup` runtime surface.
+- Active planning and delivery sources:
+  - `.ai-engineering/context/backlog/tasks.md`
+  - `.ai-engineering/context/delivery/planning.md`
+  - `.ai-engineering/context/delivery/implementation.md`

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/epics.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/epics.md
@@ -1,5 +1,13 @@
 # Epics
 
+## Document Metadata
+
+- Doc ID: BL-EPICS
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/epics.md`
+
 ## Update Metadata
 
 - Rationale: rebase epics to final governance architecture.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/features.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/features.md
@@ -1,5 +1,13 @@
 # Features
 
+## Document Metadata
+
+- Doc ID: BL-FEATURES
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/features.md`
+
 ## Update Metadata
 
 - Rationale: map feature scope to finalized policy and command decisions.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/index.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/index.md
@@ -1,0 +1,28 @@
+# Backlog Index
+
+## Document Metadata
+
+- Doc ID: BL-INDEX
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/index.md`
+
+## Purpose
+
+Single entrypoint for product intent and prioritized work.
+
+## Canonical Files
+
+- epics: `.ai-engineering/context/backlog/epics.md`
+- features: `.ai-engineering/context/backlog/features.md`
+- user stories: `.ai-engineering/context/backlog/user-stories.md`
+- tasks: `.ai-engineering/context/backlog/tasks.md`
+- operational status: `.ai-engineering/context/backlog/status.md`
+- traceability matrix: `.ai-engineering/context/backlog/traceability-matrix.md`
+
+## Rules
+
+- Backlog defines what and why.
+- Delivery defines how and what happened.
+- Historical snapshots are archived and never used as active planning sources.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/status.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/status.md
@@ -1,0 +1,34 @@
+# Backlog Status
+
+## Document Metadata
+
+- Doc ID: BL-STATUS
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/status.md`
+
+## Now
+
+- T-016 richer doctor/install readiness and ownership-safe update hook extensions.
+- T-017 charter workstreams W1-W5 execution closure.
+- T-018 updater advanced merge strategy and migration hooks.
+- T-019 Windows-safe hook launcher hardening.
+
+## Next
+
+- tighten story-to-task mapping where stories have broad multi-feature acceptance criteria.
+- add acceptance evidence links per active task in traceability matrix.
+
+## Later
+
+- compact backlog wording for token efficiency after carry-over closure.
+- evaluate backlog automation hints for weekly maintenance reports.
+
+## Current Blockers
+
+- none recorded.
+
+## Gate Reminder
+
+- required before done: `unit`, `integration`, `e2e`, `ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/tasks.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/tasks.md
@@ -1,12 +1,20 @@
 # Tasks
 
+## Document Metadata
+
+- Doc ID: BL-TASKS
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/tasks.md`
+
 ## Update Metadata
 
-- Rationale: sequence tasks according to architecture dependencies.
-- Expected gain: faster MVP execution with fewer blockers.
-- Potential impact: task IDs and ordering changed from previous drafts.
+- Rationale: keep backlog tasks focused on active executable work and move historical execution logs to delivery evidence.
+- Expected gain: lower planning noise and faster backlog-to-delivery navigation for humans and AI agents.
+- Potential impact: phase history is no longer maintained in this file.
 
-## P0 Tasks
+## P0 Task Catalog
 
 - T-001 implement installer creation of required ownership/state files.
 - T-002 implement ownership map enforcement in updater.
@@ -21,130 +29,42 @@
 - T-011 implement readiness validator for `gh`, `az`, hooks, and stack tooling.
 - T-012 implement sources lock/cache handling with checksum + signature metadata fields.
 
-## P1 Tasks
+## P1 Task Catalog
 
 - T-013 implement weekly maintenance-agent local reports.
 - T-014 implement report-to-PR workflow after approval.
 - T-015 implement context compaction checks and redundancy metrics.
 
+## Active Execution Queue (Now)
+
+- [ ] T-016 close carry-over item B-007: richer doctor/install readiness and ownership-safe update hook extensions.
+- [ ] T-017 close carry-over item F-007: execute charter workstreams W1-W5 end-to-end.
+- [ ] T-018 close carry-over item H-005: advanced merge strategy and migration hooks in updater.
+- [ ] T-019 close carry-over item K-006: Windows-safe hook launcher hardening.
+
 ## Definition of Done
 
 - all P0 tasks merged with tests.
 - cross-OS verification green on Windows, macOS, and Linux.
+- quality and security gates green: `unit`, `integration`, `e2e`, `ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`.
 
-## Phase A Execution Log
+## Delivery and History References
 
-- [x] A-001 create root `AGENTS.md` aligned with governance contract.
-- [x] A-002 align `CLAUDE.md` with command/security/ownership contract.
-- [x] A-003 align root `README.md` with current product contract.
-- [x] A-004 harden `.claude/settings.local.json` by removing wildcard permissions.
-- [x] A-005 align `pyproject.toml` to Astral-first baseline metadata.
-- [x] A-006 run Phase A validations and record outputs.
-- [x] A-007 publish Phase A completion note in implementation log.
+- phase execution history: `.ai-engineering/context/delivery/evidence/execution-history.md`
+- implementation decision log: `.ai-engineering/context/delivery/implementation.md`
+- traceability mapping: `.ai-engineering/context/backlog/traceability-matrix.md`
 
-## Phase B Execution Log
+## Backlog Maintenance Log
 
-- Rationale: move from contract alignment to executable framework baseline.
-- Expected gain: enforceable state contracts and runnable CLI bootstrap commands.
-- Potential impact: introduces new module boundaries and runtime entrypoints.
-
-- [x] B-001 scaffold core packages (`cli`, `state`, `installer`, `doctor`, `detector`, `hooks`, `policy`, `standards`, `skills`, `updater`).
-- [x] B-002 implement state schemas and JSON/ndjson I/O helpers.
-- [x] B-003 implement default state payload generators for installer bootstrap.
-- [x] B-004 implement minimal `ai install` and `ai doctor` commands.
-- [x] B-005 add unit and integration tests for schema and CLI baseline.
-- [x] B-006 run quality checks (`ruff`, `pytest`, `ty`, `pip-audit`) in project virtualenv.
-- [ ] B-007 extend doctor/install behavior for richer readiness and ownership-safe update hooks.
-
-## Phase C Execution Log
-
-- Rationale: activate governance and security checks in real git workflows.
-- Expected gain: local enforcement catches violations before remote integration.
-- Potential impact: direct commit/push attempts on protected branches are blocked.
-
-- [x] C-001 replace placeholder hooks with managed hook scripts.
-- [x] C-002 add hook integrity verification in doctor readiness checks.
-- [x] C-003 implement gate engine for `pre-commit`, `commit-msg`, and `pre-push` stages.
-- [x] C-004 enforce protected branch blocking for `main` and `master` commit/push operations.
-- [x] C-005 integrate mandatory tools: `ruff`, `gitleaks`, `semgrep`, `pip-audit`, `pytest`, `ty`.
-- [x] C-006 add policy and integration tests for hook/gate behavior.
-- [x] C-007 improve failed-check remediation output and branch-policy discovery.
-
-## Phase D Execution Log
-
-- Rationale: operationalize user-facing command contract with governance guardrails.
-- Expected gain: predictable command behavior for commit/push/PR workflows.
-- Potential impact: CLI now orchestrates git/gh operations directly and can fail on governance checks.
-
-- [x] D-001 implement `commit` workflow (`stage + commit` and optional push).
-- [x] D-002 implement `pr` workflow (`stage + commit + push + create PR`).
-- [x] D-003 implement `acho` and `acho pr` command flows.
-- [x] D-004 implement `/pr --only` continuation modes with warning on unpushed branches.
-- [x] D-005 integrate decision-store reuse and persistence for PR-only unpushed-branch behavior.
-- [x] D-006 add unit tests for command workflow policy paths.
-- [x] D-007 add deeper E2E command tests with real git branch/remote scenarios.
-
-## Phase E Execution Log
-
-- Rationale: make remote skills and maintenance workflow operational for sustained governance quality.
-- Expected gain: predictable source lock behavior and recurring context health visibility.
-- Potential impact: extra state outputs and new CLI command surfaces (`skill`, `maintenance`).
-
-- [x] E-001 implement remote skills sync/list service with cache and lock updates.
-- [x] E-002 add CLI commands for `skill list`, `skill sync` with offline mode.
-- [x] E-003 implement maintenance local report generation and optional PR payload draft.
-- [x] E-004 add integration and unit tests for skills and maintenance behavior.
-- [x] E-005 enforce allowlist/pinning validation hard-fail logic in sync path.
-- [x] E-006 wire approved maintenance reports to optional automated PR command flow.
-
-## Phase F Execution Log
-
-- Rationale: establish a single canonical product contract and adoption strategy for the content-first rebuild.
-- Expected gain: removes ambiguity on scope, migration decisions, and rollout sequence.
-- Potential impact: legacy implementation assumptions are superseded by contract-first guidance.
-
-- [x] F-001 add `context/product/framework-contract.md` with finalized non-negotiable product contract.
-- [x] F-002 add `context/product/framework-adoption-map.md` mapping legacy assets (keep/adapt/drop).
-- [x] F-003 add `context/product/rebuild-rollout-charter.md` with milestones, validation plan, and readiness gates.
-- [x] F-004 fix CLI `Literal` compatibility regression and restore JSON command behavior.
-- [x] F-005 pin `click` compatibility for Typer 0.12 runtime stability.
-- [x] F-006 run full local quality gate validation (`ruff`, `pytest`, `ty`, `pip-audit`).
-- [ ] F-007 execute full implementation of charter workstreams W1-W5.
-
-## Phase G Execution Log
-
-- Rationale: begin legacy adoption execution while preserving content-first architecture and minimal Python runtime scope.
-- Expected gain: recover high-value legacy work without reintroducing runtime complexity.
-- Potential impact: installer now syncs canonical templates into target repositories when files are missing.
-
-- [x] G-001 add bundled quality standards templates (Sonar-like + SonarLint-like + Python profile).
-- [x] G-002 add bundled utility/validation skill templates from legacy concepts (platform detection, git helpers, install readiness).
-- [x] G-003 add compact multi-assistant project templates (`CLAUDE.md`, `codex.md`, Copilot instructions).
-- [x] G-004 implement template sync during `ai install` with ownership-safe create-only behavior.
-- [x] G-005 add integration tests for template creation and team-owned file preservation.
-- [x] G-006 run full local quality suite and record evidence.
-
-## Phase H Execution Log
-
-- Rationale: start ownership-safe updater phase to align update behavior with framework-managed vs team/project-managed boundaries.
-- Expected gain: deterministic dry-run/apply updates with explicit ownership enforcement.
-- Potential impact: update command now rewrites framework-managed files when apply mode is used.
-
-- [x] H-001 implement updater service with ownership-map rule evaluation and template diffing.
-- [x] H-002 add CLI `update` command with dry-run default and explicit `--apply` mode.
-- [x] H-003 extend ownership defaults to include framework template paths and assistant instruction files.
-- [x] H-004 add integration coverage for updater dry-run and ownership preservation behavior.
-- [ ] H-005 continue with advanced merge strategy and migration hooks from legacy updater model.
-
-## Phase I Execution Log
-
-- Rationale: remove template/canonical drift and keep installation outputs aligned with declared governance model.
-- Expected gain: deterministic installs and lower maintenance overhead for governance content updates.
-- Potential impact: installer sync surface expands to full non-state governance tree and may increase update report entries.
-
-- [x] I-001 merge template-only governance artifacts into canonical `.ai-engineering` where missing.
-- [x] I-002 mirror canonical non-state governance files into `src/ai_engineering/templates/.ai-engineering`.
-- [x] I-003 switch installer template mappings to dynamic discovery of bundled governance files.
-- [x] I-004 add regression test ensuring install creates every bundled governance template file.
-- [x] I-005 remove clearly outdated/unused tracked artifacts (`poetry.lock`, empty e2e placeholder).
-- [x] I-006 run full local quality suite (`ruff`, `pytest`, `ty`, `pip-audit`) and record evidence.
+- [x] P-001 split active backlog tasks from historical phase execution logs.
+- [x] P-002 add active status board and backlog index entrypoint.
+- [x] P-003 re-point historical execution tracking to delivery evidence archive.
+- [x] Q-001 normalize document metadata headers across backlog and delivery artifacts.
+- [x] Q-002 add pre-merge backlog/delivery documentation checklist to review gates.
+- [x] R-001 add automated docs contract check to governance pre-commit gates.
+- [x] R-002 add CLI command to run docs contract check directly (`ai gate docs`).
+- [x] R-003 add unit tests for docs contract gate behavior.
+- [x] S-001 enforce framework-managed native `.git/hooks` scripts and remove lefthook dependency from hook runtime.
+- [x] S-002 harden hook runtime scripts with fail-closed cross-OS python launcher fallback.
+- [x] S-003 add gate auto-remediation for missing mandatory tools and re-run checks.
+- [x] S-004 add install/doctor and unit tests covering lefthook wrapper replacement and hook readiness conflict detection.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/traceability-matrix.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/traceability-matrix.md
@@ -1,0 +1,39 @@
+# Traceability Matrix
+
+## Document Metadata
+
+- Doc ID: BL-TRACE
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/traceability-matrix.md`
+
+## Purpose
+
+Single mapping source from product intent to executable work and validation evidence.
+
+## ID Convention
+
+- Epic: `EPIC-*`
+- Feature: `F-*`
+- Story: `US-*`
+- Task: `T-*`
+- Implementation evidence: phase entries in `.ai-engineering/context/delivery/implementation.md`
+- Verification/testing evidence: `.ai-engineering/context/delivery/verification.md` and `.ai-engineering/context/delivery/testing.md`
+
+## End-to-End Mapping
+
+| Epic | Feature | Story | Tasks | Delivery Evidence | Verification/Testing Evidence |
+|---|---|---|---|---|---|
+| EPIC-1 Ownership and State Foundation | F-1 Installer/Updater Ownership Safety | US-3 Ownership-Safe Updates | T-001, T-002 | Phase B, H, I entries in `delivery/implementation.md` | `delivery/verification.md` ownership safety matrix, `delivery/testing.md` integration layers |
+| EPIC-2 Mandatory Local Enforcement | F-5 Mandatory Local Security and Quality Gates | US-1 Commanded Commit Flow | T-004, T-005, T-006 | Phase C entries in `delivery/implementation.md` | `delivery/verification.md` security failure scenarios, `delivery/testing.md` mandatory checks |
+| EPIC-3 Command Contract Runtime | F-3 Command Flow Engine; F-4 /pr --only Continuation Policy | US-1, US-2 | T-007, T-008 | Phase D, K, N entries in `delivery/implementation.md` | `delivery/verification.md` command flow matrix, `delivery/testing.md` regression targets |
+| EPIC-4 Remote Skills Trust Model | F-6 Remote Skills Lock and Cache | US-5 Readiness Assurance (partial) | T-012 | Phase E entries in `delivery/implementation.md` | `delivery/verification.md` connectivity/offline cases, `delivery/testing.md` security tests |
+| EPIC-5 Decision and Audit Governance | F-7 Risk Decision Store and Audit Trail | US-4 Risk Decision Reuse | T-009, T-010 | Phase D, M entries in `delivery/implementation.md` | `delivery/verification.md` decision reuse criteria, `delivery/testing.md` regression targets |
+| EPIC-6 Context Compaction and Maintenance | F-8 Maintenance Agent Reporting | (TBD story expansion) | T-013, T-014, T-015 | Phase E entries in `delivery/implementation.md` | `delivery/iteration.md` cadence and KPI contract |
+
+## Drift Checks
+
+- Every `US-*` must map to at least one `T-*`.
+- Every completed `T-*` must map to at least one implementation entry.
+- Every merged feature must map to verification/testing evidence.

--- a/src/ai_engineering/templates/.ai-engineering/context/backlog/user-stories.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/backlog/user-stories.md
@@ -1,5 +1,13 @@
 # User Stories
 
+## Document Metadata
+
+- Doc ID: BL-STORIES
+- Owner: project-managed (backlog)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/backlog/user-stories.md`
+
 ## Update Metadata
 
 - Rationale: recast stories around the final command and governance model.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/architecture.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/architecture.md
@@ -1,5 +1,13 @@
 # Target Architecture
 
+## Document Metadata
+
+- Doc ID: DEL-ARCHITECTURE
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/architecture.md`
+
 ## Update Metadata
 
 - Rationale: replace legacy architecture with current governance contract.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/discovery.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/discovery.md
@@ -1,5 +1,13 @@
 # Discovery
 
+## Document Metadata
+
+- Doc ID: DEL-DISCOVERY
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/discovery.md`
+
 ## Update Metadata
 
 - Rationale: capture finalized requirements and assumptions for execution.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/evidence/execution-history.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/evidence/execution-history.md
@@ -1,0 +1,44 @@
+# Execution History Archive
+
+## Document Metadata
+
+- Doc ID: DEL-EVID-HISTORY
+- Owner: project-managed (delivery/evidence)
+- Status: active-archive
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/evidence/execution-history.md`
+
+## Purpose
+
+Keep historical phase checklist snapshots out of active backlog planning files.
+
+## Archived Source
+
+- Migrated from prior `backlog/tasks.md` execution-log sections.
+
+## Phase Summary
+
+- Phase A: completed.
+- Phase B: completed with open carry-over B-007.
+- Phase C: completed.
+- Phase D: completed.
+- Phase E: completed.
+- Phase F: completed with open carry-over F-007.
+- Phase G: completed.
+- Phase H: completed with open carry-over H-005.
+- Phase I: completed.
+- Phase J: archived/superseded.
+- Phase K: completed with open carry-over K-006.
+- Phase L: completed.
+- Phase M: completed.
+- Phase N: completed.
+- Phase O: completed (backlog-delivery traceability hardening docs).
+
+## Active Carry-Over References
+
+- `.ai-engineering/context/backlog/tasks.md` (T-016, T-017, T-018, T-019)
+- `.ai-engineering/context/backlog/status.md`
+
+## Detailed Narrative Reference
+
+- `.ai-engineering/context/delivery/implementation.md`

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/evidence/validation-runs.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/evidence/validation-runs.md
@@ -1,0 +1,50 @@
+# Validation Runs
+
+## Document Metadata
+
+- Doc ID: DEL-EVID-VALIDATION
+- Owner: project-managed (delivery/evidence)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/evidence/validation-runs.md`
+
+## Purpose
+
+Record concrete validation evidence with links or command outputs for auditable delivery quality.
+
+## Required Gate Set
+
+- `unit`
+- `integration`
+- `e2e`
+- `ruff`
+- `ty`
+- `gitleaks`
+- `semgrep`
+- `pip-audit`
+
+## Entry Template
+
+```text
+Date:
+Scope:
+Environment:
+Commands:
+Results:
+Evidence links:
+Notes:
+```
+
+## Latest Entries
+
+### 2026-02-09 - Docs Reorganization (Phase O/P)
+
+- Scope: backlog/delivery documentation hardening and structure reorganization.
+- Environment: local repository documentation-only update.
+- Commands: documentation consistency review and traceability linkage checks.
+- Results: pass (no code/runtime behavior changes in this block).
+- Evidence links:
+  - `.ai-engineering/context/backlog/traceability-matrix.md`
+  - `.ai-engineering/context/backlog/tasks.md`
+  - `.ai-engineering/context/delivery/planning.md`
+- Notes: full runtime quality/security gates continue to be required for code-changing phases.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/implementation.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/implementation.md
@@ -1,5 +1,13 @@
 # Implementation Log
 
+## Document Metadata
+
+- Doc ID: DEL-IMPLEMENTATION
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/implementation.md`
+
 ## Update Metadata
 
 - Rationale: keep execution logging concise and usable during build phase.
@@ -175,3 +183,130 @@ Status:
 - Blockers: none.
 - Decisions: keep `state/*` runtime-generated and excluded from template mirror while enforcing identical non-state governance content.
 - Next step: run full quality suite and address any regressions from template/mapping changes.
+
+### 2026-02-09 - Phase K / Command Contract Closure (Auto-Complete + Stack/IDE Management)
+
+- Work completed: aligned contract and manifest command semantics so `/pr` and `/acho pr` explicitly require PR auto-complete behavior.
+- Work completed: implemented full minimal-runtime stack/IDE management commands (`ai stack add/remove/list`, `ai ide add/remove/list`) with ownership-safe file operations.
+- Work completed: extended install manifest schema/defaults to track installed stacks and IDE profiles.
+- Changed modules: `src/ai_engineering/installer/operations.py`, `src/ai_engineering/cli.py`, `src/ai_engineering/state/models.py`, `src/ai_engineering/state/defaults.py`, contract/manifest canonical and mirrored templates, integration/unit tests.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: remove operations stay safe by default; customized team files are preserved and reported as `skipped-customized`.
+- Next step: implement Windows-safe hook launcher improvements to complete remaining cross-OS hardening item.
+
+### 2026-02-09 - Phase L / Core Runtime Simplification (Non-Contractual Cleanup Removal)
+
+- Rationale: reduce accidental complexity and keep runtime scope strictly aligned with the command contract and governance-first MVP.
+- Expected gain: smaller Python surface area, lower cognitive load in CLI maintenance, and less operational risk from non-essential destructive flows.
+- Potential impact: `ai git cleanup` command is no longer available from core CLI; users must use native git commands for branch cleanup.
+- Work completed: removed core `ai git cleanup` command wiring from CLI and deleted git cleanup runtime module/tests.
+- Work completed: removed unused scaffolding (`standards` package placeholder, unused pytest fixture) and dropped unused cleanup skill template.
+- Work completed: simplified installer baseline layout by removing unused `skills/git` directory bootstrap.
+- Changed modules: `src/ai_engineering/cli.py`, `src/ai_engineering/installer/service.py`, removed `src/ai_engineering/git/**`, removed `src/ai_engineering/standards/__init__.py`, removed `tests/unit/test_git_cleanup.py`, updated `tests/conftest.py`, removed template `skills/git/cleanup.md`.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: keep governance/security non-negotiables unchanged; simplify only non-contractual runtime surface.
+- Next step: execute full quality suite and proceed to CLI modularization phase.
+
+### 2026-02-09 - Phase M / CLI Modularization + Audit Log Hardening
+
+- Rationale: continue runtime simplification by reducing CLI cognitive load and harden audit evidence quality for governance traces.
+- Expected gain: smaller, domain-focused CLI modules and consistent audit timestamps across all governance events.
+- Potential impact: internal CLI module layout changes without command contract changes; install now creates state-level `.gitignore` to keep `audit-log.ndjson` local by default.
+- Work completed: split monolithic CLI into domain registration modules under `src/ai_engineering/cli_commands/*` with a thin `ai_engineering.cli` entrypoint.
+- Work completed: added timestamp auto-injection in ndjson append helper so every audit event has `timestamp`, `event`, `actor`, `details`.
+- Work completed: installer now creates `.ai-engineering/state/.gitignore` that excludes `audit-log.ndjson` from normal git tracking while allowing required state JSON files.
+- Work completed: removed root `.gitignore` exception for `.ai-engineering/state/audit-log.ndjson`, untracked the repository audit log from git index, and added tests for state ignore behavior and ndjson timestamp logic.
+- Changed modules: `src/ai_engineering/cli.py`, `src/ai_engineering/cli_factory.py`, `src/ai_engineering/cli_commands/*`, `src/ai_engineering/state/io.py`, `src/ai_engineering/installer/service.py`, `.gitignore`, integration/unit tests.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: keep audit schema minimal and stable (`timestamp`, `event`, `actor`, `details`) and prefer local-only audit log by default to avoid noisy remote churn.
+- Next step: run full local quality suite and then evaluate follow-up modularization of workflow internals.
+
+### 2026-02-09 - Phase N / Workflow Runtime Simplification
+
+- Rationale: reduce branching complexity in command workflows without changing contract behavior.
+- Expected gain: lower maintenance cost in PR-only handling and cleaner extension path for future workflow hardening.
+- Potential impact: no command/flag behavior changes; internal control flow becomes less repetitive.
+- Work completed: refactored PR-only mode constants and decision policy ID into shared constants.
+- Work completed: reduced repeated upstream checks in PR-only flow to a single state transition path.
+- Work completed: extracted decision persistence helper for `defer-pr` mode and normalized root reuse in standard PR flow.
+- Changed modules: `src/ai_engineering/commands/workflows.py`.
+- Validation run: `.venv/bin/ruff check src tests`, `.venv/bin/python -m pytest`, `.venv/bin/ty check src`, `.venv/bin/pip-audit` all passed.
+- Blockers: none.
+- Decisions: keep behavior fully backward compatible and avoid policy changes during structural simplification.
+- Next step: add focused tests for CLI command module coverage to improve post-modularization coverage signal.
+
+### 2026-02-09 - Phase O / Backlog-Delivery Traceability Hardening (Docs)
+
+- Rationale: execute quick-win documentation hardening to reduce stale phase drift and make traceability explicit for spec-driven delivery.
+- Expected gain: cleaner source-of-truth navigation and tighter linkage from backlog intent to delivery evidence.
+- Potential impact: historical phase-J snapshots are no longer treated as active planning artifacts.
+- Work completed: archived Phase J snapshot content in `.ai-engineering/context/backlog/archive/phase-j.md` and marked phase-J standalone files as deprecated references.
+- Work completed: aligned `delivery/planning.md` phase execution table with current progression through Phase N and listed carry-over open items.
+- Work completed: added `.ai-engineering/context/backlog/traceability-matrix.md` with initial epic-to-evidence mapping and drift checks.
+- Changed modules: `.ai-engineering/context/backlog/archive/phase-j.md`, `.ai-engineering/context/backlog/phase-j-tasks.md`, `.ai-engineering/context/backlog/traceability-matrix.md`, `.ai-engineering/context/backlog/tasks.md`, `.ai-engineering/context/delivery/phase-j-auto-complete-git-cleanup.md`, `.ai-engineering/context/delivery/planning.md`, `.ai-engineering/context/delivery/implementation.md`.
+- Validation run: documentation consistency pass across backlog/delivery files and contract alignment review against lifecycle and ownership model.
+- Blockers: none.
+- Decisions: keep historical snapshots available but explicitly deprecated; active planning and execution must reference canonical backlog/delivery files.
+- Next step: continue with structural phase (indexes, status board, active-vs-historical separation in tasks/implementation surfaces).
+
+### 2026-02-09 - Phase P / Structure Reorganization (Backlog vs Delivery)
+
+- Rationale: complete phase-2 documentation structure work so backlog remains planning-focused and delivery owns execution evidence.
+- Expected gain: lower context noise, better AI navigation, and clearer operational ownership boundaries between intent and execution artifacts.
+- Potential impact: previous mixed-use `backlog/tasks.md` format is replaced by active queue + references; historical phase details move to delivery evidence.
+- Work completed: rewrote `backlog/tasks.md` to keep active catalog and current queue only, with history references to delivery evidence.
+- Work completed: added backlog entrypoint and status board (`backlog/index.md`, `backlog/status.md`).
+- Work completed: added delivery entrypoint and evidence files (`delivery/index.md`, `delivery/evidence/validation-runs.md`, `delivery/evidence/execution-history.md`).
+- Work completed: aligned planning phase table to include Phase O and Phase P completion.
+- Changed modules: `.ai-engineering/context/backlog/tasks.md`, `.ai-engineering/context/backlog/index.md`, `.ai-engineering/context/backlog/status.md`, `.ai-engineering/context/delivery/index.md`, `.ai-engineering/context/delivery/evidence/validation-runs.md`, `.ai-engineering/context/delivery/evidence/execution-history.md`, `.ai-engineering/context/delivery/planning.md`, `.ai-engineering/context/delivery/implementation.md`.
+- Validation run: documentation structure and cross-reference consistency review across backlog/delivery/evidence paths.
+- Blockers: none.
+- Decisions: keep `implementation.md` as detailed narrative source; keep `execution-history.md` as compact archive to prevent backlog drift.
+- Next step: hardening phase for template/metadata normalization and pre-merge doc checklist enforcement.
+
+### 2026-02-09 - Phase Q / Documentation Hardening (Metadata + Checklist)
+
+- Rationale: enforce a consistent document contract so humans and AI agents can parse and operate backlog/delivery artifacts with lower ambiguity.
+- Expected gain: faster navigation, clearer ownership, and repeatable pre-merge quality checks for documentation changes.
+- Potential impact: all active backlog and delivery documents now include a standardized metadata block.
+- Work completed: added `Document Metadata` blocks (doc ID, owner, status, last reviewed, source of truth) across active backlog and delivery files.
+- Work completed: added pre-merge backlog/delivery documentation checklist in `delivery/review.md`.
+- Work completed: updated planning phase table to include Phase Q completion.
+- Changed modules: `.ai-engineering/context/backlog/{epics.md,features.md,user-stories.md,tasks.md,index.md,status.md,traceability-matrix.md}`, `.ai-engineering/context/delivery/{discovery.md,architecture.md,planning.md,implementation.md,review.md,verification.md,testing.md,iteration.md,index.md,evidence/validation-runs.md,evidence/execution-history.md}`.
+- Validation run: cross-file consistency review for metadata presence, checklist coverage, and canonical reference integrity.
+- Blockers: none.
+- Decisions: keep metadata minimal and stable to reduce maintenance overhead while preserving auditability.
+- Next step: optionally enforce metadata/checklist presence with an automated docs lint check in CI/pre-commit.
+
+### 2026-02-09 - Phase R / Automated Docs Contract Enforcement
+
+- Rationale: convert documentation quality expectations into an enforceable local gate to prevent regression at commit time.
+- Expected gain: lower documentation drift and deterministic validation of metadata/checklist requirements.
+- Potential impact: pre-commit now fails when active backlog/delivery docs violate the documentation contract.
+- Work completed: added a docs-contract validator in gate policy and wired it into pre-commit mandatory checks.
+- Work completed: added direct CLI execution path via `ai gate docs`.
+- Work completed: added unit coverage for docs-contract pass/fail behavior and pre-commit failure surfacing.
+- Changed modules: `src/ai_engineering/policy/gates.py`, `src/ai_engineering/cli_commands/gate.py`, `tests/unit/test_gate_policy.py`, `.ai-engineering/context/backlog/tasks.md`, `.ai-engineering/context/delivery/planning.md`, `.ai-engineering/context/delivery/implementation.md`.
+- Validation run: `.venv/bin/ruff check src tests` and `.venv/bin/python -m pytest tests/unit/test_gate_policy.py`.
+- Blockers: none.
+- Decisions: enforce docs contract on active backlog/delivery files only; deprecated historical snapshots remain out of the mandatory set.
+- Next step: optionally add a dedicated docs-check step to CI reporting for clearer visibility separate from pre-commit output.
+
+### 2026-02-09 - Phase S / Native Hook Hardening + Tool Auto-Remediation
+
+- Rationale: enforce non-bypassable local gates without lefthook dependency and guarantee that missing mandatory tools trigger remediation-before-retry behavior.
+- Expected gain: deterministic `.git/hooks` behavior, stronger cross-OS hook reliability, and lower false success rates when local tooling is missing.
+- Potential impact: commit/push operations now attempt auto-install for missing mandatory tools and fail closed if remediation cannot complete.
+- Work completed: hardened managed hook scripts to use fail-closed execution with cross-OS python launcher fallback (`.venv/bin/python`, `.venv/Scripts/python.exe`, `python3`, `python`, then `ai`).
+- Work completed: expanded hook readiness to detect external wrapper conflicts (including lefthook wrappers) and expose managed/integrity/conflict status details.
+- Work completed: added optional `ai doctor --fix-hooks` repair flow to reinstall framework-managed hooks before readiness checks.
+- Work completed: implemented gate-level missing-tool auto-remediation with re-run behavior for Python baseline tools and `gitleaks` package-manager install attempts.
+- Work completed: clarified contract and standards text so agents must remediate missing tools locally before continuing.
+- Changed modules: `src/ai_engineering/hooks/manager.py`, `src/ai_engineering/policy/gates.py`, `src/ai_engineering/doctor/service.py`, `src/ai_engineering/cli_commands/core.py`, `tests/integration/test_cli_install_doctor.py`, `tests/unit/test_gate_policy.py`, `tests/unit/test_hooks_manager.py`, `.ai-engineering/context/product/framework-contract.md`, `.ai-engineering/standards/framework/core.md`, `.ai-engineering/context/delivery/review.md`, template mirrors under `src/ai_engineering/templates/.ai-engineering/**`, and delivery/backlog phase logs.
+- Validation run: `.venv/bin/ruff check src tests` and `.venv/bin/python -m pytest`.
+- Blockers: none.
+- Decisions: keep operation blocked when remediation cannot complete (permissions/network/auth constraints) and return explicit manual remediation steps.
+- Next step: add CI visibility split for pre-commit vs pre-push gate subsets to make remediation failures easier to triage.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/index.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/index.md
@@ -1,0 +1,34 @@
+# Delivery Index
+
+## Document Metadata
+
+- Doc ID: DEL-INDEX
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/index.md`
+
+## Purpose
+
+Single entrypoint for lifecycle execution artifacts and evidence.
+
+## Lifecycle Files
+
+- discovery: `.ai-engineering/context/delivery/discovery.md`
+- architecture: `.ai-engineering/context/delivery/architecture.md`
+- planning: `.ai-engineering/context/delivery/planning.md`
+- implementation: `.ai-engineering/context/delivery/implementation.md`
+- review: `.ai-engineering/context/delivery/review.md`
+- verification: `.ai-engineering/context/delivery/verification.md`
+- testing: `.ai-engineering/context/delivery/testing.md`
+- iteration: `.ai-engineering/context/delivery/iteration.md`
+
+## Evidence Files
+
+- validation runs: `.ai-engineering/context/delivery/evidence/validation-runs.md`
+- execution history archive: `.ai-engineering/context/delivery/evidence/execution-history.md`
+
+## Rules
+
+- Delivery documents how and what happened.
+- Backlog remains the source of planned intent.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/iteration.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/iteration.md
@@ -1,5 +1,13 @@
 # Iteration and Maintenance
 
+## Document Metadata
+
+- Doc ID: DEL-ITERATION
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/iteration.md`
+
 ## Update Metadata
 
 - Rationale: codify maintenance-agent and decision-reuse behavior.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/phase-j-auto-complete-git-cleanup.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/phase-j-auto-complete-git-cleanup.md
@@ -1,0 +1,17 @@
+# Phase J - PR Auto-Complete and Git Cleanup (Deprecated)
+
+## Status
+
+- State: deprecated historical snapshot.
+- Reason: later phases superseded this behavior.
+
+## Supersession
+
+- Phase K made PR auto-complete explicit in contract behavior.
+- Phase L removed non-contractual `ai git cleanup` runtime surface.
+
+## Canonical Reference
+
+- Historical archive: `.ai-engineering/context/backlog/archive/phase-j.md`
+- Active delivery log: `.ai-engineering/context/delivery/implementation.md`
+- Active planning source: `.ai-engineering/context/delivery/planning.md`

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/planning.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/planning.md
@@ -1,5 +1,13 @@
 # Planning
 
+## Document Metadata
+
+- Doc ID: DEL-PLANNING
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/planning.md`
+
 ## Update Metadata
 
 - Rationale: convert architecture decisions into executable workstreams.
@@ -56,6 +64,32 @@ If branch is not pushed:
 | Phase C | Governance enforcement: hooks, mandatory checks, protected-branch blocking | Completed |
 | Phase D | Command runtime: `/commit`, `/pr`, `/acho`, `/pr --only` continuation modes | Completed |
 | Phase E | Remote skills lock/cache and maintenance-agent workflow | Completed |
+| Phase F | Product contract consolidation and rollout charter alignment | Completed |
+| Phase G | Legacy content adoption pack with content-first constraints | Completed |
+| Phase H | Ownership-safe updater (dry-run/apply, ownership rule evaluation) | Completed (advanced merge hooks pending) |
+| Phase I | Canonical/template governance alignment and cleanup | Completed |
+| Phase J | PR auto-complete and git cleanup slice | Archived/Superseded |
+| Phase K | Command contract closure and stack/IDE management commands | Completed (cross-OS hook launcher hardening pending) |
+| Phase L | Runtime simplification and removal of non-contractual cleanup command | Completed |
+| Phase M | CLI modularization and audit-log timestamp hardening | Completed |
+| Phase N | Workflow runtime simplification and internal path cleanup | Completed |
+| Phase O | Backlog-delivery traceability hardening quick wins | Completed |
+| Phase P | Structure reorganization (indexes, status board, active-vs-history split) | Completed |
+| Phase Q | Documentation hardening (metadata normalization and pre-merge checklist) | Completed |
+| Phase R | Automated docs contract enforcement (gate + CLI + tests) | Completed |
+| Phase S | Native hook hardening and missing-tool auto-remediation | Completed |
+
+## Phase Status Alignment Notes
+
+- Phase J records are historical only and are no longer normative for active planning.
+- Active backlog and execution sources are:
+  - `.ai-engineering/context/backlog/tasks.md`
+  - `.ai-engineering/context/delivery/implementation.md`
+- Open carry-over items from prior phases remain tracked in active backlog queue:
+  - B-007 richer doctor/install ownership-safe extensions.
+  - F-007 charter workstreams W1-W5 full implementation.
+  - H-005 advanced merge strategy and migration hooks.
+  - K-006 Windows-safe hook launcher hardening.
 
 ## Phase B Progress Notes
 

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/review.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/review.md
@@ -1,5 +1,13 @@
 # Review and Quality Gates
 
+## Document Metadata
+
+- Doc ID: DEL-REVIEW
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/review.md`
+
 ## Update Metadata
 
 - Rationale: enforce non-negotiables at review and merge boundaries.
@@ -20,12 +28,6 @@
 - dependency vulnerability checks (`pip-audit` in Python baseline).
 - stack checks (`uv`, `ruff`, `ty`, tests).
 
-## Tool Remediation Rule
-
-- missing mandatory tools must be remediated locally before continuing.
-- remediation order: detect -> install -> configure/authenticate -> re-run failed checks.
-- if remediation cannot complete, keep operation blocked and provide explicit manual steps.
-
 ## Blocking Policies
 
 - no direct commits to `main` or `master`.
@@ -45,3 +47,14 @@ When policy weakening is requested:
 
 - MVP PRs must validate behavior on Windows, macOS, Linux.
 - manifest/provider changes must preserve provider-agnostic schema and ADO extension points.
+
+## Backlog and Delivery Docs Pre-Merge Checklist
+
+- lifecycle alignment present: Discovery -> Architecture -> Planning -> Implementation -> Review -> Verification -> Testing -> Iteration.
+- ownership model respected: no contradiction with framework/team/project/system boundaries.
+- traceability complete: epic -> feature -> story -> task -> implementation/verif/testing evidence links.
+- active-vs-history separation respected: no phase execution logs added to active backlog catalogs.
+- stale snapshot handling respected: historical snapshots are archived or explicitly marked deprecated.
+- required quality/security gate statement present for code-affecting work: `unit`, `integration`, `e2e`, `ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`.
+- missing mandatory tooling was auto-remediated and checks re-run, or operation stayed blocked with explicit manual remediation steps.
+- references updated: `backlog/index.md`, `delivery/index.md`, and `backlog/status.md` reflect current state.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/testing.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/testing.md
@@ -1,5 +1,13 @@
 # Testing Strategy
 
+## Document Metadata
+
+- Doc ID: DEL-TESTING
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/testing.md`
+
 ## Update Metadata
 
 - Rationale: make tests reflect mandatory enforcement and new command flows.

--- a/src/ai_engineering/templates/.ai-engineering/context/delivery/verification.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/delivery/verification.md
@@ -1,5 +1,13 @@
 # Verification
 
+## Document Metadata
+
+- Doc ID: DEL-VERIFICATION
+- Owner: project-managed (delivery)
+- Status: active
+- Last reviewed: 2026-02-09
+- Source of truth: `.ai-engineering/context/delivery/verification.md`
+
 ## Update Metadata
 
 - Rationale: align verification scope with finalized command and policy model.

--- a/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
+++ b/src/ai_engineering/templates/.ai-engineering/context/product/framework-contract.md
@@ -29,14 +29,17 @@ Python is intentionally minimal and operational.
 
 ### Minimal Python Runtime Scope
 
-Python is used only for:
+Python runtime is intentionally limited to operational workflows:
 
 1. `install` - copy templates, set up hooks, run readiness checks.
 2. `update` - ownership-safe updates and migrations.
 3. `doctor` - verify installed/configured/authenticated/ready state.
 4. `add/remove stack|ide` - safe template operations and cleanup.
+5. governed command workflows (`/commit`, `/pr`, `/acho`) and local gate execution.
+6. risk acceptance persistence/reuse checks with append-only audit events.
+7. remote skills sync/lock/cache enforcement and maintenance report generation.
 
-No heavy policy engine should be embedded in Python if behavior can be declared in governance content.
+Policy and standards remain content-first; Python orchestration must stay thin, deterministic, and test-covered.
 
 ## Product Principles (Non-Negotiable)
 

--- a/src/ai_engineering/templates/.ai-engineering/manifest.yml
+++ b/src/ai_engineering/templates/.ai-engineering/manifest.yml
@@ -104,6 +104,7 @@ enforcement:
       - "ruff-format"
       - "ruff-lint"
       - "gitleaks"
+      - "docs-contract"
     pre_push:
       - "semgrep"
       - "pip-audit"

--- a/tests/unit/test_decision_logic.py
+++ b/tests/unit/test_decision_logic.py
@@ -1,0 +1,108 @@
+"""Unit tests for decision reuse logic."""
+
+from __future__ import annotations
+
+from ai_engineering.state.decision_logic import evaluate_reuse
+from ai_engineering.state.models import (
+    DecisionRecord,
+    DecisionScope,
+    DecisionStore,
+    UpdateMetadata,
+)
+
+
+def _store_with(record: DecisionRecord) -> DecisionStore:
+    return DecisionStore(
+        updateMetadata=UpdateMetadata(
+            rationale="test",
+            expectedGain="test",
+            potentialImpact="test",
+        ),
+        decisions=[record],
+    )
+
+
+def test_evaluate_reuse_reports_material_context_change() -> None:
+    record = DecisionRecord(
+        id="1",
+        scope=DecisionScope(repo="ai-engineering", policyId="P1"),
+        contextHash="sha256:old",
+        severity="medium",
+        decision="defer-pr",
+        rationale="test",
+        createdAt="2026-02-09T00:00:00Z",
+    )
+    result = evaluate_reuse(
+        _store_with(record),
+        policy_id="P1",
+        repo_name="ai-engineering",
+        context_hash_value="sha256:new",
+        severity="medium",
+    )
+    assert not result.reusable
+    assert result.reason == "material_context_hash_changed"
+
+
+def test_evaluate_reuse_reports_severity_change() -> None:
+    record = DecisionRecord(
+        id="1",
+        scope=DecisionScope(repo="ai-engineering", policyId="P1"),
+        contextHash="sha256:same",
+        severity="low",
+        decision="accept",
+        rationale="test",
+        createdAt="2026-02-09T00:00:00Z",
+    )
+    result = evaluate_reuse(
+        _store_with(record),
+        policy_id="P1",
+        repo_name="ai-engineering",
+        context_hash_value="sha256:same",
+        severity="high",
+    )
+    assert not result.reusable
+    assert result.reason == "severity_changed"
+
+
+def test_evaluate_reuse_reports_scope_change() -> None:
+    record = DecisionRecord(
+        id="1",
+        scope=DecisionScope(repo="ai-engineering", policyId="P1", pathPattern="src/**"),
+        contextHash="sha256:same",
+        severity="medium",
+        decision="accept",
+        rationale="test",
+        createdAt="2026-02-09T00:00:00Z",
+    )
+    result = evaluate_reuse(
+        _store_with(record),
+        policy_id="P1",
+        repo_name="ai-engineering",
+        context_hash_value="sha256:same",
+        severity="medium",
+        path_pattern="tests/**",
+    )
+    assert not result.reusable
+    assert result.reason == "scope_changed"
+
+
+def test_evaluate_reuse_reuses_when_inputs_match() -> None:
+    record = DecisionRecord(
+        id="1",
+        scope=DecisionScope(repo="ai-engineering", policyId="P1"),
+        contextHash="sha256:same",
+        severity="medium",
+        decision="defer-pr",
+        rationale="test",
+        createdAt="2026-02-09T00:00:00Z",
+    )
+    result = evaluate_reuse(
+        _store_with(record),
+        policy_id="P1",
+        repo_name="ai-engineering",
+        context_hash_value="sha256:same",
+        severity="medium",
+        expected_decision="defer-pr",
+    )
+    assert result.reusable
+    assert result.reason == "reused"

--- a/tests/unit/test_gate_policy.py
+++ b/tests/unit/test_gate_policy.py
@@ -81,47 +81,36 @@ def test_gate_requirements_includes_stages(monkeypatch) -> None:  # type: ignore
 def test_docs_contract_check_requires_metadata(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     doc = tmp_path / "backlog.md"
     doc.write_text("# Backlog\n", encoding="utf-8")
-    review = tmp_path / "review.md"
-    review.write_text(
-        "# Review\n\n## Backlog and Delivery Docs Pre-Merge Checklist\n"
-        "- required gates: `unit` `integration` `e2e` `ruff` `ty` `gitleaks` `semgrep` `pip-audit`\n",
-        encoding="utf-8",
-    )
 
-    monkeypatch.setattr(gates, "DOC_CONTRACT_FILES", ("backlog.md", "review.md"))
-    monkeypatch.setattr(gates, "DOC_CONTRACT_REVIEW_FILE", "review.md")
+    monkeypatch.setattr(gates, "DOC_CONTRACT_FILES", ("backlog.md",))
 
     ok, output = gates._run_docs_contract_check(tmp_path)
 
     assert not ok
-    assert "missing '## Document Metadata'" in output
+    assert "missing '## Update Metadata'" in output
 
 
 def test_docs_contract_check_passes_with_required_fields(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    metadata_block = (
+    document_metadata = (
         "## Document Metadata\n\n"
         "- Doc ID: TEST\n"
         "- Owner: team\n"
         "- Status: active\n"
         "- Last reviewed: 2026-02-09\n"
     )
+    update_metadata = (
+        "## Update Metadata\n\n"
+        "- Rationale: keep docs aligned\n"
+        "- Expected gain: deterministic checks\n"
+        "- Potential impact: none\n"
+    )
     doc = tmp_path / "backlog.md"
     doc.write_text(
-        f"# Backlog\n\n{metadata_block}- Source of truth: `backlog.md`\n",
-        encoding="utf-8",
-    )
-    review = tmp_path / "review.md"
-    review.write_text(
-        "# Review\n\n"
-        f"{metadata_block}"
-        "- Source of truth: `review.md`\n\n"
-        "## Backlog and Delivery Docs Pre-Merge Checklist\n"
-        "- required gates: `unit` `integration` `e2e` `ruff` `ty` `gitleaks` `semgrep` `pip-audit`\n",
+        f"# Backlog\n\n{document_metadata}- Source of truth: `backlog.md`\n\n{update_metadata}",
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(gates, "DOC_CONTRACT_FILES", ("backlog.md", "review.md"))
-    monkeypatch.setattr(gates, "DOC_CONTRACT_REVIEW_FILE", "review.md")
+    monkeypatch.setattr(gates, "DOC_CONTRACT_FILES", ("backlog.md",))
 
     ok, output = gates._run_docs_contract_check(tmp_path)
 


### PR DESCRIPTION
## Summary
- align docs-contract enforcement with the active backlog/delivery baseline and declare it in manifest pre-commit checks
- add explicit risk decision commands (`ai gate risk-accept`, `ai gate risk-check`) with decision-store persistence, reuse reason evaluation, and audit-log events
- sync canonical/template governance content to full non-state parity and add a cross-OS GitHub Actions validation workflow

## Validation
- `.venv/bin/pytest tests/unit/test_gate_policy.py tests/unit/test_decision_logic.py`
- `.venv/bin/pytest tests/integration/test_cli_install_doctor.py::test_gate_risk_accept_persists_decision_and_audit tests/integration/test_cli_install_doctor.py::test_gate_risk_check_reports_scope_change_reason`
- `.venv/bin/ruff check src tests`
- canonical/template parity check: ONLY_CANON=0, ONLY_TEMPLATE=0, DIFF_CONTENT=0