### PR TITLE
docs: add open-source documentation baseline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<https://github.com/arcasilesgroup/ai-engineering/issues>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,145 @@
+# Contributing to ai-engineering
+
+Thank you for your interest in contributing. This guide covers everything you need to get started — from setting up a development environment to submitting a pull request.
+
+## Development setup
+
+Clone the repository and install the project with development dependencies:
+
+```bash
+git clone https://github.com/arcasilesgroup/ai-engineering.git
+cd ai-engineering
+```
+
+With `uv` (recommended):
+
+```bash
+uv sync --all-extras
+```
+
+With `pip`:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Verify the installation:
+
+```bash
+ai-eng version
+```
+
+## Code style
+
+This project uses strict automated tooling. All checks run locally through git hooks — you don't need to remember them manually.
+
+**Formatting and linting** — `ruff` with a 100-character line length:
+
+```bash
+ruff format src/ tests/
+ruff check src/ tests/ --fix
+```
+
+**Type checking** — `ty`:
+
+```bash
+ty check src/
+```
+
+**Docstrings** — Google-style on all public functions and classes.
+
+**Type hints** — required on all public APIs. Use `from __future__ import annotations` at the top of every module.
+
+**Imports** — sorted by `ruff` with `isort` rules. First-party package: `ai_engineering`.
+
+## Testing
+
+Run the full test suite with:
+
+```bash
+pytest
+```
+
+This automatically runs with verbose output and coverage reporting (configured in `pyproject.toml`).
+
+**Test conventions**:
+
+- Follow the AAA pattern (Arrange, Act, Assert).
+- Name tests as `test_<unit>_<scenario>_<expected_outcome>`.
+- Use `tmp_path` for any filesystem operations.
+- Aim for ≥ 80% coverage (≥ 90% for governance-critical modules).
+- Tests live in `tests/` with `unit/`, `integration/`, and `e2e/` subdirectories.
+
+Run a specific test file:
+
+```bash
+pytest tests/unit/test_installer.py
+```
+
+## Pull request process
+
+1. Create a feature branch from `main`:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. Make your changes. Git hooks enforce quality gates automatically:
+   - **Pre-commit** — formatting (`ruff format`), linting (`ruff check`), secret scanning (`gitleaks`).
+   - **Commit-msg** — validates the commit message format.
+   - **Pre-push** — static analysis (`semgrep`), dependency audit (`pip-audit`), tests (`pytest`), type-check (`ty`).
+
+3. Push your branch and open a pull request against `main`.
+
+4. Include a clear description of what you changed and why. Reference any related issues.
+
+5. All PRs use squash merge with branch deletion.
+
+**Commit message format** — use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short description
+
+Optional body explaining what and why.
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+## Reporting issues
+
+**Bug reports** — include the following:
+
+- What you expected to happen.
+- What actually happened.
+- Steps to reproduce (minimal example preferred).
+- Your environment: OS, Python version, ai-engineering version (`ai-eng version`).
+
+**Feature requests** — describe the problem you want to solve and your proposed approach. Open an issue before starting significant work so we can discuss the design.
+
+## Project structure
+
+```
+src/ai_engineering/
+├── cli.py                # CLI entry point
+├── cli_factory.py        # Typer app factory
+├── paths.py              # Path resolution utilities
+├── __version__.py        # Version string
+├── cli_commands/         # Command groups (core, gate, maintenance, skills, stack_ide)
+├── commands/             # Workflow building blocks (commit, PR, acho)
+├── installer/            # Framework bootstrap and stack/IDE operations
+├── updater/              # Ownership-safe framework updates
+├── doctor/               # Diagnostics and remediation
+├── hooks/                # Git hook generation and installation
+├── policy/               # Quality gate execution
+├── state/                # Pydantic models, JSON/NDJSON I/O, decision logic
+├── git/                  # Shared git operations
+├── pipeline/             # CI/CD compliance scanning and injection
+├── skills/               # Remote skill source management
+├── maintenance/          # Health reports and branch cleanup
+├── detector/             # Tool readiness detection
+└── templates/            # Bundled governance and IDE templates
+```
+
+## Code of conduct
+
+This project follows the Contributor Covenant Code of Conduct. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details.

--- a/README.md
+++ b/README.md
@@ -2,44 +2,193 @@
 
 Open-source AI governance framework for secure, practical software delivery.
 
