### PR TITLE
spec-002: Cross-reference hardening + lifecycle skill category

### DIFF
--- a/.ai-engineering/agents/code-simplifier.md
+++ b/.ai-engineering/agents/code-simplifier.md
@@ -42,6 +42,7 @@ Complexity reducer who systematically identifies and eliminates unnecessary comp
 ## Referenced Standards
 
 - `standards/framework/quality/python.md` — complexity thresholds (cyclomatic ≤ 10, cognitive ≤ 15, functions < 50 lines).
+- `standards/framework/quality/core.md` — quality gate severity policy.
 - `standards/framework/stacks/python.md` — code patterns and conventions.
 
 ## Output Contract

--- a/.ai-engineering/agents/codebase-mapper.md
+++ b/.ai-engineering/agents/codebase-mapper.md
@@ -35,6 +35,7 @@ Codebase analyst who builds comprehensive maps of project structure, module rela
 ## Referenced Skills
 
 - `skills/swe/architecture-analysis.md` — structural analysis methodology.
+- `skills/swe/doc-writer.md` — documentation generation from codebase knowledge.
 - `skills/swe/python-mastery.md` — Python module system domain.
 
 ## Referenced Standards

--- a/.ai-engineering/agents/principal-engineer.md
+++ b/.ai-engineering/agents/principal-engineer.md
@@ -37,6 +37,7 @@ Senior technical reviewer who evaluates code as a principal engineer would: focu
 - `skills/swe/test-strategy.md` — test assessment criteria.
 - `skills/swe/performance-analysis.md` — performance evaluation.
 - `skills/swe/python-mastery.md` — Python patterns and anti-patterns.
+- `skills/swe/security-review.md` — security assessment procedure.
 
 ## Referenced Standards
 

--- a/.ai-engineering/agents/quality-auditor.md
+++ b/.ai-engineering/agents/quality-auditor.md
@@ -39,6 +39,7 @@ Quality gate enforcer who executes the quality contract defined in standards, ru
 - `standards/framework/quality/core.md` — quality contract, thresholds, gate structure.
 - `standards/framework/quality/python.md` — Python-specific checks.
 - `standards/framework/quality/sonarlint.md` — severity mapping.
+- `standards/framework/stacks/python.md` — required tooling (ruff, ty, uv).
 
 ## Output Contract
 

--- a/.ai-engineering/agents/verify-app.md
+++ b/.ai-engineering/agents/verify-app.md
@@ -36,6 +36,7 @@ End-to-end verification agent who confirms the application works correctly from 
 ## Referenced Skills
 
 - `skills/swe/debug.md` — for investigating failures found during verification.
+- `skills/swe/migration.md` — migration testing procedure.
 - `skills/swe/test-strategy.md` — test design principles.
 - `skills/workflows/commit.md` — commit workflow specification.
 - `skills/workflows/pr.md` — PR workflow specification.

--- a/.ai-engineering/context/product/product-contract.md
+++ b/.ai-engineering/context/product/product-contract.md
@@ -23,7 +23,7 @@ This project dogfoods the ai-engineering framework on itself.
 
 ### Active Objectives
 
-1. Complete governance content: 18 skills, 8 agents, 3 stack instructions.
+1. Complete governance content: 21 skills, 8 agents, 3 stack instructions.
 2. Rewrite all Python modules from scratch following new standards.
 3. Achieve CI/CD with cross-OS matrix (Python 3.11/3.12/3.13 × Ubuntu/Windows/macOS).
 4. Validate full E2E install/update/doctor cycle.
@@ -46,12 +46,12 @@ This project dogfoods the ai-engineering framework on itself.
 
 ## Active Spec
 
-Current work tracked in: `specs/_active.md` → `001-rewrite-v2`.
+Current work tracked in: `specs/_active.md` → `002-cross-ref-hardening`.
 
 Read sequence:
-1. `specs/001-rewrite-v2/spec.md` — problem, solution, scope
-2. `specs/001-rewrite-v2/plan.md` — architecture, patterns, session map
-3. `specs/001-rewrite-v2/tasks.md` — ordered phases, checkboxes
+1. `specs/002-cross-ref-hardening/spec.md` — problem, solution, scope
+2. `specs/002-cross-ref-hardening/plan.md` — architecture, patterns, session map
+3. `specs/002-cross-ref-hardening/tasks.md` — ordered phases, checkboxes
 
 ## KPIs
 
@@ -59,7 +59,7 @@ Read sequence:
 |--------|--------|---------|
 | Install adoption (repos using framework) | Tracking | Pre-release |
 | Quality gate pass rate | 100% on governed ops | Establishing baseline |
-| Agent coverage (skills + agents defined) | 18 skills + 8 agents | 0/18 skills, 0/8 agents |
+| Agent coverage (skills + agents defined) | 21 skills + 8 agents | 0/21 skills, 0/8 agents |
 | Test coverage | ≥80% | Rewrite pending |
 | Cross-OS CI pass | 3×3 matrix green | CI not yet created |
 

--- a/.ai-engineering/context/specs/002-cross-ref-hardening/done.md
+++ b/.ai-engineering/context/specs/002-cross-ref-hardening/done.md
@@ -1,0 +1,82 @@
+# Spec 002: Cross-Reference Hardening — Closure Summary
+
+## Status
+
+**COMPLETE** — All 22 tasks across 4 phases executed.
+
+## Timeline
+
+| Milestone | Date | Notes |
+|-----------|------|-------|
+| Spec created | 2026-02-10 | Formalizing in-progress git changes + lifecycle category |
+| Phase 0-2 complete | 2026-02-10 | 16 tasks: scaffold, 4 new skills, cross-references |
+| Phase 3-4 complete | 2026-02-10 | 6 tasks: lifecycle/ category, moves, verification |
+| Closure | 2026-02-10 | This document |
+
+## Scope Delivered
+
+### Phase 0 — Scaffold (2 tasks)
+
+- Created `specs/002-cross-ref-hardening/` with spec.md, plan.md, tasks.md.
+- Updated `_active.md` to point to `002-cross-ref-hardening`.
+
+### Phase 1 — New Skill Creation (4 tasks)
+
+- Created 4 new skills with canonical files and byte-identical template mirrors:
+  - `swe/changelog-documentation.md` — changelog and release notes generation.
+  - `swe/doc-writer.md` — open-source documentation from codebase knowledge.
+  - `lifecycle/create-skill.md` — definitive skill authoring and registration.
+  - `lifecycle/create-agent.md` — definitive agent authoring and registration.
+- All 4 registered in 6 instruction files with CHANGELOG entries.
+
+### Phase 2 — Cross-Reference Hardening (8 tasks)
+
+- Added bidirectional cross-references across 25+ governance files:
+  - 5 agents: code-simplifier, codebase-mapper, principal-engineer, quality-auditor, verify-app.
+  - 8 SWE skills: code-review, debug, dependency-update, performance-analysis, pr-creation, prompt-engineer, python-mastery, test-strategy.
+  - 2 utility skills: git-helpers, platform-detection.
+  - 1 validation skill: install-readiness.
+  - 2 workflow skills: commit, pr.
+- All changes applied to both canonical and template mirror copies.
+- Updated product-contract counters and CHANGELOG.
+
+### Phase 3 — Lifecycle Category (6 tasks)
+
+- Created `skills/lifecycle/` directory (canonical + mirror).
+- Moved `create-skill.md` and `create-agent.md` from `swe/` to `lifecycle/`.
+- Added `lifecycle/` to the `create-skill.md` valid category list and subsection mapping.
+- Created `### Lifecycle Skills` subsection in all 6 instruction files.
+- Updated all internal cross-references to use `lifecycle/` paths.
+
+### Phase 4 — Verification (4 tasks)
+
+- Verified 22 canonical/mirror pairs are byte-identical (17 cross-referenced + 5 new/moved).
+- Verified 0 stale `swe/create-skill` or `swe/create-agent` references remain.
+- Verified product-contract counter (21 skills) matches instruction file listing count.
+- Verified all lifecycle/ instruction file references exist in all 6 files.
+
+## Decisions Applied
+
+| # | Decision | Applied |
+|---|----------|---------|
+| D1 | `skills/lifecycle/` as category name | Phase 3 — directory created |
+| D2 | Move create-skill/create-agent to lifecycle/ | Phase 3 — files moved, refs updated |
+| D3 | Separate Spec 002 from Spec 003 | Spec scope — governance enforcement deferred to Spec 003 |
+| D4 | 21 skills total (instruction-file convention) | Phase 4 — counter verified |
+
+## Quality Gate
+
+| Check | Result |
+|-------|--------|
+| All canonical files exist | PASS |
+| All mirrors byte-identical | PASS (22/22) |
+| No stale swe/ references | PASS (0 in all 6 instruction files) |
+| Product-contract counter accurate | PASS (21 skills, 8 agents) |
+| CHANGELOG entries present | PASS (4 new skill entries) |
+| Lifecycle subsection in instruction files | PASS (all 6 files) |
+
+## Learnings
+
+- The original product-contract "18 skills" count from Spec 001 tracked instruction-file-listed skills only (excluding utils/ and validation/ utility files). New convention continues this: 14 SWE + 3 workflows + 2 lifecycle + 2 quality = 21.
+- Mirror contract enforcement is critical — one mirror (prompt-engineer template) was missing cross-references that existed in the canonical copy. The move to lifecycle/ caught and fixed this.
+- The `create-skill.md` procedure itself needed updating when a new category was added — the procedure is self-referential and must be maintained when the category taxonomy changes.

--- a/.ai-engineering/context/specs/002-cross-ref-hardening/plan.md
+++ b/.ai-engineering/context/specs/002-cross-ref-hardening/plan.md
@@ -1,0 +1,130 @@
+# Plan 002: Cross-Reference Hardening + Skill Registration
+
+## Environment
+
+- **Python**: 3.11.4
+- **Package manager**: `uv`
+- **Linter/formatter**: `ruff` (line-length 100)
+- **Type checker**: `ty`
+- **OS**: Windows primary
+- **VCS**: GitHub (`arcasilesgroup/ai-engineering`)
+- **Branch**: `main` (direct — content-only changes, no Python code)
+
+## Architecture Overview
+
+```
+Phase 0: Scaffold
+├── Create spec 002 directory and files
+└── Update _active.md
+
+Phase 1: New Skill Creation
+├── Create 4 canonical skill files (swe/)
+└── Create 4 template mirrors
+
+Phase 2: Cross-Reference Hardening
+├── Add cross-refs to 5 agents
+├── Add cross-refs to 8 SWE skills
+├── Add cross-refs to 2 utility skills
+├── Add cross-refs to 1 validation skill
+├── Add cross-refs to 2 workflow skills
+├── Update 6 instruction files
+├── Update product-contract counters
+└── Update CHANGELOG.md
+
+Phase 3: Lifecycle Category
+├── Create skills/lifecycle/ directory
+├── Move create-skill from swe/ to lifecycle/
+├── Move create-agent from swe/ to lifecycle/
+├── Update create-skill procedure (add lifecycle/ category)
+├── Update all 6 instruction files (new subsection)
+└── Update all internal cross-references
+
+Phase 4: Verify + Close
+├── Verify canonical/mirror parity
+├── Verify counter accuracy
+└── Create done.md
+```
+
+## File Structure
+
+### New files
+
+```
+.ai-engineering/
+├── context/specs/002-cross-ref-hardening/
+│   ├── spec.md                          # NEW (this spec)
+│   ├── plan.md                          # NEW (this plan)
+│   ├── tasks.md                         # NEW (task tracker)
+│   └── done.md                          # NEW (closure — Phase 4)
+├── skills/
+│   ├── lifecycle/                       # NEW (category)
+│   │   ├── create-skill.md              # MOVED from swe/
+│   │   └── create-agent.md              # MOVED from swe/
+│   └── swe/
+│       ├── changelog-documentation.md   # NEW
+│       └── doc-writer.md                # NEW
+
+src/ai_engineering/templates/.ai-engineering/
+├── skills/
+│   ├── lifecycle/                       # NEW (mirror category)
+│   │   ├── create-skill.md              # MOVED mirror
+│   │   └── create-agent.md              # MOVED mirror
+│   └── swe/
+│       ├── changelog-documentation.md   # NEW mirror
+│       └── doc-writer.md                # NEW mirror
+```
+
+### Modified files (cross-references added)
+
+```
+Agents (5 files):
+  code-simplifier.md    — +quality/core.md ref
+  codebase-mapper.md    — +doc-writer.md ref
+  principal-engineer.md — +security-review.md ref
+  quality-auditor.md    — +stacks/python.md ref
+  verify-app.md         — +migration.md ref
+
+SWE skills (8 files):
+  code-review.md        — +security-review, test-strategy, performance-analysis, code-simplifier refs
+  debug.md              — +verify-app ref
+  dependency-update.md  — +security-reviewer ref
+  performance-analysis.md — +principal-engineer ref
+  pr-creation.md        — +changelog-documentation, stacks/python refs
+  prompt-engineer.md    — +create-skill, create-agent refs
+  python-mastery.md     — +architect, code-simplifier, codebase-mapper, principal-engineer refs
+  test-strategy.md      — +debugger, principal-engineer, verify-app refs
+
+Utility skills (2 files):
+  git-helpers.md        — +commit, pr, core.md refs
+  platform-detection.md — +install-readiness, core.md refs
+
+Validation skills (1 file):
+  install-readiness.md  — +platform-detection, core.md, verify-app refs
+
+Workflow skills (2 files):
+  commit.md             — +verify-app ref
+  pr.md                 — +pr-creation, verify-app refs
+
+Instruction files (6 files):
+  .github/copilot-instructions.md
+  AGENTS.md
+  CLAUDE.md
+  src/ai_engineering/templates/project/copilot-instructions.md
+  src/ai_engineering/templates/project/AGENTS.md
+  src/ai_engineering/templates/project/CLAUDE.md
+
+Counters (1 file):
+  context/product/product-contract.md — 18→22 skills
+
+Changelog (1 file):
+  CHANGELOG.md — 4 new skill entries
+```
+
+All modified files above are updated in BOTH canonical and template mirror copies (where applicable).
+
+## Session Map
+
+| Session | Agent | Scope | Size |
+|---------|-------|-------|------|
+| S0 | Agent-1 | Phase 0 (scaffold) + Phase 1 (new skills) + Phase 2 (cross-refs) | L |
+| S1 | Agent-1 | Phase 3 (lifecycle category) + Phase 4 (verify + close) | M |

--- a/.ai-engineering/context/specs/002-cross-ref-hardening/spec.md
+++ b/.ai-engineering/context/specs/002-cross-ref-hardening/spec.md
@@ -1,0 +1,60 @@
+# Spec 002: Cross-Reference Hardening + Skill Registration
+
+## Problem
+
+After Spec 001 (Rewrite v2) delivered 18 skills and 8 agents, these governance gaps remained:
+
+1. **Missing cross-references** — skills did not reference related agents, and agents did not reference all consumed skills. This broke the bidirectional discoverability contract: an agent reading a skill couldn't find related agents, and vice versa.
+2. **No lifecycle skills** — the framework had no procedure for creating skills (`create-skill`), creating agents (`create-agent`), documenting changelogs (`changelog-documentation`), or generating user-facing documentation (`doc-writer`). These were tribal knowledge, not governed procedures.
+3. **No lifecycle skill category** — `create-skill` and `create-agent` are not SWE skills (they don't produce application code). They are framework lifecycle operations that belong in their own category.
+4. **Skill count drift** — product-contract.md reported "18 skills" but the actual target after adding 4 new skills is 22. Counters must match reality.
+
+## Solution
+
+Three-phase approach:
+
+- **Phase 1 (New Skills)**: Author 4 new skills (`changelog-documentation`, `create-skill`, `create-agent`, `doc-writer`) with canonical files, template mirrors, instruction file registration, and changelog entries.
+- **Phase 2 (Cross-Reference Hardening)**: Add bidirectional cross-references across all 25+ governance files — skills reference related agents, agents reference consumed skills, utility/validation skills reference their consumers.
+- **Phase 3 (Lifecycle Category)**: Create `skills/lifecycle/` as a new skill category. Move `create-skill` and `create-agent` from `swe/` to `lifecycle/`. Update all references to reflect the new paths.
+
+## Scope
+
+### In Scope
+
+- 4 new skills: `changelog-documentation.md`, `create-skill.md`, `create-agent.md`, `doc-writer.md`.
+- Cross-reference additions across agents (5 files), SWE skills (8 files), utility skills (2 files), validation skills (1 file), workflow skills (2 files).
+- All 6 instruction files updated with new skill references.
+- Product-contract counter updates (18 → 21 skills).
+- CHANGELOG.md entries for new skills.
+- New `skills/lifecycle/` category directory.
+- Move `create-skill` and `create-agent` from `swe/` to `lifecycle/` (canonical + mirror).
+- Update `create-skill.md` procedure to include `lifecycle/` as a valid category.
+- Instruction file restructuring: new `### Lifecycle Skills` subsection.
+
+### Out of Scope
+
+- Governance enforcement rules (Spec 003).
+- `delete-skill`, `delete-agent`, `create-spec`, `content-integrity` skills (Spec 003).
+- `verify-app` agent expansion (Spec 003).
+- Enforcement rules in `core.md` or `framework-contract.md` (Spec 003).
+- Any Python code changes (glob-based discovery handles new files automatically).
+
+## Acceptance Criteria
+
+- [ ] All 4 new skills exist as canonical files with byte-identical template mirrors.
+- [ ] `create-skill` and `create-agent` are in `skills/lifecycle/`, not `skills/swe/`.
+- [ ] `skills/lifecycle/` is referenced in the `create-skill` procedure as a valid category.
+- [ ] All 6 instruction files list all 22 skills with correct paths.
+- [ ] Product-contract shows "21 skills, 8 agents" in objectives and KPIs.
+- [ ] Bidirectional cross-references exist: every agent references its consumed skills, every skill references agents that use it.
+- [ ] CHANGELOG.md has entries for all 4 new skills.
+- [ ] Template mirrors for moved files reflect the new `lifecycle/` paths.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **`skills/lifecycle/`** as new category name | Descriptive of purpose (framework lifecycle operations). Alternatives `framework/` and `core/` were rejected — `framework/` conflicts with `standards/framework/`, and `core/` is too generic. |
+| D2 | **Move `create-skill`/`create-agent` to `lifecycle/`** | These skills govern framework administration, not application SWE. Keeping them in `swe/` misrepresents their purpose. |
+| D3 | **Separate Spec 002 from Spec 003** | Spec 002 formalizes content that is already written (git changes). Spec 003 introduces new governance capabilities. Separating avoids a mega-spec and allows incremental delivery. |
+| D4 | **21 skills total** | 14 SWE + 3 workflows + 2 lifecycle + 2 quality = 21. Utility and validation skills (git-helpers, platform-detection, install-readiness) are not counted in the instruction-file listing convention. |

--- a/.ai-engineering/context/specs/002-cross-ref-hardening/tasks.md
+++ b/.ai-engineering/context/specs/002-cross-ref-hardening/tasks.md
@@ -1,0 +1,47 @@
+---
+total: 22
+completed: 22
+last_session: S1
+next_session: done
+---
+
+# Tasks: Cross-Reference Hardening + Skill Registration
+
+## Phase 0: Scaffold — `S0 · Agent-1 · ✓ COMPLETE`
+
+- [x] **Task 0.1**: Create `.ai-engineering/context/specs/002-cross-ref-hardening/` with `spec.md`, `plan.md`, `tasks.md`
+- [x] **Task 0.2**: Update `_active.md` — pointer to `002-cross-ref-hardening`
+
+## Phase 1: New Skill Creation — `S0 · Agent-1 · ✓ COMPLETE`
+
+- [x] **Task 1.1**: Create `skills/swe/changelog-documentation.md` (canonical + mirror)
+- [x] **Task 1.2**: Create `skills/swe/create-skill.md` (canonical + mirror)
+- [x] **Task 1.3**: Create `skills/swe/create-agent.md` (canonical + mirror)
+- [x] **Task 1.4**: Create `skills/swe/doc-writer.md` (canonical + mirror)
+
+## Phase 2: Cross-Reference Hardening — `S0 · Agent-1 · ✓ COMPLETE`
+
+- [x] **Task 2.1**: Add cross-refs to agents — `code-simplifier` (+quality/core.md), `codebase-mapper` (+doc-writer), `principal-engineer` (+security-review), `quality-auditor` (+stacks/python.md), `verify-app` (+migration) — canonical + mirror
+- [x] **Task 2.2**: Add cross-refs to SWE skills — `code-review` (+security-review, test-strategy, performance-analysis, code-simplifier), `debug` (+verify-app), `dependency-update` (+security-reviewer), `performance-analysis` (+principal-engineer), `pr-creation` (+changelog-documentation, stacks/python), `prompt-engineer` (+create-skill, create-agent), `python-mastery` (+architect, code-simplifier, codebase-mapper, principal-engineer), `test-strategy` (+debugger, principal-engineer, verify-app) — canonical + mirror
+- [x] **Task 2.3**: Add cross-refs to utility skills — `git-helpers` (+commit, pr, core.md), `platform-detection` (+install-readiness, core.md) — canonical + mirror
+- [x] **Task 2.4**: Add cross-refs to validation skills — `install-readiness` (+platform-detection, core.md, verify-app) — canonical + mirror
+- [x] **Task 2.5**: Add cross-refs to workflow skills — `commit` (+verify-app), `pr` (+pr-creation, verify-app) — canonical + mirror
+- [x] **Task 2.6**: Update all 6 instruction files — add `changelog-documentation`, `create-skill`, `create-agent`, `doc-writer` references under `### SWE Skills`
+- [x] **Task 2.7**: Update `product-contract.md` — skill count 18 → 21 in objectives and KPIs
+- [x] **Task 2.8**: Update `CHANGELOG.md` — add entries for 4 new skills
+
+## Phase 3: Lifecycle Category — `S1 · Agent-1 · ✓ COMPLETE`
+
+- [x] **Task 3.1**: Create `skills/lifecycle/` directory (canonical + mirror)
+- [x] **Task 3.2**: Move `create-skill.md` from `swe/` to `lifecycle/` (canonical + mirror) — `git mv` or file move + delete
+- [x] **Task 3.3**: Move `create-agent.md` from `swe/` to `lifecycle/` (canonical + mirror) — `git mv` or file move + delete
+- [x] **Task 3.4**: Update `create-skill.md` procedure — add `lifecycle/` to the valid category list and update subsection mapping
+- [x] **Task 3.5**: Update all 6 instruction files — move `create-skill`/`create-agent` from `### SWE Skills` to new `### Lifecycle Skills` subsection, update paths from `swe/` to `lifecycle/`
+- [x] **Task 3.6**: Update cross-references in `prompt-engineer.md` and `create-agent.md` — change `swe/create-skill` → `lifecycle/create-skill` and `swe/create-agent` → `lifecycle/create-agent` (canonical + mirror)
+
+## Phase 4: Verify + Close — `S1 · Agent-1 · ✓ COMPLETE`
+
+- [x] **Task 4.1**: Verify all canonical files exist and follow template structure
+- [x] **Task 4.2**: Verify all template mirrors are byte-identical to canonical
+- [x] **Task 4.3**: Verify product-contract counter matches actual skill count (21)
+- [x] **Task 4.4**: Update tasks.md frontmatter and create `done.md`

--- a/.ai-engineering/context/specs/_active.md
+++ b/.ai-engineering/context/specs/_active.md
@@ -1,17 +1,17 @@
 ---
-active: "001-rewrite-v2"
+active: "002-cross-ref-hardening"
 updated: "2026-02-10"
 ---
 
 # Active Spec
 
-Current work: [001-rewrite-v2](001-rewrite-v2/spec.md)
+Current work: [002-cross-ref-hardening](002-cross-ref-hardening/spec.md)
 
 ## Quick Resume
 
-1. Read [spec.md](001-rewrite-v2/spec.md) — problem, solution, scope, decisions
-2. Read [plan.md](001-rewrite-v2/plan.md) — technical approach, architecture, patterns
-3. Read [tasks.md](001-rewrite-v2/tasks.md) — ordered phases, check checkboxes
+1. Read [spec.md](002-cross-ref-hardening/spec.md) — problem, solution, scope, decisions
+2. Read [plan.md](002-cross-ref-hardening/plan.md) — technical approach, architecture, patterns
+3. Read [tasks.md](002-cross-ref-hardening/tasks.md) — ordered phases, check checkboxes
 4. No done.md = still in progress
 5. Check `state/decision-store.json` — decisions already taken (do not re-ask)
 6. Check last N lines of `state/audit-log.ndjson` — recent events

--- a/.ai-engineering/skills/lifecycle/create-agent.md
+++ b/.ai-engineering/skills/lifecycle/create-agent.md
@@ -1,0 +1,155 @@
+# Create Agent
+
+## Purpose
+
+Definitive procedure for authoring and registering a new agent in the ai-engineering framework. Ensures every registration point is updated — canonical file, template mirror, all instruction files, counters, changelog, and cross-references — eliminating partial registration risk.
+
+## Trigger
+
+- Command: agent invokes create-agent skill or user requests adding a new agent.
+- Context: new agent persona is needed, complex multi-step task requires dedicated behavior protocol, governance content expansion.
+
+## Procedure
+
+### Phase 1: Design
+
+1. **Define agent identity** — determine name, identity, capabilities, and activation triggers.
+   - Name: kebab-case (`my-agent`).
+   - Identity: third-person description of WHO the agent is and their expertise (e.g., "Senior technical reviewer who...").
+   - Capabilities: concrete, actionable abilities as noun phrases.
+   - Activation: when/how users invoke or trigger this agent.
+
+2. **Check for duplicates** — verify no existing agent covers the same ground.
+   - Review agents listed in `.github/copilot-instructions.md` under `## Agents`.
+   - Search `.ai-engineering/agents/` for overlapping names or capabilities.
+   - If overlap exists, consider extending the existing agent instead.
+
+3. **Identify referenced skills and standards** — determine which skills and standards the agent will use.
+   - Map behavior steps to existing skills that provide procedures.
+   - Identify standards that govern the agent's domain.
+
+### Phase 2: Author
+
+4. **Create the canonical agent file** — write `.ai-engineering/agents/<name>.md`.
+   - Follow the agent template structure:
+
+     ```
+     # Agent Name
+     ## Identity
+     ## Capabilities
+     ## Activation
+     ## Behavior
+       1. **Step name** — description.
+       2. **Step name** — description.
+     ## Referenced Skills
+     ## Referenced Standards
+     ## Output Contract
+     ## Boundaries
+     ```
+
+   - Identity is written in **third person** (not "I am", but "Senior ... who ...").
+   - Capabilities are listed as **noun phrases** (not sentences).
+   - Behavior is a **numbered protocol** (typically 4-8 sequential steps).
+   - Referenced Skills and Referenced Standards are **separate sections**.
+   - Boundaries explicitly state what the agent does NOT do and escalation paths.
+   - References use relative paths from `.ai-engineering/` (e.g., `skills/swe/debug.md`).
+
+5. **Validate structure** — confirm the agent file contains all required sections.
+   - Identity: present, third-person, describes expertise and approach.
+   - Capabilities: bullet list of concrete abilities.
+   - Activation: when/how to trigger.
+   - Behavior: numbered protocol, sequential, 4-8 steps.
+   - Referenced Skills: at least one skill linked.
+   - Referenced Standards: at least one standard linked.
+   - Output Contract: measurable deliverables.
+   - Boundaries: scope limitations and escalation paths.
+
+### Phase 3: Mirror
+
+6. **Create the template mirror** — copy to `src/ai_engineering/templates/.ai-engineering/agents/<name>.md`.
+   - Content must be **byte-identical** to the canonical file.
+   - This is required by framework-contract: "Keep non-state files identical between canonical and template mirror."
+   - The installer uses `rglob("*")` to discover templates — no Python code changes needed.
+   - The `pyproject.toml` includes `src/ai_engineering/templates/**/*.md` — no build config changes needed.
+
+### Phase 4: Register
+
+7. **Add to all 6 instruction files** — insert a reference line under the `## Agents` section.
+   - Format: `- \`.ai-engineering/agents/<name>.md\` — one-line description.`
+   - Files to update (all 6, every time):
+
+     | # | File | Location |
+     |---|------|----------|
+     | 1 | `.github/copilot-instructions.md` | `## Agents` |
+     | 2 | `AGENTS.md` (repo root) | `## Agents` |
+     | 3 | `CLAUDE.md` (repo root) | `## Agents` |
+     | 4 | `src/ai_engineering/templates/project/copilot-instructions.md` | `## Agents` |
+     | 5 | `src/ai_engineering/templates/project/AGENTS.md` | `## Agents` |
+     | 6 | `src/ai_engineering/templates/project/CLAUDE.md` | `## Agents` |
+
+   - Insert alphabetically within the agents list for consistency.
+
+### Phase 5: Update Counters
+
+8. **Update agent count in product-contract** — edit `.ai-engineering/context/product/product-contract.md`.
+   - Update the `Active Objectives` line (e.g., "8 agents" → "9 agents").
+   - Update the `KPIs` table row for `Agent coverage` (e.g., "19 skills + 8 agents" → "19 skills + 9 agents").
+   - The count must match the actual number of agents listed in the instruction files.
+
+### Phase 6: Changelog
+
+9. **Add changelog entry** — edit `CHANGELOG.md`.
+   - Add under `## [Unreleased] → ### Added`.
+   - Format: `- <Agent name> agent for <purpose summary>.`
+
+### Phase 7: Cross-Reference
+
+10. **Update related skills** — add the new agent to `## References` of skills that the agent uses.
+    - If a skill's procedure is part of the agent's behavior, add a reference in the skill: `agents/<name>.md — agent that uses this skill.`
+
+11. **Update the agent's own references** — ensure `## Referenced Skills` and `## Referenced Standards` are complete.
+    - Every skill mentioned in the behavior protocol must appear in `## Referenced Skills`.
+    - Every standard governing the agent's domain must appear in `## Referenced Standards`.
+
+### Phase 8: Verify
+
+12. **Run the verification checklist** — confirm all registration points are complete.
+
+    | # | Check | How to verify |
+    |---|-------|---------------|
+    | 1 | Canonical file exists | `Test-Path .ai-engineering/agents/<name>.md` |
+    | 2 | Follows template structure | Has Identity, Capabilities, Activation, Behavior, Referenced Skills, Referenced Standards, Output Contract, Boundaries |
+    | 3 | Template mirror exists | `Test-Path src/ai_engineering/templates/.ai-engineering/agents/<name>.md` |
+    | 4 | Mirror is identical | `diff` canonical vs. mirror — 0 differences |
+    | 5 | Listed in all 6 files | `grep` for the agent path in each instruction file |
+    | 6 | Count matches | Count agents in instruction files = count in product-contract |
+    | 7 | CHANGELOG updated | Entry under `## [Unreleased] → ### Added` |
+    | 8 | Cross-references added | Related skills reference the new agent |
+
+## Output Contract
+
+- Canonical agent file at `.ai-engineering/agents/<name>.md` following template structure.
+- Identical template mirror at `src/ai_engineering/templates/.ai-engineering/agents/<name>.md`.
+- Reference entry in all 6 instruction files under the `## Agents` section.
+- Updated agent count in `product-contract.md` (objectives + KPIs).
+- Changelog entry in `CHANGELOG.md`.
+- Cross-references in related skills.
+- Verification checklist passes all 8 checks.
+
+## Governance Notes
+
+- No Python code changes are needed — installer, ownership, packaging, and maintenance all use glob-based discovery.
+- Template mirror must be byte-identical to canonical — never diverge.
+- Agent count in product-contract must match actual count listed in instruction files.
+- Agents are framework-managed content (`OwnershipLevel.FRAMEWORK_MANAGED`) — they follow the governed update flow.
+- Never create an agent that duplicates an existing agent's capabilities — extend instead.
+- Agent identity must be written in third person.
+- Agent references use paths relative to `.ai-engineering/` (e.g., `skills/swe/debug.md`, not `.ai-engineering/skills/swe/debug.md`).
+
+## References
+
+- `standards/framework/core.md` — governance structure, ownership model, lifecycle.
+- `context/product/framework-contract.md` — template packaging and replication rule.
+- `skills/swe/prompt-engineer.md` — prompt engineering for agent persona authoring.
+- `skills/lifecycle/create-skill.md` — companion procedure for skill registration.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting.

--- a/.ai-engineering/skills/lifecycle/create-skill.md
+++ b/.ai-engineering/skills/lifecycle/create-skill.md
@@ -1,0 +1,147 @@
+# Create Skill
+
+## Purpose
+
+Definitive procedure for authoring and registering a new skill in the ai-engineering framework. Ensures every registration point is updated — canonical file, template mirror, all instruction files, counters, changelog, and cross-references — eliminating partial registration risk.
+
+## Trigger
+
+- Command: agent invokes create-skill skill or user requests adding a new skill.
+- Context: new procedural skill is needed, existing gap identified, governance content expansion.
+
+## Procedure
+
+### Phase 1: Design
+
+1. **Define skill identity** — determine name, category, purpose, and trigger contexts.
+   - Name: kebab-case (`my-skill`).
+   - Category: `swe/`, `workflows/`, `quality/`, `lifecycle/`, `utils/`, or `validation/`.
+   - Purpose: one paragraph explaining what the skill does and when to use it.
+   - Trigger: command pattern and context scenarios.
+
+2. **Check for duplicates** — verify no existing skill covers the same ground.
+   - Review skills listed in `.github/copilot-instructions.md` under `## Skills`.
+   - Search `.ai-engineering/skills/` for overlapping names or purposes.
+   - If overlap exists, consider extending the existing skill instead.
+
+### Phase 2: Author
+
+3. **Create the canonical skill file** — write `.ai-engineering/skills/<category>/<name>.md`.
+   - Follow the skill template structure:
+
+     ```
+     # Skill Name
+     ## Purpose
+     ## Trigger
+     ## Procedure
+       ### Phase N: <Name>
+       N. **Step name** — description.
+     ## Output Contract
+     ## Governance Notes
+     ## References
+     ```
+
+   - Procedure steps are **numbered sequentially** across all phases.
+   - Use bold step names with em-dash: `**Step name** — description.`
+   - References use relative paths from `.ai-engineering/` (e.g., `standards/framework/core.md`).
+
+4. **Validate structure** — confirm the skill file contains all required sections.
+   - Purpose: present and concise.
+   - Trigger: command and context defined.
+   - Procedure: at least one phase with numbered steps.
+   - Output Contract: measurable deliverables listed.
+   - Governance Notes: relevant constraints from standards.
+   - References: at least one link to a related standard, skill, or agent.
+
+### Phase 3: Mirror
+
+5. **Create the template mirror** — copy to `src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md`.
+   - Content must be **byte-identical** to the canonical file.
+   - This is required by framework-contract: "Keep non-state files identical between canonical and template mirror."
+   - The installer uses `rglob("*")` to discover templates — no Python code changes needed.
+   - The `pyproject.toml` includes `src/ai_engineering/templates/**/*.md` — no build config changes needed.
+
+### Phase 4: Register
+
+6. **Add to all 6 instruction files** — insert a reference line under the correct subsection.
+   - Format: `- \`.ai-engineering/skills/<category>/<name>.md\` — one-line description.`
+   - Subsection mapping:
+     - `workflows/` → `### Workflows`
+     - `swe/` → `### SWE Skills`
+     - `lifecycle/` → `### Lifecycle Skills`
+     - `quality/` → `### Quality Skills`
+   - Files to update (all 6, every time):
+
+     | # | File | Location |
+     |---|------|----------|
+     | 1 | `.github/copilot-instructions.md` | `## Skills` → appropriate subsection |
+     | 2 | `AGENTS.md` (repo root) | `## Skills` → appropriate subsection |
+     | 3 | `CLAUDE.md` (repo root) | `## Skills` → appropriate subsection |
+     | 4 | `src/ai_engineering/templates/project/copilot-instructions.md` | `## Skills` → appropriate subsection |
+     | 5 | `src/ai_engineering/templates/project/AGENTS.md` | `## Skills` → appropriate subsection |
+     | 6 | `src/ai_engineering/templates/project/CLAUDE.md` | `## Skills` → appropriate subsection |
+
+   - Insert alphabetically within the subsection for consistency.
+
+### Phase 5: Update Counters
+
+7. **Update skill count in product-contract** — edit `.ai-engineering/context/product/product-contract.md`.
+   - Update the `Active Objectives` line (e.g., "19 skills" → "21 skills").
+   - Update the `KPIs` table row for `Agent coverage` (e.g., "19 skills + 8 agents" → "21 skills + 8 agents").
+   - The count must match the actual number of skills listed in the instruction files.
+
+### Phase 6: Changelog
+
+8. **Add changelog entry** — edit `CHANGELOG.md`.
+   - Add under `## [Unreleased] → ### Added`.
+   - Format: `- <Skill name> skill for <purpose summary>.`
+
+### Phase 7: Cross-Reference
+
+9. **Update related skills** — add the new skill to `## References` of skills that relate to it.
+   - If the new skill extends or complements an existing skill, add a reference in both directions.
+
+10. **Update related agents** — add the new skill to `## Referenced Skills` of agents that would use it.
+    - If an agent's behavior involves the new skill's procedure, add the reference.
+
+### Phase 8: Verify
+
+11. **Run the verification checklist** — confirm all registration points are complete.
+
+    | # | Check | How to verify |
+    |---|-------|---------------|
+    | 1 | Canonical file exists | `Test-Path .ai-engineering/skills/<category>/<name>.md` |
+    | 2 | Follows template structure | Has Purpose, Trigger, Procedure, Output Contract, Governance Notes, References |
+    | 3 | Template mirror exists | `Test-Path src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md` |
+    | 4 | Mirror is identical | `diff` canonical vs. mirror — 0 differences |
+    | 5 | Listed in all 6 files | `grep` for the skill path in each instruction file |
+    | 6 | Count matches | Count skills in instruction files = count in product-contract |
+    | 7 | CHANGELOG updated | Entry under `## [Unreleased] → ### Added` |
+    | 8 | Cross-references added | Related skills/agents reference the new skill |
+
+## Output Contract
+
+- Canonical skill file at `.ai-engineering/skills/<category>/<name>.md` following template structure.
+- Identical template mirror at `src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md`.
+- Reference entry in all 6 instruction files under the correct subsection.
+- Updated skill count in `product-contract.md` (objectives + KPIs).
+- Changelog entry in `CHANGELOG.md`.
+- Cross-references in related skills and agents.
+- Verification checklist passes all 8 checks.
+
+## Governance Notes
+
+- No Python code changes are needed — installer, ownership, packaging, and maintenance all use glob-based discovery.
+- Template mirror must be byte-identical to canonical — never diverge.
+- Skill count in product-contract must match actual count listed in instruction files.
+- Skills are framework-managed content (`OwnershipLevel.FRAMEWORK_MANAGED`) — they follow the governed update flow.
+- Never create a skill that duplicates an existing skill's purpose — extend instead.
+- Skill references use paths relative to `.ai-engineering/` (e.g., `standards/framework/core.md`, not `.ai-engineering/standards/framework/core.md`).
+
+## References
+
+- `standards/framework/core.md` — governance structure, ownership model, lifecycle.
+- `context/product/framework-contract.md` — template packaging and replication rule.
+- `skills/swe/prompt-engineer.md` — prompt engineering for skill content authoring.
+- `skills/lifecycle/create-agent.md` — companion procedure for agent registration.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting.

--- a/.ai-engineering/skills/swe/changelog-documentation.md
+++ b/.ai-engineering/skills/swe/changelog-documentation.md
@@ -1,0 +1,201 @@
+# Changelog Documentation
+
+## Purpose
+
+Transform technical git history into polished, user-friendly documentation that customers and developers actually understand. Produces two outputs: a structured CHANGELOG.md following Keep a Changelog format, and GitHub Release Notes with highlights, upgrade guides, and contributor acknowledgments. Emphasizes user-facing language — write what users can DO, not what you BUILT.
+
+## Trigger
+
+- Command: agent invokes changelog-documentation skill or user requests changelog/release notes generation.
+- Context: preparing a release, documenting recent changes, writing app store update descriptions, creating customer-facing product updates, transitioning `[Unreleased]` to a versioned release.
+
+## Procedure
+
+### Phase 1: Gather Changes
+
+1. **Identify scope** — determine the range of changes to document.
+   - Between two tags: `git log v1.0.0..v2.0.0 --oneline`.
+   - Since last release: `git log $(git describe --tags --abbrev=0)..HEAD --oneline`.
+   - Time-based: `git log --since="2 weeks ago" --oneline`.
+   - If active spec exists, cross-reference `specs/<active>/tasks.md` for completed work.
+
+2. **Collect raw material** — for each commit/PR, gather:
+   - Commit message (may follow `spec-NNN: Task X.Y — <description>` format).
+   - PR title and description (richer context than commit messages).
+   - Changed files and diff summary (`git diff --stat`).
+   - Linked issues or specs.
+
+3. **Assess impact** — classify each change by user impact:
+   - **User-visible**: changes behavior, adds capability, fixes a bug users experience.
+   - **Internal**: refactoring, test improvements, CI changes, dependency bumps.
+   - **Breaking**: changes API, removes features, requires migration.
+   - **Security**: fixes vulnerabilities, updates vulnerable dependencies.
+
+### Phase 2: Categorize
+
+4. **Map to Keep a Changelog categories** — assign each user-visible change to exactly one category:
+
+   | Category       | Rule                                                    | Example                                           |
+   |---------------|---------------------------------------------------------|---------------------------------------------------|
+   | **Added**      | Users couldn't do this before at all                    | "You can now export reports in bulk"              |
+   | **Changed**    | Existing capability is now better, faster, or different | "Dashboard loads 3× faster on large datasets"     |
+   | **Deprecated** | Still works, but will be removed — include timeline     | "REST API v1 will be removed in v3.0.0"           |
+   | **Removed**    | Previously available, now gone                          | "Removed support for Python 3.9"                  |
+   | **Fixed**      | Was broken, now works correctly                         | "Fixed an issue where CSV exports had missing columns" |
+   | **Security**   | Vulnerability fix — include CVE, impact, affected versions | "Fixed SQL injection in search (CVE-2025-12346)" |
+
+5. **Filter noise** — exclude from the changelog:
+   - Internal refactoring with no behavior change.
+   - Test additions/modifications (unless fixing a user-reported bug).
+   - CI/CD pipeline changes.
+   - Code style/formatting changes.
+   - Dependency bumps with no user-visible impact (unless security-related).
+   - Merge commits and branch housekeeping.
+
+### Phase 3: Transform to User-Facing Language
+
+6. **Rewrite entries** — convert technical commit messages to user-facing language:
+
+   ```
+   ❌ Technical (don't):
+   "Implemented batch processing queue for the export service"
+   "Refactored ReportExporter class to support pagination"
+   "Fixed bug in CSV serialization (PR #4521)"
+   "Various bug fixes and improvements"
+   "Updated dependencies"
+
+   ✅ User-facing (do):
+   "You can now export up to 10,000 rows at once from any report"
+   "Reports now load 3× faster when filtering large datasets"
+   "Fixed an issue where exported CSV files had missing columns"
+   ```
+
+7. **Apply language rules**:
+   - Start with "You can now..." / "X now..." / "Fixed an issue where..." / "Added support for...".
+   - Include the benefit, not just the mechanism.
+   - Use present tense.
+   - Strip internal references (PR numbers, file paths, branch names) — unless linking to issues.
+   - One changelog entry may represent many commits — group related work.
+   - Don't say "Updated X" without saying how — was it improved or fixed?
+
+### Phase 4: Format CHANGELOG.md
+
+8. **Write entries in `[Unreleased]`** — add entries to the appropriate category section:
+
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+   - Changelog documentation skill for generating user-friendly changelogs and release notes.
+
+   ### Fixed
+   - Fixed an issue where exported CSV files had missing column headers.
+   ```
+
+9. **Handle version transitions** — when cutting a release:
+   - Rename `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`.
+   - Create a new empty `[Unreleased]` section above it.
+   - Add comparison links in the footer:
+     ```markdown
+     [Unreleased]: https://github.com/owner/repo/compare/vX.Y.Z...HEAD
+     [X.Y.Z]: https://github.com/owner/repo/compare/vPREVIOUS...vX.Y.Z
+     ```
+   - Version number follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+     - MAJOR: breaking changes.
+     - MINOR: new features (backwards-compatible).
+     - PATCH: bug fixes.
+
+### Phase 5: Format Release Notes (Optional)
+
+10. **Produce GitHub Release Notes** — a standalone document for the GitHub release page:
+
+    ```markdown
+    # Release vX.Y.Z
+
+    **Release Date:** YYYY-MM-DD
+
+    ## Highlights
+
+    - **Feature Name** — 1-2 sentence user-facing summary.
+
+    ## What's New
+
+    ### Feature Name
+    Description of what users can now do and how.
+
+    ## Improvements
+
+    - Concise improvement entries.
+
+    ## Bug Fixes
+
+    - Fixed an issue where...
+
+    ## Breaking Changes
+
+    ### ⚠️ Change Title
+    **What changed:** Description.
+    **What you need to do:** Migration steps.
+    **Timeline:** Deprecation → removal dates.
+
+    ## Security Updates
+
+    - **SEVERITY**: Description (CVE-YYYY-NNNNN)
+      - Impact: ...
+      - Affected versions: ...
+      - Action: Upgrade immediately.
+
+    ## Upgrade Guide
+
+    Steps to upgrade from the previous version.
+
+    ## Contributors
+
+    Thanks to @contributor1, @contributor2.
+
+    **Full Changelog**: https://github.com/owner/repo/compare/vPREVIOUS...vX.Y.Z
+    ```
+
+### Phase 6: Quality Check
+
+11. **Validate against anti-patterns** — reject entries that match:
+    - "Various bug fixes and improvements" — list specific fixes or omit.
+    - "Updated dependencies" without stating user impact.
+    - "Updated X" without explaining how (improved? fixed? changed?).
+    - Internal jargon (class names, module paths, PR numbers in prose).
+    - Missing dates on releases.
+    - Breaking changes buried in the middle — must be prominent with `⚠️`.
+    - Security entries without CVE references, impact level, or affected versions.
+    - Vague language ("improved performance" without metrics or context).
+
+12. **Cross-check completeness**:
+    - Every user-visible change from the git range is represented.
+    - Breaking changes have migration guidance.
+    - Deprecated features include removal timeline.
+    - Security entries include severity, affected versions, and required action.
+    - Categories are mutually exclusive — each entry appears in exactly one.
+
+## Output Contract
+
+- **CHANGELOG.md entries**: new entries in `[Unreleased]` (or versioned section) following Keep a Changelog format.
+- **Release Notes** (when requested): standalone GitHub Release Notes document with highlights, upgrade guide, breaking changes, and contributors.
+- **Quality check results**: list of anti-patterns checked with pass/fail status.
+
+## Governance Notes
+
+- CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format — no exceptions.
+- Version numbers follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Breaking changes must be documented prominently — never buried in a list.
+- Security entries must reference CVEs where applicable and include impact assessment.
+- Changelog updates go through PR — never direct commit to protected branches.
+- Internal-only changes (refactoring, tests, CI) are excluded from the changelog unless they affect user behavior.
+- Don't manually edit auto-generated tool output without review — generated changelogs are a starting point, not final output.
+- Each entry must be user-facing: benefit-first, present tense, no internal references.
+
+## References
+
+- `standards/framework/core.md` — governance structure and non-negotiables.
+- `context/product/framework-contract.md` — release model and versioning.
+- `skills/swe/pr-creation.md` — PR workflow (changelog updates go through PRs).
+- `skills/swe/security-review.md` — security entry format and CVE handling.
+- `skills/swe/migration.md` — breaking changes documentation requirements.

--- a/.ai-engineering/skills/swe/code-review.md
+++ b/.ai-engineering/skills/swe/code-review.md
@@ -63,4 +63,8 @@ Deep code review skill covering security, quality, performance, and maintainabil
 - `standards/framework/quality/core.md` — severity policy and quality gates.
 - `standards/framework/quality/python.md` — Python-specific checks.
 - `standards/framework/stacks/python.md` — code patterns.
+- `skills/swe/security-review.md` — detailed security review procedure.
+- `skills/swe/test-strategy.md` — test assessment criteria.
+- `skills/swe/performance-analysis.md` — performance evaluation procedure.
 - `agents/principal-engineer.md` — agent that performs deep reviews.
+- `agents/code-simplifier.md` — agent that uses code quality criteria.

--- a/.ai-engineering/skills/swe/debug.md
+++ b/.ai-engineering/skills/swe/debug.md
@@ -54,3 +54,4 @@ Systematic diagnosis skill for identifying, isolating, and fixing bugs. Follows 
 
 - `standards/framework/quality/python.md` — test and coverage requirements.
 - `agents/debugger.md` — agent that uses this skill systematically.
+- `agents/verify-app.md` — agent that uses debug for investigating verification failures.

--- a/.ai-engineering/skills/swe/dependency-update.md
+++ b/.ai-engineering/skills/swe/dependency-update.md
@@ -57,3 +57,4 @@ Structured dependency update skill: audit current dependencies, update safely, t
 - `standards/framework/stacks/python.md` — required tooling.
 - `standards/framework/quality/core.md` — security gate.
 - `standards/framework/core.md` — risk acceptance policy.
+- `agents/security-reviewer.md` — agent that assesses dependency security.

--- a/.ai-engineering/skills/swe/doc-writer.md
+++ b/.ai-engineering/skills/swe/doc-writer.md
@@ -1,0 +1,287 @@
+# Doc Writer
+
+## Purpose
+
+Transform codebase knowledge into polished, user-facing open-source documentation that end users actually understand and appreciate. Reads code, configuration, `.ai-engineering` context (specs, learnings, product-contract), and project metadata to produce README.md, CONTRIBUTING.md, docs/ site content, Wiki pages, and CODE_OF_CONDUCT.md. Writes what users can DO, not what you BUILT — translating technical implementation into benefits, capabilities, and clear instructions.
+
+## Trigger
+
+- Command: agent invokes doc-writer skill or user requests project documentation.
+- Context: creating or updating README.md, writing getting-started guides, producing contribution guidelines, generating docs/ site content, building Wiki articles, onboarding new users, preparing a project for open-source release.
+
+## Procedure
+
+### Phase 1: Codebase Discovery
+
+Autonomously scan the project to build a complete mental model before writing a single line of documentation.
+
+1. **Read project identity** — understand what the project is and who it serves.
+   - Read `context/product/product-contract.md` — goals, KPIs, release status.
+   - Read `context/product/framework-contract.md` — identity, personas, roadmap.
+   - Read `pyproject.toml` — project name, version, description, entry points, dependencies.
+   - Read `__version__.py` or equivalent — current version string.
+
+2. **Read project context** — understand current scope and institutional knowledge.
+   - Read `context/specs/_active.md` and the active spec's `spec.md` — current scope, decisions, what's in/out.
+   - Read `context/learnings.md` — retained institutional knowledge, past decisions.
+   - Scan `standards/framework/core.md` — governance model (for understanding, not for user docs).
+
+3. **Scan source code** — identify user-facing features and capabilities.
+   - Read CLI entry points (`cli.py`, `cli_factory.py`, or equivalent) — available commands and options.
+   - Scan feature modules in `src/` — public API surface, key classes, exported functions.
+   - Read configuration files — what users can configure and how.
+   - Identify install method — pip, uv, package manager, from source.
+
+4. **Produce Project Knowledge Map** — structured internal artifact (not published):
+
+   | Dimension         | What to capture                                      |
+   |-------------------|------------------------------------------------------|
+   | **Identity**      | Name, tagline, one-sentence value proposition        |
+   | **Audience**      | Who uses this and why                                 |
+   | **Install**       | How to install (pip, uv, from source)                 |
+   | **Quick start**   | Minimum steps to first useful result                  |
+   | **Features**      | User-facing capabilities (not internal modules)       |
+   | **Configuration** | What can be customized and how                        |
+   | **Architecture**  | Simplified view — only what users need to understand  |
+   | **Ecosystem**     | Related tools, integrations, plugins                  |
+
+### Phase 2: Documentation Standards and Structuring
+
+Establish writing standards and document architecture before drafting.
+
+5. **Apply voice and tone rules** — every document follows these conventions:
+   - Address the reader as "you." Use active voice and present tense.
+   - Professional, friendly, and direct tone — not corporate, not casual.
+   - Use simple vocabulary. Avoid jargon, slang, and marketing hype.
+   - Write for a global audience — standard US English, no idioms or cultural references.
+   - Be clear about requirements ("must") vs. recommendations ("we recommend"). Avoid "should."
+   - Use contractions (don't, it's). Avoid "please" and anthropomorphism.
+   - Start instructions with imperative verbs: "Run...", "Create...", "Add...".
+
+6. **Apply formatting rules** — consistent structure across all artifacts:
+   - ATX-style headers (`#`, `##`, `###`). Sentence case for headings.
+   - Every heading followed by at least one introductory paragraph before lists or sub-headings.
+   - Numbered lists for sequential steps. Bullet lists for non-sequential items.
+   - Code blocks with language tags (` ```bash `, ` ```python `, ` ```yaml `).
+   - Bold for UI elements and emphasis. Backticks for filenames, commands, API elements.
+   - Descriptive link text — never "click here." Links must make sense out of context.
+   - Meaningful names in examples — never "foo", "bar", or "test123."
+   - Alt text for all images. Lowercase hyphenated filenames for media.
+
+7. **Select and outline artifacts** — determine which documents to produce:
+
+   | Artifact              | When to produce                                           |
+   |-----------------------|-----------------------------------------------------------|
+   | **README.md**         | Always — the project's front door                         |
+   | **CONTRIBUTING.md**   | When the project accepts external contributions           |
+   | **docs/ site content**| When the project has enough features to warrant guides    |
+   | **Wiki pages**        | When conceptual/architectural guides complement docs/     |
+   | **CODE_OF_CONDUCT.md**| When the project is published as open-source              |
+
+   For each selected artifact, generate a **section outline** with placeholder headings. Present the outlines to the user for validation before writing.
+
+### Phase 3: Co-Authoring and Drafting
+
+Iteratively build each document section by section. Never dump a full draft — collaborate through structured refinement.
+
+8. **For each artifact, work section by section**:
+
+   1. **Clarify** — ask 3-5 targeted questions about what to include in this section.
+   2. **Brainstorm** — propose 5-10 content options for the section, drawing from the Project Knowledge Map.
+   3. **Curate** — user indicates what to keep, remove, or combine (shorthand is fine: "keep 1,3,5 — remove 2,4").
+   4. **Draft** — write the section based on curated selections. Create or update the file directly.
+   5. **Iterate** — user reviews and provides feedback. Apply surgical edits — never reprint entire documents for small changes.
+
+   Repeat steps 1-5 until the user approves the section, then move to the next.
+
+9. **Track style preferences** — as the user provides feedback across sections, learn and apply their preferences to subsequent sections. Common patterns to track:
+   - Preferred level of technical detail.
+   - Tone adjustments (more formal, more casual, more concise).
+   - Structural preferences (more examples, fewer tables, shorter paragraphs).
+
+10. **Apply artifact-specific structure** — each document type has its own anatomy:
+
+#### README.md
+
+```markdown
+# Project Name
+
+Brief description — what it does, who it's for, why it matters.
+
+## Features
+
+Key capabilities as a bullet list — user benefits, not implementation details.
+
+## Quick start
+
+### Prerequisites
+
+What users need before installing.
+
+### Installation
+
+Exact install commands (pip, uv, from source).
+
+### First use
+
+Minimum steps to a first useful result.
+
+## Usage
+
+Expanded usage guide — common workflows, CLI commands, configuration.
+
+## Configuration
+
+Available options, environment variables, config files.
+
+## Architecture
+
+Simplified view — only what helps users understand the project.
+Not internal module structure — user-facing concepts.
+
+## Documentation
+
+Links to docs/, Wiki, API reference.
+
+## Contributing
+
+Brief mention + link to CONTRIBUTING.md.
+
+## License
+
+License type and link.
+```
+
+#### CONTRIBUTING.md
+
+```markdown
+# Contributing to Project Name
+
+Thank your contributors. Set the tone for collaboration.
+
+## Development setup
+
+Exact steps: clone, install dependencies, verify setup works.
+
+## Code style
+
+Linting, formatting, type checking tools and commands.
+
+## Testing
+
+How to run tests. Coverage expectations.
+
+## Pull request process
+
+Branch naming, commit conventions, PR template, review process.
+
+## Reporting issues
+
+How to report bugs. What to include.
+
+## Code of conduct
+
+Link to CODE_OF_CONDUCT.md.
+```
+
+#### docs/ site content
+
+- **Getting started guide**: prerequisites, installation, first use, next steps.
+- **Feature guides**: one per major feature — what it does, how to use it, examples.
+- **Configuration reference**: all options, defaults, environment variables.
+- **FAQ / Troubleshooting**: common questions and known issues.
+
+#### Wiki pages
+
+- **Conceptual guides**: architecture for users, design philosophy, integration patterns.
+- **How-to articles**: task-oriented guides for specific use cases.
+- **Glossary**: project-specific terminology.
+
+#### CODE_OF_CONDUCT.md
+
+- Adopt [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as default.
+- Customize: project name, contact info, enforcement details.
+- Keep it standard — deviations from Contributor Covenant must be justified.
+
+### Phase 4: Reader Testing
+
+Validate documentation quality by testing with a fresh perspective.
+
+11. **Predict user questions** — generate 5-10 questions a new user would ask:
+    - "How do I install this?"
+    - "What does this project do?"
+    - "How do I configure X?"
+    - "What are the prerequisites?"
+    - "How do I report a bug?"
+
+12. **Test with sub-agent** — invoke a fresh agent (no conversation history) with only the document content and one question at a time.
+    - Does the agent find the answer from the docs alone?
+    - Is anything ambiguous or assumed?
+    - Are there comprehension gaps?
+
+13. **Validate technical accuracy**:
+    - Are install instructions actually runnable?
+    - Are code examples syntactically valid?
+    - Do all links resolve?
+    - Does the documented version match `__version__.py`?
+    - Are CLI commands and flags accurate against the actual implementation?
+
+14. **Fix gaps** — for any failing tests, loop back to Phase 3 step 5 for the affected section. Don't rewrite from scratch — apply surgical fixes.
+
+### Phase 5: Ship and Integrate
+
+Finalize and position documentation in the project.
+
+15. **Final coherence review** — read all artifacts end-to-end and check:
+    - Consistent terminology across all documents (same name for same concept everywhere).
+    - No contradictions between README, docs/, and CONTRIBUTING.
+    - Cross-references work (README links to CONTRIBUTING, docs links to README, etc.).
+    - No orphaned sections or dead-end flows.
+
+16. **Version alignment** — ensure documentation reflects the current state:
+    - Version string matches `__version__.py` or `pyproject.toml`.
+    - Features documented match features that actually exist in the current release.
+    - Roadmap or "coming soon" items are clearly marked as such.
+
+17. **Add navigation** — connect all documentation artifacts:
+    - README → docs/, CONTRIBUTING.md, CODE_OF_CONDUCT.md.
+    - docs/ pages → back to README, between guides.
+    - CONTRIBUTING.md → CODE_OF_CONDUCT.md.
+
+18. **Recommend next steps** — suggest improvements beyond the current scope:
+    - Add documentation CI (link checking, markdown linting).
+    - Set up a docs site (Nextra, MkDocs, Docusaurus) if `docs/` content warrants it.
+    - Add documentation updates to the PR template checklist.
+    - Schedule periodic documentation review (quarterly).
+
+## Output Contract
+
+- One or more documentation files from the supported set: README.md, CONTRIBUTING.md, docs/*, Wiki pages, CODE_OF_CONDUCT.md.
+- Each file follows the voice, tone, and formatting standards from Phase 2.
+- Every claim is traceable to code, configuration, or `context/` content — no hallucinated features.
+- Reader Testing passes: a fresh agent can answer user questions from the docs alone.
+- Install instructions are verified or explicitly marked as untested.
+- All cross-references and links resolve.
+
+## Governance Notes
+
+- Never expose internal governance details (`.ai-engineering/` internals, state files, audit logs, decision store) in user-facing documentation — describe user-facing behavior only.
+- Never fabricate features, commands, or configuration options — all documented capabilities must be verifiable in source code.
+- Never overwrite team-managed or project-managed content without user confirmation.
+- Respect the framework-contract's identity: use the correct project name, positioning, and value proposition from `context/product/product-contract.md`.
+- Security-sensitive information (API keys, secrets handling, credentials) must reference the security review skill before documenting.
+- Install and usage instructions must be tested against the actual codebase or explicitly marked as untested.
+- Breaking changes and deprecations must be prominent, never buried — mirror the changelog-documentation skill's conventions.
+- Code examples in documentation must be syntactically valid and idiomatic.
+
+## References
+
+- `context/product/product-contract.md` — source of truth for project identity and positioning.
+- `context/product/framework-contract.md` — roadmap, personas, value proposition.
+- `context/learnings.md` — institutional knowledge that may inform documentation content.
+- `standards/framework/core.md` — governance model (for understanding internal structure, not for user docs).
+- `skills/swe/changelog-documentation.md` — user-facing language conventions and anti-patterns.
+- `skills/swe/code-review.md` — quality patterns for code examples in documentation.
+- `skills/swe/prompt-engineer.md` — Chain of Density for content compression and summaries.
+- `skills/swe/security-review.md` — security assessment before documenting sensitive features.
+- `agents/codebase-mapper.md` — complementary agent for deep codebase understanding.

--- a/.ai-engineering/skills/swe/performance-analysis.md
+++ b/.ai-engineering/skills/swe/performance-analysis.md
@@ -59,3 +59,4 @@ Identify and resolve performance bottlenecks through systematic profiling, measu
 - `standards/framework/stacks/python.md` — code patterns.
 - `standards/framework/quality/python.md` — complexity thresholds.
 - `skills/swe/python-mastery.md` — performance optimization domain.
+- `agents/principal-engineer.md` — agent that evaluates performance.

--- a/.ai-engineering/skills/swe/pr-creation.md
+++ b/.ai-engineering/skills/swe/pr-creation.md
@@ -57,5 +57,7 @@ Craft well-structured pull requests with clear titles, descriptive bodies, break
 ## References
 
 - `skills/workflows/pr.md` — full `/pr` workflow procedure.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting for PRs.
 - `standards/framework/quality/core.md` — PR quality gates.
 - `standards/framework/core.md` — command governance.
+- `standards/framework/stacks/python.md` — Python checks in PR checklist.

--- a/.ai-engineering/skills/swe/prompt-engineer.md
+++ b/.ai-engineering/skills/swe/prompt-engineer.md
@@ -144,4 +144,6 @@ For complex, multi-type tasks, blend frameworks:
 - `standards/framework/core.md` — non-negotiables that prompts must enforce.
 - `context/product/framework-contract.md` — product principles and context efficiency.
 - `agents/principal-engineer.md` — example of a well-structured agent persona.
+- `skills/lifecycle/create-skill.md` — definitive procedure for skill registration.
+- `skills/lifecycle/create-agent.md` — definitive procedure for agent registration.
 - All agent and skill templates defined in `context/specs/001-rewrite-v2/plan.md`.

--- a/.ai-engineering/skills/swe/python-mastery.md
+++ b/.ai-engineering/skills/swe/python-mastery.md
@@ -221,3 +221,7 @@ Before committing, verify:
 - `skills/swe/test-strategy.md` — testing details.
 - `skills/swe/performance-analysis.md` — performance deep-dive.
 - `skills/swe/security-review.md` — security-specific patterns.
+- `agents/architect.md` — agent that uses design patterns domain.
+- `agents/code-simplifier.md` — agent that uses Pythonic patterns.
+- `agents/codebase-mapper.md` — agent that uses Python module system domain.
+- `agents/principal-engineer.md` — agent that uses Python patterns for review.

--- a/.ai-engineering/skills/swe/test-strategy.md
+++ b/.ai-engineering/skills/swe/test-strategy.md
@@ -62,3 +62,6 @@ Define what to test, how to structure tests, and how to achieve meaningful cover
 - `standards/framework/stacks/python.md` — testing patterns.
 - `standards/framework/quality/python.md` — coverage policy.
 - `standards/framework/quality/core.md` — quality gates.
+- `agents/debugger.md` — agent that writes regression tests.
+- `agents/principal-engineer.md` — agent that assesses test completeness.
+- `agents/verify-app.md` — agent that follows test design principles.

--- a/.ai-engineering/skills/utils/git-helpers.md
+++ b/.ai-engineering/skills/utils/git-helpers.md
@@ -41,3 +41,9 @@ Fallbacks:
 - Do not suggest `--no-verify`.
 - Do not force push.
 - Do not bypass mandatory checks.
+
+## References
+
+- `skills/workflows/commit.md` — primary consumer of git helper procedures.
+- `skills/workflows/pr.md` — PR workflow using git operations.
+- `standards/framework/core.md` — protected branch rules and enforcement.

--- a/.ai-engineering/skills/utils/platform-detection.md
+++ b/.ai-engineering/skills/utils/platform-detection.md
@@ -38,3 +38,8 @@ az account show
 
 - GitHub is runtime priority in current phase.
 - Azure DevOps constraints must remain represented in manifest schema.
+
+## References
+
+- `skills/validation/install-readiness.md` — uses platform detection for readiness checks.
+- `standards/framework/core.md` — provider support model.

--- a/.ai-engineering/skills/validation/install-readiness.md
+++ b/.ai-engineering/skills/validation/install-readiness.md
@@ -36,3 +36,9 @@ Validate that ai-engineering is operational after install/update.
 - machine-readable JSON summary for automation,
 - concise human-readable remediation steps,
 - no bypass recommendations.
+
+## References
+
+- `skills/utils/platform-detection.md` — provider and tooling detection.
+- `standards/framework/core.md` — enforcement requirements.
+- `agents/verify-app.md` — verification agent that uses readiness checks.

--- a/.ai-engineering/skills/workflows/commit.md
+++ b/.ai-engineering/skills/workflows/commit.md
@@ -47,3 +47,4 @@ Follow steps 1–5 above. Skip step 6.
 - `standards/framework/stacks/python.md` — Python-specific checks.
 - `standards/framework/quality/core.md` — gate structure (pre-commit gate).
 - `skills/workflows/acho.md` — alias workflow.
+- `agents/verify-app.md` — agent that validates commit workflow execution.

--- a/.ai-engineering/skills/workflows/pr.md
+++ b/.ai-engineering/skills/workflows/pr.md
@@ -62,3 +62,5 @@ Execute the `/pr` governed workflow: stage, commit, push, create a pull request,
 - `standards/framework/quality/core.md` — gate structure (pre-push + PR gates).
 - `skills/workflows/commit.md` — shared pre-commit steps.
 - `skills/workflows/acho.md` — alias workflow.
+- `skills/swe/pr-creation.md` — PR structure and formatting.
+- `agents/verify-app.md` — agent that validates PR workflow execution.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -37,6 +38,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -45,6 +46,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Create-skill skill for definitive skill authoring and registration procedure.
+- Create-agent skill for definitive agent authoring and registration procedure.
+- Changelog documentation skill for generating user-friendly changelogs and release notes from git history.
+- Doc-writer skill for open-source documentation generation from codebase knowledge.
 - Canonical/template mirror contract for `.ai-engineering` governance artifacts.
 - Installer coverage for full bundled non-state governance template tree.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -45,6 +46,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 

--- a/src/ai_engineering/templates/.ai-engineering/agents/code-simplifier.md
+++ b/src/ai_engineering/templates/.ai-engineering/agents/code-simplifier.md
@@ -42,6 +42,7 @@ Complexity reducer who systematically identifies and eliminates unnecessary comp
 ## Referenced Standards
 
 - `standards/framework/quality/python.md` — complexity thresholds (cyclomatic ≤ 10, cognitive ≤ 15, functions < 50 lines).
+- `standards/framework/quality/core.md` — quality gate severity policy.
 - `standards/framework/stacks/python.md` — code patterns and conventions.
 
 ## Output Contract

--- a/src/ai_engineering/templates/.ai-engineering/agents/codebase-mapper.md
+++ b/src/ai_engineering/templates/.ai-engineering/agents/codebase-mapper.md
@@ -35,6 +35,7 @@ Codebase analyst who builds comprehensive maps of project structure, module rela
 ## Referenced Skills
 
 - `skills/swe/architecture-analysis.md` — structural analysis methodology.
+- `skills/swe/doc-writer.md` — documentation generation from codebase knowledge.
 - `skills/swe/python-mastery.md` — Python module system domain.
 
 ## Referenced Standards

--- a/src/ai_engineering/templates/.ai-engineering/agents/principal-engineer.md
+++ b/src/ai_engineering/templates/.ai-engineering/agents/principal-engineer.md
@@ -37,6 +37,7 @@ Senior technical reviewer who evaluates code as a principal engineer would: focu
 - `skills/swe/test-strategy.md` — test assessment criteria.
 - `skills/swe/performance-analysis.md` — performance evaluation.
 - `skills/swe/python-mastery.md` — Python patterns and anti-patterns.
+- `skills/swe/security-review.md` — security assessment procedure.
 
 ## Referenced Standards
 

--- a/src/ai_engineering/templates/.ai-engineering/agents/quality-auditor.md
+++ b/src/ai_engineering/templates/.ai-engineering/agents/quality-auditor.md
@@ -39,6 +39,7 @@ Quality gate enforcer who executes the quality contract defined in standards, ru
 - `standards/framework/quality/core.md` — quality contract, thresholds, gate structure.
 - `standards/framework/quality/python.md` — Python-specific checks.
 - `standards/framework/quality/sonarlint.md` — severity mapping.
+- `standards/framework/stacks/python.md` — required tooling (ruff, ty, uv).
 
 ## Output Contract
 

--- a/src/ai_engineering/templates/.ai-engineering/agents/verify-app.md
+++ b/src/ai_engineering/templates/.ai-engineering/agents/verify-app.md
@@ -36,6 +36,7 @@ End-to-end verification agent who confirms the application works correctly from 
 ## Referenced Skills
 
 - `skills/swe/debug.md` — for investigating failures found during verification.
+- `skills/swe/migration.md` — migration testing procedure.
 - `skills/swe/test-strategy.md` — test design principles.
 - `skills/workflows/commit.md` — commit workflow specification.
 - `skills/workflows/pr.md` — PR workflow specification.

--- a/src/ai_engineering/templates/.ai-engineering/skills/lifecycle/create-agent.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/lifecycle/create-agent.md
@@ -1,0 +1,155 @@
+# Create Agent
+
+## Purpose
+
+Definitive procedure for authoring and registering a new agent in the ai-engineering framework. Ensures every registration point is updated — canonical file, template mirror, all instruction files, counters, changelog, and cross-references — eliminating partial registration risk.
+
+## Trigger
+
+- Command: agent invokes create-agent skill or user requests adding a new agent.
+- Context: new agent persona is needed, complex multi-step task requires dedicated behavior protocol, governance content expansion.
+
+## Procedure
+
+### Phase 1: Design
+
+1. **Define agent identity** — determine name, identity, capabilities, and activation triggers.
+   - Name: kebab-case (`my-agent`).
+   - Identity: third-person description of WHO the agent is and their expertise (e.g., "Senior technical reviewer who...").
+   - Capabilities: concrete, actionable abilities as noun phrases.
+   - Activation: when/how users invoke or trigger this agent.
+
+2. **Check for duplicates** — verify no existing agent covers the same ground.
+   - Review agents listed in `.github/copilot-instructions.md` under `## Agents`.
+   - Search `.ai-engineering/agents/` for overlapping names or capabilities.
+   - If overlap exists, consider extending the existing agent instead.
+
+3. **Identify referenced skills and standards** — determine which skills and standards the agent will use.
+   - Map behavior steps to existing skills that provide procedures.
+   - Identify standards that govern the agent's domain.
+
+### Phase 2: Author
+
+4. **Create the canonical agent file** — write `.ai-engineering/agents/<name>.md`.
+   - Follow the agent template structure:
+
+     ```
+     # Agent Name
+     ## Identity
+     ## Capabilities
+     ## Activation
+     ## Behavior
+       1. **Step name** — description.
+       2. **Step name** — description.
+     ## Referenced Skills
+     ## Referenced Standards
+     ## Output Contract
+     ## Boundaries
+     ```
+
+   - Identity is written in **third person** (not "I am", but "Senior ... who ...").
+   - Capabilities are listed as **noun phrases** (not sentences).
+   - Behavior is a **numbered protocol** (typically 4-8 sequential steps).
+   - Referenced Skills and Referenced Standards are **separate sections**.
+   - Boundaries explicitly state what the agent does NOT do and escalation paths.
+   - References use relative paths from `.ai-engineering/` (e.g., `skills/swe/debug.md`).
+
+5. **Validate structure** — confirm the agent file contains all required sections.
+   - Identity: present, third-person, describes expertise and approach.
+   - Capabilities: bullet list of concrete abilities.
+   - Activation: when/how to trigger.
+   - Behavior: numbered protocol, sequential, 4-8 steps.
+   - Referenced Skills: at least one skill linked.
+   - Referenced Standards: at least one standard linked.
+   - Output Contract: measurable deliverables.
+   - Boundaries: scope limitations and escalation paths.
+
+### Phase 3: Mirror
+
+6. **Create the template mirror** — copy to `src/ai_engineering/templates/.ai-engineering/agents/<name>.md`.
+   - Content must be **byte-identical** to the canonical file.
+   - This is required by framework-contract: "Keep non-state files identical between canonical and template mirror."
+   - The installer uses `rglob("*")` to discover templates — no Python code changes needed.
+   - The `pyproject.toml` includes `src/ai_engineering/templates/**/*.md` — no build config changes needed.
+
+### Phase 4: Register
+
+7. **Add to all 6 instruction files** — insert a reference line under the `## Agents` section.
+   - Format: `- \`.ai-engineering/agents/<name>.md\` — one-line description.`
+   - Files to update (all 6, every time):
+
+     | # | File | Location |
+     |---|------|----------|
+     | 1 | `.github/copilot-instructions.md` | `## Agents` |
+     | 2 | `AGENTS.md` (repo root) | `## Agents` |
+     | 3 | `CLAUDE.md` (repo root) | `## Agents` |
+     | 4 | `src/ai_engineering/templates/project/copilot-instructions.md` | `## Agents` |
+     | 5 | `src/ai_engineering/templates/project/AGENTS.md` | `## Agents` |
+     | 6 | `src/ai_engineering/templates/project/CLAUDE.md` | `## Agents` |
+
+   - Insert alphabetically within the agents list for consistency.
+
+### Phase 5: Update Counters
+
+8. **Update agent count in product-contract** — edit `.ai-engineering/context/product/product-contract.md`.
+   - Update the `Active Objectives` line (e.g., "8 agents" → "9 agents").
+   - Update the `KPIs` table row for `Agent coverage` (e.g., "19 skills + 8 agents" → "19 skills + 9 agents").
+   - The count must match the actual number of agents listed in the instruction files.
+
+### Phase 6: Changelog
+
+9. **Add changelog entry** — edit `CHANGELOG.md`.
+   - Add under `## [Unreleased] → ### Added`.
+   - Format: `- <Agent name> agent for <purpose summary>.`
+
+### Phase 7: Cross-Reference
+
+10. **Update related skills** — add the new agent to `## References` of skills that the agent uses.
+    - If a skill's procedure is part of the agent's behavior, add a reference in the skill: `agents/<name>.md — agent that uses this skill.`
+
+11. **Update the agent's own references** — ensure `## Referenced Skills` and `## Referenced Standards` are complete.
+    - Every skill mentioned in the behavior protocol must appear in `## Referenced Skills`.
+    - Every standard governing the agent's domain must appear in `## Referenced Standards`.
+
+### Phase 8: Verify
+
+12. **Run the verification checklist** — confirm all registration points are complete.
+
+    | # | Check | How to verify |
+    |---|-------|---------------|
+    | 1 | Canonical file exists | `Test-Path .ai-engineering/agents/<name>.md` |
+    | 2 | Follows template structure | Has Identity, Capabilities, Activation, Behavior, Referenced Skills, Referenced Standards, Output Contract, Boundaries |
+    | 3 | Template mirror exists | `Test-Path src/ai_engineering/templates/.ai-engineering/agents/<name>.md` |
+    | 4 | Mirror is identical | `diff` canonical vs. mirror — 0 differences |
+    | 5 | Listed in all 6 files | `grep` for the agent path in each instruction file |
+    | 6 | Count matches | Count agents in instruction files = count in product-contract |
+    | 7 | CHANGELOG updated | Entry under `## [Unreleased] → ### Added` |
+    | 8 | Cross-references added | Related skills reference the new agent |
+
+## Output Contract
+
+- Canonical agent file at `.ai-engineering/agents/<name>.md` following template structure.
+- Identical template mirror at `src/ai_engineering/templates/.ai-engineering/agents/<name>.md`.
+- Reference entry in all 6 instruction files under the `## Agents` section.
+- Updated agent count in `product-contract.md` (objectives + KPIs).
+- Changelog entry in `CHANGELOG.md`.
+- Cross-references in related skills.
+- Verification checklist passes all 8 checks.
+
+## Governance Notes
+
+- No Python code changes are needed — installer, ownership, packaging, and maintenance all use glob-based discovery.
+- Template mirror must be byte-identical to canonical — never diverge.
+- Agent count in product-contract must match actual count listed in instruction files.
+- Agents are framework-managed content (`OwnershipLevel.FRAMEWORK_MANAGED`) — they follow the governed update flow.
+- Never create an agent that duplicates an existing agent's capabilities — extend instead.
+- Agent identity must be written in third person.
+- Agent references use paths relative to `.ai-engineering/` (e.g., `skills/swe/debug.md`, not `.ai-engineering/skills/swe/debug.md`).
+
+## References
+
+- `standards/framework/core.md` — governance structure, ownership model, lifecycle.
+- `context/product/framework-contract.md` — template packaging and replication rule.
+- `skills/swe/prompt-engineer.md` — prompt engineering for agent persona authoring.
+- `skills/lifecycle/create-skill.md` — companion procedure for skill registration.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting.

--- a/src/ai_engineering/templates/.ai-engineering/skills/lifecycle/create-skill.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/lifecycle/create-skill.md
@@ -1,0 +1,147 @@
+# Create Skill
+
+## Purpose
+
+Definitive procedure for authoring and registering a new skill in the ai-engineering framework. Ensures every registration point is updated — canonical file, template mirror, all instruction files, counters, changelog, and cross-references — eliminating partial registration risk.
+
+## Trigger
+
+- Command: agent invokes create-skill skill or user requests adding a new skill.
+- Context: new procedural skill is needed, existing gap identified, governance content expansion.
+
+## Procedure
+
+### Phase 1: Design
+
+1. **Define skill identity** — determine name, category, purpose, and trigger contexts.
+   - Name: kebab-case (`my-skill`).
+   - Category: `swe/`, `workflows/`, `quality/`, `lifecycle/`, `utils/`, or `validation/`.
+   - Purpose: one paragraph explaining what the skill does and when to use it.
+   - Trigger: command pattern and context scenarios.
+
+2. **Check for duplicates** — verify no existing skill covers the same ground.
+   - Review skills listed in `.github/copilot-instructions.md` under `## Skills`.
+   - Search `.ai-engineering/skills/` for overlapping names or purposes.
+   - If overlap exists, consider extending the existing skill instead.
+
+### Phase 2: Author
+
+3. **Create the canonical skill file** — write `.ai-engineering/skills/<category>/<name>.md`.
+   - Follow the skill template structure:
+
+     ```
+     # Skill Name
+     ## Purpose
+     ## Trigger
+     ## Procedure
+       ### Phase N: <Name>
+       N. **Step name** — description.
+     ## Output Contract
+     ## Governance Notes
+     ## References
+     ```
+
+   - Procedure steps are **numbered sequentially** across all phases.
+   - Use bold step names with em-dash: `**Step name** — description.`
+   - References use relative paths from `.ai-engineering/` (e.g., `standards/framework/core.md`).
+
+4. **Validate structure** — confirm the skill file contains all required sections.
+   - Purpose: present and concise.
+   - Trigger: command and context defined.
+   - Procedure: at least one phase with numbered steps.
+   - Output Contract: measurable deliverables listed.
+   - Governance Notes: relevant constraints from standards.
+   - References: at least one link to a related standard, skill, or agent.
+
+### Phase 3: Mirror
+
+5. **Create the template mirror** — copy to `src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md`.
+   - Content must be **byte-identical** to the canonical file.
+   - This is required by framework-contract: "Keep non-state files identical between canonical and template mirror."
+   - The installer uses `rglob("*")` to discover templates — no Python code changes needed.
+   - The `pyproject.toml` includes `src/ai_engineering/templates/**/*.md` — no build config changes needed.
+
+### Phase 4: Register
+
+6. **Add to all 6 instruction files** — insert a reference line under the correct subsection.
+   - Format: `- \`.ai-engineering/skills/<category>/<name>.md\` — one-line description.`
+   - Subsection mapping:
+     - `workflows/` → `### Workflows`
+     - `swe/` → `### SWE Skills`
+     - `lifecycle/` → `### Lifecycle Skills`
+     - `quality/` → `### Quality Skills`
+   - Files to update (all 6, every time):
+
+     | # | File | Location |
+     |---|------|----------|
+     | 1 | `.github/copilot-instructions.md` | `## Skills` → appropriate subsection |
+     | 2 | `AGENTS.md` (repo root) | `## Skills` → appropriate subsection |
+     | 3 | `CLAUDE.md` (repo root) | `## Skills` → appropriate subsection |
+     | 4 | `src/ai_engineering/templates/project/copilot-instructions.md` | `## Skills` → appropriate subsection |
+     | 5 | `src/ai_engineering/templates/project/AGENTS.md` | `## Skills` → appropriate subsection |
+     | 6 | `src/ai_engineering/templates/project/CLAUDE.md` | `## Skills` → appropriate subsection |
+
+   - Insert alphabetically within the subsection for consistency.
+
+### Phase 5: Update Counters
+
+7. **Update skill count in product-contract** — edit `.ai-engineering/context/product/product-contract.md`.
+   - Update the `Active Objectives` line (e.g., "19 skills" → "21 skills").
+   - Update the `KPIs` table row for `Agent coverage` (e.g., "19 skills + 8 agents" → "21 skills + 8 agents").
+   - The count must match the actual number of skills listed in the instruction files.
+
+### Phase 6: Changelog
+
+8. **Add changelog entry** — edit `CHANGELOG.md`.
+   - Add under `## [Unreleased] → ### Added`.
+   - Format: `- <Skill name> skill for <purpose summary>.`
+
+### Phase 7: Cross-Reference
+
+9. **Update related skills** — add the new skill to `## References` of skills that relate to it.
+   - If the new skill extends or complements an existing skill, add a reference in both directions.
+
+10. **Update related agents** — add the new skill to `## Referenced Skills` of agents that would use it.
+    - If an agent's behavior involves the new skill's procedure, add the reference.
+
+### Phase 8: Verify
+
+11. **Run the verification checklist** — confirm all registration points are complete.
+
+    | # | Check | How to verify |
+    |---|-------|---------------|
+    | 1 | Canonical file exists | `Test-Path .ai-engineering/skills/<category>/<name>.md` |
+    | 2 | Follows template structure | Has Purpose, Trigger, Procedure, Output Contract, Governance Notes, References |
+    | 3 | Template mirror exists | `Test-Path src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md` |
+    | 4 | Mirror is identical | `diff` canonical vs. mirror — 0 differences |
+    | 5 | Listed in all 6 files | `grep` for the skill path in each instruction file |
+    | 6 | Count matches | Count skills in instruction files = count in product-contract |
+    | 7 | CHANGELOG updated | Entry under `## [Unreleased] → ### Added` |
+    | 8 | Cross-references added | Related skills/agents reference the new skill |
+
+## Output Contract
+
+- Canonical skill file at `.ai-engineering/skills/<category>/<name>.md` following template structure.
+- Identical template mirror at `src/ai_engineering/templates/.ai-engineering/skills/<category>/<name>.md`.
+- Reference entry in all 6 instruction files under the correct subsection.
+- Updated skill count in `product-contract.md` (objectives + KPIs).
+- Changelog entry in `CHANGELOG.md`.
+- Cross-references in related skills and agents.
+- Verification checklist passes all 8 checks.
+
+## Governance Notes
+
+- No Python code changes are needed — installer, ownership, packaging, and maintenance all use glob-based discovery.
+- Template mirror must be byte-identical to canonical — never diverge.
+- Skill count in product-contract must match actual count listed in instruction files.
+- Skills are framework-managed content (`OwnershipLevel.FRAMEWORK_MANAGED`) — they follow the governed update flow.
+- Never create a skill that duplicates an existing skill's purpose — extend instead.
+- Skill references use paths relative to `.ai-engineering/` (e.g., `standards/framework/core.md`, not `.ai-engineering/standards/framework/core.md`).
+
+## References
+
+- `standards/framework/core.md` — governance structure, ownership model, lifecycle.
+- `context/product/framework-contract.md` — template packaging and replication rule.
+- `skills/swe/prompt-engineer.md` — prompt engineering for skill content authoring.
+- `skills/lifecycle/create-agent.md` — companion procedure for agent registration.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/changelog-documentation.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/changelog-documentation.md
@@ -1,0 +1,201 @@
+# Changelog Documentation
+
+## Purpose
+
+Transform technical git history into polished, user-friendly documentation that customers and developers actually understand. Produces two outputs: a structured CHANGELOG.md following Keep a Changelog format, and GitHub Release Notes with highlights, upgrade guides, and contributor acknowledgments. Emphasizes user-facing language — write what users can DO, not what you BUILT.
+
+## Trigger
+
+- Command: agent invokes changelog-documentation skill or user requests changelog/release notes generation.
+- Context: preparing a release, documenting recent changes, writing app store update descriptions, creating customer-facing product updates, transitioning `[Unreleased]` to a versioned release.
+
+## Procedure
+
+### Phase 1: Gather Changes
+
+1. **Identify scope** — determine the range of changes to document.
+   - Between two tags: `git log v1.0.0..v2.0.0 --oneline`.
+   - Since last release: `git log $(git describe --tags --abbrev=0)..HEAD --oneline`.
+   - Time-based: `git log --since="2 weeks ago" --oneline`.
+   - If active spec exists, cross-reference `specs/<active>/tasks.md` for completed work.
+
+2. **Collect raw material** — for each commit/PR, gather:
+   - Commit message (may follow `spec-NNN: Task X.Y — <description>` format).
+   - PR title and description (richer context than commit messages).
+   - Changed files and diff summary (`git diff --stat`).
+   - Linked issues or specs.
+
+3. **Assess impact** — classify each change by user impact:
+   - **User-visible**: changes behavior, adds capability, fixes a bug users experience.
+   - **Internal**: refactoring, test improvements, CI changes, dependency bumps.
+   - **Breaking**: changes API, removes features, requires migration.
+   - **Security**: fixes vulnerabilities, updates vulnerable dependencies.
+
+### Phase 2: Categorize
+
+4. **Map to Keep a Changelog categories** — assign each user-visible change to exactly one category:
+
+   | Category       | Rule                                                    | Example                                           |
+   |---------------|---------------------------------------------------------|---------------------------------------------------|
+   | **Added**      | Users couldn't do this before at all                    | "You can now export reports in bulk"              |
+   | **Changed**    | Existing capability is now better, faster, or different | "Dashboard loads 3× faster on large datasets"     |
+   | **Deprecated** | Still works, but will be removed — include timeline     | "REST API v1 will be removed in v3.0.0"           |
+   | **Removed**    | Previously available, now gone                          | "Removed support for Python 3.9"                  |
+   | **Fixed**      | Was broken, now works correctly                         | "Fixed an issue where CSV exports had missing columns" |
+   | **Security**   | Vulnerability fix — include CVE, impact, affected versions | "Fixed SQL injection in search (CVE-2025-12346)" |
+
+5. **Filter noise** — exclude from the changelog:
+   - Internal refactoring with no behavior change.
+   - Test additions/modifications (unless fixing a user-reported bug).
+   - CI/CD pipeline changes.
+   - Code style/formatting changes.
+   - Dependency bumps with no user-visible impact (unless security-related).
+   - Merge commits and branch housekeeping.
+
+### Phase 3: Transform to User-Facing Language
+
+6. **Rewrite entries** — convert technical commit messages to user-facing language:
+
+   ```
+   ❌ Technical (don't):
+   "Implemented batch processing queue for the export service"
+   "Refactored ReportExporter class to support pagination"
+   "Fixed bug in CSV serialization (PR #4521)"
+   "Various bug fixes and improvements"
+   "Updated dependencies"
+
+   ✅ User-facing (do):
+   "You can now export up to 10,000 rows at once from any report"
+   "Reports now load 3× faster when filtering large datasets"
+   "Fixed an issue where exported CSV files had missing columns"
+   ```
+
+7. **Apply language rules**:
+   - Start with "You can now..." / "X now..." / "Fixed an issue where..." / "Added support for...".
+   - Include the benefit, not just the mechanism.
+   - Use present tense.
+   - Strip internal references (PR numbers, file paths, branch names) — unless linking to issues.
+   - One changelog entry may represent many commits — group related work.
+   - Don't say "Updated X" without saying how — was it improved or fixed?
+
+### Phase 4: Format CHANGELOG.md
+
+8. **Write entries in `[Unreleased]`** — add entries to the appropriate category section:
+
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+   - Changelog documentation skill for generating user-friendly changelogs and release notes.
+
+   ### Fixed
+   - Fixed an issue where exported CSV files had missing column headers.
+   ```
+
+9. **Handle version transitions** — when cutting a release:
+   - Rename `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`.
+   - Create a new empty `[Unreleased]` section above it.
+   - Add comparison links in the footer:
+     ```markdown
+     [Unreleased]: https://github.com/owner/repo/compare/vX.Y.Z...HEAD
+     [X.Y.Z]: https://github.com/owner/repo/compare/vPREVIOUS...vX.Y.Z
+     ```
+   - Version number follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+     - MAJOR: breaking changes.
+     - MINOR: new features (backwards-compatible).
+     - PATCH: bug fixes.
+
+### Phase 5: Format Release Notes (Optional)
+
+10. **Produce GitHub Release Notes** — a standalone document for the GitHub release page:
+
+    ```markdown
+    # Release vX.Y.Z
+
+    **Release Date:** YYYY-MM-DD
+
+    ## Highlights
+
+    - **Feature Name** — 1-2 sentence user-facing summary.
+
+    ## What's New
+
+    ### Feature Name
+    Description of what users can now do and how.
+
+    ## Improvements
+
+    - Concise improvement entries.
+
+    ## Bug Fixes
+
+    - Fixed an issue where...
+
+    ## Breaking Changes
+
+    ### ⚠️ Change Title
+    **What changed:** Description.
+    **What you need to do:** Migration steps.
+    **Timeline:** Deprecation → removal dates.
+
+    ## Security Updates
+
+    - **SEVERITY**: Description (CVE-YYYY-NNNNN)
+      - Impact: ...
+      - Affected versions: ...
+      - Action: Upgrade immediately.
+
+    ## Upgrade Guide
+
+    Steps to upgrade from the previous version.
+
+    ## Contributors
+
+    Thanks to @contributor1, @contributor2.
+
+    **Full Changelog**: https://github.com/owner/repo/compare/vPREVIOUS...vX.Y.Z
+    ```
+
+### Phase 6: Quality Check
+
+11. **Validate against anti-patterns** — reject entries that match:
+    - "Various bug fixes and improvements" — list specific fixes or omit.
+    - "Updated dependencies" without stating user impact.
+    - "Updated X" without explaining how (improved? fixed? changed?).
+    - Internal jargon (class names, module paths, PR numbers in prose).
+    - Missing dates on releases.
+    - Breaking changes buried in the middle — must be prominent with `⚠️`.
+    - Security entries without CVE references, impact level, or affected versions.
+    - Vague language ("improved performance" without metrics or context).
+
+12. **Cross-check completeness**:
+    - Every user-visible change from the git range is represented.
+    - Breaking changes have migration guidance.
+    - Deprecated features include removal timeline.
+    - Security entries include severity, affected versions, and required action.
+    - Categories are mutually exclusive — each entry appears in exactly one.
+
+## Output Contract
+
+- **CHANGELOG.md entries**: new entries in `[Unreleased]` (or versioned section) following Keep a Changelog format.
+- **Release Notes** (when requested): standalone GitHub Release Notes document with highlights, upgrade guide, breaking changes, and contributors.
+- **Quality check results**: list of anti-patterns checked with pass/fail status.
+
+## Governance Notes
+
+- CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format — no exceptions.
+- Version numbers follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Breaking changes must be documented prominently — never buried in a list.
+- Security entries must reference CVEs where applicable and include impact assessment.
+- Changelog updates go through PR — never direct commit to protected branches.
+- Internal-only changes (refactoring, tests, CI) are excluded from the changelog unless they affect user behavior.
+- Don't manually edit auto-generated tool output without review — generated changelogs are a starting point, not final output.
+- Each entry must be user-facing: benefit-first, present tense, no internal references.
+
+## References
+
+- `standards/framework/core.md` — governance structure and non-negotiables.
+- `context/product/framework-contract.md` — release model and versioning.
+- `skills/swe/pr-creation.md` — PR workflow (changelog updates go through PRs).
+- `skills/swe/security-review.md` — security entry format and CVE handling.
+- `skills/swe/migration.md` — breaking changes documentation requirements.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/code-review.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/code-review.md
@@ -63,4 +63,8 @@ Deep code review skill covering security, quality, performance, and maintainabil
 - `standards/framework/quality/core.md` — severity policy and quality gates.
 - `standards/framework/quality/python.md` — Python-specific checks.
 - `standards/framework/stacks/python.md` — code patterns.
+- `skills/swe/security-review.md` — detailed security review procedure.
+- `skills/swe/test-strategy.md` — test assessment criteria.
+- `skills/swe/performance-analysis.md` — performance evaluation procedure.
 - `agents/principal-engineer.md` — agent that performs deep reviews.
+- `agents/code-simplifier.md` — agent that uses code quality criteria.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/debug.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/debug.md
@@ -54,3 +54,4 @@ Systematic diagnosis skill for identifying, isolating, and fixing bugs. Follows 
 
 - `standards/framework/quality/python.md` — test and coverage requirements.
 - `agents/debugger.md` — agent that uses this skill systematically.
+- `agents/verify-app.md` — agent that uses debug for investigating verification failures.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/dependency-update.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/dependency-update.md
@@ -57,3 +57,4 @@ Structured dependency update skill: audit current dependencies, update safely, t
 - `standards/framework/stacks/python.md` — required tooling.
 - `standards/framework/quality/core.md` — security gate.
 - `standards/framework/core.md` — risk acceptance policy.
+- `agents/security-reviewer.md` — agent that assesses dependency security.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/doc-writer.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/doc-writer.md
@@ -1,0 +1,287 @@
+# Doc Writer
+
+## Purpose
+
+Transform codebase knowledge into polished, user-facing open-source documentation that end users actually understand and appreciate. Reads code, configuration, `.ai-engineering` context (specs, learnings, product-contract), and project metadata to produce README.md, CONTRIBUTING.md, docs/ site content, Wiki pages, and CODE_OF_CONDUCT.md. Writes what users can DO, not what you BUILT — translating technical implementation into benefits, capabilities, and clear instructions.
+
+## Trigger
+
+- Command: agent invokes doc-writer skill or user requests project documentation.
+- Context: creating or updating README.md, writing getting-started guides, producing contribution guidelines, generating docs/ site content, building Wiki articles, onboarding new users, preparing a project for open-source release.
+
+## Procedure
+
+### Phase 1: Codebase Discovery
+
+Autonomously scan the project to build a complete mental model before writing a single line of documentation.
+
+1. **Read project identity** — understand what the project is and who it serves.
+   - Read `context/product/product-contract.md` — goals, KPIs, release status.
+   - Read `context/product/framework-contract.md` — identity, personas, roadmap.
+   - Read `pyproject.toml` — project name, version, description, entry points, dependencies.
+   - Read `__version__.py` or equivalent — current version string.
+
+2. **Read project context** — understand current scope and institutional knowledge.
+   - Read `context/specs/_active.md` and the active spec's `spec.md` — current scope, decisions, what's in/out.
+   - Read `context/learnings.md` — retained institutional knowledge, past decisions.
+   - Scan `standards/framework/core.md` — governance model (for understanding, not for user docs).
+
+3. **Scan source code** — identify user-facing features and capabilities.
+   - Read CLI entry points (`cli.py`, `cli_factory.py`, or equivalent) — available commands and options.
+   - Scan feature modules in `src/` — public API surface, key classes, exported functions.
+   - Read configuration files — what users can configure and how.
+   - Identify install method — pip, uv, package manager, from source.
+
+4. **Produce Project Knowledge Map** — structured internal artifact (not published):
+
+   | Dimension         | What to capture                                      |
+   |-------------------|------------------------------------------------------|
+   | **Identity**      | Name, tagline, one-sentence value proposition        |
+   | **Audience**      | Who uses this and why                                 |
+   | **Install**       | How to install (pip, uv, from source)                 |
+   | **Quick start**   | Minimum steps to first useful result                  |
+   | **Features**      | User-facing capabilities (not internal modules)       |
+   | **Configuration** | What can be customized and how                        |
+   | **Architecture**  | Simplified view — only what users need to understand  |
+   | **Ecosystem**     | Related tools, integrations, plugins                  |
+
+### Phase 2: Documentation Standards and Structuring
+
+Establish writing standards and document architecture before drafting.
+
+5. **Apply voice and tone rules** — every document follows these conventions:
+   - Address the reader as "you." Use active voice and present tense.
+   - Professional, friendly, and direct tone — not corporate, not casual.
+   - Use simple vocabulary. Avoid jargon, slang, and marketing hype.
+   - Write for a global audience — standard US English, no idioms or cultural references.
+   - Be clear about requirements ("must") vs. recommendations ("we recommend"). Avoid "should."
+   - Use contractions (don't, it's). Avoid "please" and anthropomorphism.
+   - Start instructions with imperative verbs: "Run...", "Create...", "Add...".
+
+6. **Apply formatting rules** — consistent structure across all artifacts:
+   - ATX-style headers (`#`, `##`, `###`). Sentence case for headings.
+   - Every heading followed by at least one introductory paragraph before lists or sub-headings.
+   - Numbered lists for sequential steps. Bullet lists for non-sequential items.
+   - Code blocks with language tags (` ```bash `, ` ```python `, ` ```yaml `).
+   - Bold for UI elements and emphasis. Backticks for filenames, commands, API elements.
+   - Descriptive link text — never "click here." Links must make sense out of context.
+   - Meaningful names in examples — never "foo", "bar", or "test123."
+   - Alt text for all images. Lowercase hyphenated filenames for media.
+
+7. **Select and outline artifacts** — determine which documents to produce:
+
+   | Artifact              | When to produce                                           |
+   |-----------------------|-----------------------------------------------------------|
+   | **README.md**         | Always — the project's front door                         |
+   | **CONTRIBUTING.md**   | When the project accepts external contributions           |
+   | **docs/ site content**| When the project has enough features to warrant guides    |
+   | **Wiki pages**        | When conceptual/architectural guides complement docs/     |
+   | **CODE_OF_CONDUCT.md**| When the project is published as open-source              |
+
+   For each selected artifact, generate a **section outline** with placeholder headings. Present the outlines to the user for validation before writing.
+
+### Phase 3: Co-Authoring and Drafting
+
+Iteratively build each document section by section. Never dump a full draft — collaborate through structured refinement.
+
+8. **For each artifact, work section by section**:
+
+   1. **Clarify** — ask 3-5 targeted questions about what to include in this section.
+   2. **Brainstorm** — propose 5-10 content options for the section, drawing from the Project Knowledge Map.
+   3. **Curate** — user indicates what to keep, remove, or combine (shorthand is fine: "keep 1,3,5 — remove 2,4").
+   4. **Draft** — write the section based on curated selections. Create or update the file directly.
+   5. **Iterate** — user reviews and provides feedback. Apply surgical edits — never reprint entire documents for small changes.
+
+   Repeat steps 1-5 until the user approves the section, then move to the next.
+
+9. **Track style preferences** — as the user provides feedback across sections, learn and apply their preferences to subsequent sections. Common patterns to track:
+   - Preferred level of technical detail.
+   - Tone adjustments (more formal, more casual, more concise).
+   - Structural preferences (more examples, fewer tables, shorter paragraphs).
+
+10. **Apply artifact-specific structure** — each document type has its own anatomy:
+
+#### README.md
+
+```markdown
+# Project Name
+
+Brief description — what it does, who it's for, why it matters.
+
+## Features
+
+Key capabilities as a bullet list — user benefits, not implementation details.
+
+## Quick start
+
+### Prerequisites
+
+What users need before installing.
+
+### Installation
+
+Exact install commands (pip, uv, from source).
+
+### First use
+
+Minimum steps to a first useful result.
+
+## Usage
+
+Expanded usage guide — common workflows, CLI commands, configuration.
+
+## Configuration
+
+Available options, environment variables, config files.
+
+## Architecture
+
+Simplified view — only what helps users understand the project.
+Not internal module structure — user-facing concepts.
+
+## Documentation
+
+Links to docs/, Wiki, API reference.
+
+## Contributing
+
+Brief mention + link to CONTRIBUTING.md.
+
+## License
+
+License type and link.
+```
+
+#### CONTRIBUTING.md
+
+```markdown
+# Contributing to Project Name
+
+Thank your contributors. Set the tone for collaboration.
+
+## Development setup
+
+Exact steps: clone, install dependencies, verify setup works.
+
+## Code style
+
+Linting, formatting, type checking tools and commands.
+
+## Testing
+
+How to run tests. Coverage expectations.
+
+## Pull request process
+
+Branch naming, commit conventions, PR template, review process.
+
+## Reporting issues
+
+How to report bugs. What to include.
+
+## Code of conduct
+
+Link to CODE_OF_CONDUCT.md.
+```
+
+#### docs/ site content
+
+- **Getting started guide**: prerequisites, installation, first use, next steps.
+- **Feature guides**: one per major feature — what it does, how to use it, examples.
+- **Configuration reference**: all options, defaults, environment variables.
+- **FAQ / Troubleshooting**: common questions and known issues.
+
+#### Wiki pages
+
+- **Conceptual guides**: architecture for users, design philosophy, integration patterns.
+- **How-to articles**: task-oriented guides for specific use cases.
+- **Glossary**: project-specific terminology.
+
+#### CODE_OF_CONDUCT.md
+
+- Adopt [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as default.
+- Customize: project name, contact info, enforcement details.
+- Keep it standard — deviations from Contributor Covenant must be justified.
+
+### Phase 4: Reader Testing
+
+Validate documentation quality by testing with a fresh perspective.
+
+11. **Predict user questions** — generate 5-10 questions a new user would ask:
+    - "How do I install this?"
+    - "What does this project do?"
+    - "How do I configure X?"
+    - "What are the prerequisites?"
+    - "How do I report a bug?"
+
+12. **Test with sub-agent** — invoke a fresh agent (no conversation history) with only the document content and one question at a time.
+    - Does the agent find the answer from the docs alone?
+    - Is anything ambiguous or assumed?
+    - Are there comprehension gaps?
+
+13. **Validate technical accuracy**:
+    - Are install instructions actually runnable?
+    - Are code examples syntactically valid?
+    - Do all links resolve?
+    - Does the documented version match `__version__.py`?
+    - Are CLI commands and flags accurate against the actual implementation?
+
+14. **Fix gaps** — for any failing tests, loop back to Phase 3 step 5 for the affected section. Don't rewrite from scratch — apply surgical fixes.
+
+### Phase 5: Ship and Integrate
+
+Finalize and position documentation in the project.
+
+15. **Final coherence review** — read all artifacts end-to-end and check:
+    - Consistent terminology across all documents (same name for same concept everywhere).
+    - No contradictions between README, docs/, and CONTRIBUTING.
+    - Cross-references work (README links to CONTRIBUTING, docs links to README, etc.).
+    - No orphaned sections or dead-end flows.
+
+16. **Version alignment** — ensure documentation reflects the current state:
+    - Version string matches `__version__.py` or `pyproject.toml`.
+    - Features documented match features that actually exist in the current release.
+    - Roadmap or "coming soon" items are clearly marked as such.
+
+17. **Add navigation** — connect all documentation artifacts:
+    - README → docs/, CONTRIBUTING.md, CODE_OF_CONDUCT.md.
+    - docs/ pages → back to README, between guides.
+    - CONTRIBUTING.md → CODE_OF_CONDUCT.md.
+
+18. **Recommend next steps** — suggest improvements beyond the current scope:
+    - Add documentation CI (link checking, markdown linting).
+    - Set up a docs site (Nextra, MkDocs, Docusaurus) if `docs/` content warrants it.
+    - Add documentation updates to the PR template checklist.
+    - Schedule periodic documentation review (quarterly).
+
+## Output Contract
+
+- One or more documentation files from the supported set: README.md, CONTRIBUTING.md, docs/*, Wiki pages, CODE_OF_CONDUCT.md.
+- Each file follows the voice, tone, and formatting standards from Phase 2.
+- Every claim is traceable to code, configuration, or `context/` content — no hallucinated features.
+- Reader Testing passes: a fresh agent can answer user questions from the docs alone.
+- Install instructions are verified or explicitly marked as untested.
+- All cross-references and links resolve.
+
+## Governance Notes
+
+- Never expose internal governance details (`.ai-engineering/` internals, state files, audit logs, decision store) in user-facing documentation — describe user-facing behavior only.
+- Never fabricate features, commands, or configuration options — all documented capabilities must be verifiable in source code.
+- Never overwrite team-managed or project-managed content without user confirmation.
+- Respect the framework-contract's identity: use the correct project name, positioning, and value proposition from `context/product/product-contract.md`.
+- Security-sensitive information (API keys, secrets handling, credentials) must reference the security review skill before documenting.
+- Install and usage instructions must be tested against the actual codebase or explicitly marked as untested.
+- Breaking changes and deprecations must be prominent, never buried — mirror the changelog-documentation skill's conventions.
+- Code examples in documentation must be syntactically valid and idiomatic.
+
+## References
+
+- `context/product/product-contract.md` — source of truth for project identity and positioning.
+- `context/product/framework-contract.md` — roadmap, personas, value proposition.
+- `context/learnings.md` — institutional knowledge that may inform documentation content.
+- `standards/framework/core.md` — governance model (for understanding internal structure, not for user docs).
+- `skills/swe/changelog-documentation.md` — user-facing language conventions and anti-patterns.
+- `skills/swe/code-review.md` — quality patterns for code examples in documentation.
+- `skills/swe/prompt-engineer.md` — Chain of Density for content compression and summaries.
+- `skills/swe/security-review.md` — security assessment before documenting sensitive features.
+- `agents/codebase-mapper.md` — complementary agent for deep codebase understanding.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/performance-analysis.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/performance-analysis.md
@@ -59,3 +59,4 @@ Identify and resolve performance bottlenecks through systematic profiling, measu
 - `standards/framework/stacks/python.md` — code patterns.
 - `standards/framework/quality/python.md` — complexity thresholds.
 - `skills/swe/python-mastery.md` — performance optimization domain.
+- `agents/principal-engineer.md` — agent that evaluates performance.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/pr-creation.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/pr-creation.md
@@ -57,5 +57,7 @@ Craft well-structured pull requests with clear titles, descriptive bodies, break
 ## References
 
 - `skills/workflows/pr.md` — full `/pr` workflow procedure.
+- `skills/swe/changelog-documentation.md` — changelog entry formatting for PRs.
 - `standards/framework/quality/core.md` — PR quality gates.
 - `standards/framework/core.md` — command governance.
+- `standards/framework/stacks/python.md` — Python checks in PR checklist.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/prompt-engineer.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/prompt-engineer.md
@@ -144,4 +144,6 @@ For complex, multi-type tasks, blend frameworks:
 - `standards/framework/core.md` — non-negotiables that prompts must enforce.
 - `context/product/framework-contract.md` — product principles and context efficiency.
 - `agents/principal-engineer.md` — example of a well-structured agent persona.
+- `skills/lifecycle/create-skill.md` — definitive procedure for skill registration.
+- `skills/lifecycle/create-agent.md` — definitive procedure for agent registration.
 - All agent and skill templates defined in `context/specs/001-rewrite-v2/plan.md`.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/python-mastery.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/python-mastery.md
@@ -221,3 +221,7 @@ Before committing, verify:
 - `skills/swe/test-strategy.md` — testing details.
 - `skills/swe/performance-analysis.md` — performance deep-dive.
 - `skills/swe/security-review.md` — security-specific patterns.
+- `agents/architect.md` — agent that uses design patterns domain.
+- `agents/code-simplifier.md` — agent that uses Pythonic patterns.
+- `agents/codebase-mapper.md` — agent that uses Python module system domain.
+- `agents/principal-engineer.md` — agent that uses Python patterns for review.

--- a/src/ai_engineering/templates/.ai-engineering/skills/swe/test-strategy.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/swe/test-strategy.md
@@ -62,3 +62,6 @@ Define what to test, how to structure tests, and how to achieve meaningful cover
 - `standards/framework/stacks/python.md` — testing patterns.
 - `standards/framework/quality/python.md` — coverage policy.
 - `standards/framework/quality/core.md` — quality gates.
+- `agents/debugger.md` — agent that writes regression tests.
+- `agents/principal-engineer.md` — agent that assesses test completeness.
+- `agents/verify-app.md` — agent that follows test design principles.

--- a/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
@@ -41,3 +41,9 @@ Fallbacks:
 - Do not suggest `--no-verify`.
 - Do not force push.
 - Do not bypass mandatory checks.
+
+## References
+
+- `skills/workflows/commit.md` — primary consumer of git helper procedures.
+- `skills/workflows/pr.md` — PR workflow using git operations.
+- `standards/framework/core.md` — protected branch rules and enforcement.

--- a/src/ai_engineering/templates/.ai-engineering/skills/utils/platform-detection.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/utils/platform-detection.md
@@ -38,3 +38,8 @@ az account show
 
 - GitHub is runtime priority in current phase.
 - Azure DevOps constraints must remain represented in manifest schema.
+
+## References
+
+- `skills/validation/install-readiness.md` — uses platform detection for readiness checks.
+- `standards/framework/core.md` — provider support model.

--- a/src/ai_engineering/templates/.ai-engineering/skills/validation/install-readiness.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/validation/install-readiness.md
@@ -36,3 +36,9 @@ Validate that ai-engineering is operational after install/update.
 - machine-readable JSON summary for automation,
 - concise human-readable remediation steps,
 - no bypass recommendations.
+
+## References
+
+- `skills/utils/platform-detection.md` — provider and tooling detection.
+- `standards/framework/core.md` — enforcement requirements.
+- `agents/verify-app.md` — verification agent that uses readiness checks.

--- a/src/ai_engineering/templates/.ai-engineering/skills/workflows/commit.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/workflows/commit.md
@@ -47,3 +47,4 @@ Follow steps 1–5 above. Skip step 6.
 - `standards/framework/stacks/python.md` — Python-specific checks.
 - `standards/framework/quality/core.md` — gate structure (pre-commit gate).
 - `skills/workflows/acho.md` — alias workflow.
+- `agents/verify-app.md` — agent that validates commit workflow execution.

--- a/src/ai_engineering/templates/.ai-engineering/skills/workflows/pr.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/workflows/pr.md
@@ -62,3 +62,5 @@ Execute the `/pr` governed workflow: stage, commit, push, create a pull request,
 - `standards/framework/quality/core.md` — gate structure (pre-push + PR gates).
 - `skills/workflows/commit.md` — shared pre-commit steps.
 - `skills/workflows/acho.md` — alias workflow.
+- `skills/swe/pr-creation.md` — PR structure and formatting.
+- `agents/verify-app.md` — agent that validates PR workflow execution.

--- a/src/ai_engineering/templates/project/AGENTS.md
+++ b/src/ai_engineering/templates/project/AGENTS.md
@@ -35,6 +35,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -45,6 +46,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 

--- a/src/ai_engineering/templates/project/CLAUDE.md
+++ b/src/ai_engineering/templates/project/CLAUDE.md
@@ -35,6 +35,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -45,6 +46,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 

--- a/src/ai_engineering/templates/project/copilot-instructions.md
+++ b/src/ai_engineering/templates/project/copilot-instructions.md
@@ -27,6 +27,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 - `.ai-engineering/skills/swe/debug.md` — systematic diagnosis.
 - `.ai-engineering/skills/swe/refactor.md` — safe refactoring.
+- `.ai-engineering/skills/swe/changelog-documentation.md` — changelog documentation.
 - `.ai-engineering/skills/swe/code-review.md` — code review checklist.
 - `.ai-engineering/skills/swe/test-strategy.md` — test design.
 - `.ai-engineering/skills/swe/architecture-analysis.md` — architecture review.
@@ -37,6 +38,12 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/swe/migration.md` — migration planning.
 - `.ai-engineering/skills/swe/prompt-engineer.md` — prompt engineering frameworks.
 - `.ai-engineering/skills/swe/python-mastery.md` — comprehensive Python patterns.
+- `.ai-engineering/skills/swe/doc-writer.md` — open-source documentation generation.
+
+### Lifecycle Skills
+
+- `.ai-engineering/skills/lifecycle/create-agent.md` — agent authoring and registration procedure.
+- `.ai-engineering/skills/lifecycle/create-skill.md` — skill authoring and registration procedure.
 
 ### Quality Skills
 


### PR DESCRIPTION
## Summary

Spec 002 formalizes 4 new skills, adds bidirectional cross-references across 25+ governance files, and introduces the `skills/lifecycle/` category for framework lifecycle operations.

## Changes

### New Skills (4)
- `swe/changelog-documentation.md` — changelog and release notes generation
- `swe/doc-writer.md` — open-source documentation from codebase knowledge
- `lifecycle/create-skill.md` — definitive skill authoring and registration procedure
- `lifecycle/create-agent.md` — definitive agent authoring and registration procedure

### Lifecycle Category
- Created `skills/lifecycle/` directory (canonical + mirror)
- Moved `create-skill` and `create-agent` from `swe/` to `lifecycle/`
- Added `### Lifecycle Skills` subsection to all 6 instruction files
- Updated `create-skill.md` procedure to include `lifecycle/` as valid category

### Cross-Reference Hardening
- 5 agents updated with missing skill/standard refs
- 8 SWE skills updated with agent cross-refs
- 2 utility skills, 1 validation skill, 2 workflow skills updated with consumer refs
- All changes applied to both canonical and template mirror copies (22 pairs verified byte-identical)

### Counters and Tracking
- Product-contract: 21 skills, 8 agents
- CHANGELOG: 4 new skill entries
- Spec 002: complete lifecycle (spec.md, plan.md, tasks.md, done.md)

## Verification
- [x] 22 canonical/mirror pairs verified byte-identical
- [x] 0 stale swe/create-* references in instruction files
- [x] Product-contract counter matches instruction file listing (21 skills)
- [x] All 6 instruction files have Lifecycle Skills subsection

## Spec Reference
- `spec.md`: .ai-engineering/context/specs/002-cross-ref-hardening/spec.md
- `done.md`: .ai-engineering/context/specs/002-cross-ref-hardening/done.md