-## Status
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Python: 3.11+](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 
-- Contract baseline and CLI governance workflows are implemented.
-- `.ai-engineering/` is the canonical governance root.
+ai-engineering gives your repository a complete governance layer — quality gates, security scanning, risk lifecycle management, and AI-agent guidance — installed with a single command. It works locally through git hooks so every commit is checked before it leaves your machine.
 
-## Core Principles
+## Features
 
-- simple, efficient, practical, robust, secure.
-- quality and security by default.
-- lifecycle enforcement: Discovery -> Architecture -> Planning -> Implementation -> Review -> Verification -> Testing -> Iteration.
-- strict local enforcement with no policy drift.
+**Governance bootstrap** — Run `ai-eng install` to scaffold a `.ai-engineering/` governance root in any project. The framework creates standards, state files, and git hooks in one step.
 
-## Command Contract
+**Automatic quality gates** — Git hooks run `ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`, and `pytest` at the right stage (pre-commit, commit-msg, pre-push). No CI dependency for basic quality.
 
-- `/commit` -> stage + commit + push current branch
-- `/commit --only` -> stage + commit
-- `/pr` -> stage + commit + push + create PR + enable auto-complete (`--auto --squash --delete-branch`)
-- `/pr --only` -> create PR; warns if branch is unpushed and proposes auto-push
-- `/acho` -> stage + commit + push current branch
-- `/acho pr` -> stage + commit + push + create PR + enable auto-complete (`--auto --squash --delete-branch`)
-- `ai stack add/remove/list <stack>` -> manage stack templates with safe cleanup semantics
-- `ai ide add/remove/list <ide>` -> manage IDE instruction templates with safe cleanup semantics
+**Risk acceptance lifecycle** — Accept, renew, resolve, and revoke security risks with severity-based expiry. Expired risks block pushes until you remediate or renew.
 
-## Tooling Baseline
+**Stack and IDE management** — Add technology stacks (e.g. `python`) and IDE integrations (e.g. `vscode`) to generate tailored instruction templates for AI coding agents.
 
-- package/runtime: `uv`
-- lint/format: `ruff`
-- type checking: `ty`
-- dependency vulnerability checks: `pip-audit`
-- mandatory security checks: `gitleaks`, `semgrep`
+**Framework updates** — Update framework-managed files without touching your team or project content. Dry-run by default so you can review before applying.
 
-## Governance Docs
+**Doctor diagnostics** — Diagnose framework health: validates layout, state integrity, git hooks, and tool availability. Auto-fix hooks and install missing tools.
 
-- Product vision: `.ai-engineering/context/product/vision.md`
-- Architecture: `.ai-engineering/context/delivery/architecture.md`
-- Planning: `.ai-engineering/context/delivery/planning.md`
-- Backlog: `.ai-engineering/context/backlog/`
+**Maintenance and reporting** — Generate health reports, clean stale branches, check risk status, and scan CI/CD pipelines for risk governance gates.
+
+**Remote skills** — Sync curated skill libraries from trusted sources with checksum verification and offline fallback.
+
+## Quick start
+
+### Prerequisites
+
+- Python 3.11 or later
+- `uv` (recommended) or `pip`
+- Git
+
+### Installation
+
+```bash
+pip install ai-engineering
+```
+
+Or with `uv`:
+
+```bash
+uv pip install ai-engineering
+```
+
+### First use
+
+Bootstrap governance in your project:
+
+```bash
+cd your-project
+ai-eng install .
+```
+
+This creates the `.ai-engineering/` governance root, installs git hooks, and generates state files. Your next commit automatically runs quality gates.
+
+To install with a specific technology stack and IDE:
+
+```bash
+ai-eng install . --stack python --ide vscode
+```
+
+Verify the installation:
+
+```bash
+ai-eng doctor
+```
+
+## Usage
+
+### Core commands
+
+```bash
+ai-eng install [TARGET]          # Bootstrap governance framework
+ai-eng update [TARGET]           # Preview framework file updates (dry-run)
+ai-eng update [TARGET] --apply   # Apply framework file updates
+ai-eng doctor [TARGET]           # Diagnose framework health
+ai-eng doctor --fix-hooks        # Reinstall git hooks
+ai-eng doctor --fix-tools        # Install missing tools
+ai-eng version                   # Show installed version
+```
+
+### Stack and IDE management
+
+```bash
+ai-eng stack add python          # Add a technology stack
+ai-eng stack remove python       # Remove a technology stack
+ai-eng stack list                # List active stacks
+
+ai-eng ide add vscode            # Add IDE integration
+ai-eng ide remove vscode         # Remove IDE integration
+ai-eng ide list                  # List active IDEs
+```
+
+### Quality gates
+
+Git hooks invoke these automatically, but you can run them manually:
+
+```bash
+ai-eng gate pre-commit           # Format, lint, gitleaks
+ai-eng gate commit-msg .git/COMMIT_EDITMSG  # Commit message validation
+ai-eng gate pre-push             # Semgrep, pip-audit, tests, type-check
+ai-eng gate risk-check           # Check risk acceptance status
+ai-eng gate risk-check --strict  # Fail on expiring risks too
+```
+
+### Skills management
+
+```bash
+ai-eng skill list                # List remote skill sources
+ai-eng skill sync                # Sync from remote sources
+ai-eng skill sync --offline      # Use cached content only
+ai-eng skill add <url>           # Add a remote skill source
+ai-eng skill remove <url>        # Remove a remote skill source
+```
+
+### Maintenance
+
+```bash
+ai-eng maintenance report                  # Generate health report
+ai-eng maintenance pr                      # Generate report + create PR
+ai-eng maintenance branch-cleanup          # Clean merged local branches
+ai-eng maintenance branch-cleanup --dry-run  # Preview without deleting
+ai-eng maintenance risk-status             # Show risk acceptance status
+ai-eng maintenance pipeline-compliance     # Scan pipelines for risk gates
+```
+
+## Configuration
+
+ai-engineering uses a content-first approach — configuration lives in the `.ai-engineering/` directory as Markdown, YAML, and JSON files.
+
+**At install time**, you control which stacks and IDEs to enable via `--stack` and `--ide` flags. You can add or remove them later with `ai-eng stack` and `ai-eng ide` commands.
+
+**Updates** are dry-run by default. Run `ai-eng update` to preview changes, then `ai-eng update --apply` to write them. The updater only touches framework-managed files — your team and project content is never overwritten.
+
+**Doctor remediation** gives you `--fix-hooks` to reinstall git hooks and `--fix-tools` to auto-install missing Python tools (`ruff`, `ty`, `gitleaks`, `semgrep`, `pip-audit`).
+
+**Risk lifecycle** supports severity-based expiry:
+
+- `critical` — 15 days
+- `high` — 30 days
+- `medium` — 60 days
+- `low` — 90 days
+
+Expired risks block `git push` until you remediate or renew them (max 2 renewals).
+
+## Architecture
+
+ai-engineering is a **content framework with a minimal CLI**. The governance layer is Markdown, YAML, and JSON documents in `.ai-engineering/`. The Python CLI (`ai-eng`) handles lifecycle operations only — install, update, doctor, and gate enforcement.
+
+```
+your-project/
+├── .ai-engineering/         # Governance root
+│   ├── standards/           # Framework and team standards
+│   ├── context/             # Product contracts, specs, learnings
+│   ├── skills/              # Procedural skill definitions
+│   ├── agents/              # Agent persona definitions
+│   └── state/               # Runtime state (JSON/NDJSON)
+├── .git/hooks/              # Installed quality gate hooks
+└── ...your code
+```
+
+**Ownership model** — three clear boundaries:
+
+- **Framework-managed** (`standards/framework/`) — updated by `ai-eng update`, never edit manually.
+- **Team-managed** (`standards/team/`) — owned by your team, never overwritten by updates.
+- **Project-managed** (`context/`) — living documents you maintain during active work.
+
+**Enforcement** happens locally through git hooks. Pre-commit runs formatting and linting. Commit-msg validates message format. Pre-push runs security scans, dependency audits, tests, and type-checking. No CI pipeline required for baseline quality.
+
+## Tooling baseline
+
+| Tool | Purpose |
+|---|---|
+| `uv` | Package and runtime management |
+| `ruff` | Linting and formatting |
+| `ty` | Type checking |
+| `pip-audit` | Dependency vulnerability scanning |
+| `gitleaks` | Secret detection |
+| `semgrep` | Static analysis |
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, testing, and pull request guidelines.
+
+## Code of conduct
+
+This project follows the Contributor Covenant Code of Conduct. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## What

Add the open-source documentation baseline: a user-facing README, contribution guidelines, and a code of conduct.

## Why

The existing README was a 55-line internal sketch with no installation instructions, quick start, usage guide, or architecture overview. The project had no CONTRIBUTING.md or CODE_OF_CONDUCT.md — essential for an open-source MIT-licensed project.

## How

Followed the `doc-writer` skill procedure (5-phase: codebase discovery, standards, drafting, reader testing, ship).

**README.md** — rewritten from ~55 lines to ~200 lines:
- Features section with user-facing capability descriptions
- Quick start with prerequisites, installation (`pip`/`uv`), and first-use flow
- Usage guide organized by command group (22 CLI commands across 5 groups)
- Configuration overview (install flags, dry-run updates, doctor remediation, risk lifecycle)
- Architecture diagram with ownership model explanation
- Tooling baseline table

**CONTRIBUTING.md** — created (~130 lines):
- Development setup (`uv sync --all-extras` / `pip install -e ".[dev]"`)
- Code style (ruff, ty, Google-style docstrings, type hints)
- Testing conventions (AAA pattern, naming, coverage targets)
- Pull request process with gate descriptions
- Issue reporting guidance
- Project structure listing

**CODE_OF_CONDUCT.md** — created (~130 lines):
- Adopts Contributor Covenant v2.1
- Enforcement contact: GitHub Issues

## Validation

Reader testing (Phase 4) verified:
- All 22 CLI commands match actual Typer definitions in `src/ai_engineering/cli_commands/`
- All CLI flags match `typer.Option` definitions
- Risk expiry durations match `_SEVERITY_EXPIRY_DAYS` in `state/decision_logic.py`
- Version `0.1.0` consistent across README, `pyproject.toml`, and `__version__.py`
- All cross-references between documents resolve
- No `.ai-engineering/` internals exposed in user-facing docs

## Checklist

- [x] Docs-only change (no Python source modifications)
- [x] All CLI commands verified against actual implementation
- [x] Cross-references between README, CONTRIBUTING, and CODE_OF_CONDUCT resolve
- [x] No governance internals exposed in user-facing documentation
- [x] Version string matches `__version__.py`