### PR TITLE
feat: add /cleanup workflow skill

### DIFF
--- a/.ai-engineering/context/product/product-contract.md
+++ b/.ai-engineering/context/product/product-contract.md
@@ -23,7 +23,7 @@ This project dogfoods the ai-engineering framework on itself.
 
 ### Active Objectives
 
-1. Complete governance content: 45 skills, 9 agents, 5 stack instructions.
+1. Complete governance content: 46 skills, 9 agents, 5 stack instructions.
 2. Rewrite all Python modules from scratch following new standards.
 3. Achieve CI/CD with cross-OS matrix (Python 3.11/3.12/3.13 × Ubuntu/Windows/macOS).
 4. Validate full E2E install/update/doctor cycle.
@@ -56,7 +56,7 @@ Spec-018: Environment Stability & Governance Enforcement Hardening. Last complet
 | Quality gate pass rate | 100% on all governed ops | 100% (all tools pass) |
 | Security scan pass rate | 100% — zero medium+ findings | 100% (0 critical/high, 1 medium SAST to remediate) |
 | Tamper resistance score | 100/100 | 85/100 (B3/B4 implemented, pending CI evidence stabilization) |
-| Agent coverage (skills + agents defined) | 45 skills + 9 agents | 45/45 skills, 9/9 agents |
+| Agent coverage (skills + agents defined) | 46 skills + 9 agents | 46/46 skills, 9/9 agents |
 | Test coverage | 100% | 87% (530 tests) |
 | Cross-OS CI pass | 3×3 matrix green | In progress (matrix workflow implemented; awaiting run history) |
 

--- a/.ai-engineering/skills/utils/git-helpers.md
+++ b/.ai-engineering/skills/utils/git-helpers.md
@@ -53,4 +53,5 @@ Fallbacks:
 
 - `skills/workflows/commit.md` — primary consumer of git helper procedures.
 - `skills/workflows/pr.md` — PR workflow using git operations.
+- `skills/workflows/cleanup.md` — branch cleanup using git helper patterns.
 - `standards/framework/core.md` — protected branch rules and enforcement.

--- a/.ai-engineering/skills/workflows/cleanup.md
+++ b/.ai-engineering/skills/workflows/cleanup.md
@@ -1,0 +1,69 @@
+---
+name: cleanup
+version: 1.0.0
+category: workflows
+tags: [git, branch, cleanup, hygiene]
+requires:
+  bins: [git]
+---
+
+# Branch Cleanup Workflow
+
+## Purpose
+
+Execute branch cleanup after merging a PR or at the start of a new session. Switches to the base branch, pulls latest, prunes stale remote-tracking references, and deletes local branches that have been merged or squash-merged. Standalone counterpart to the cleanup phases of `/pre-implementation` — without creating a new branch.
+
+## Trigger
+
+- Command: `/cleanup`.
+- Context: after merging a pull request, between tasks, or when starting a session to clear stale branches.
+
+## Procedure
+
+### Phase 1: Sync
+
+1. **Identify base branch** — determine the default branch (`main` or `master`).
+2. **Check working tree** — if dirty, warn and stop. Do not stash automatically.
+3. **Switch to base** — `git checkout <base-branch>`.
+4. **Pull latest** — `git pull --ff-only origin <base-branch>`.
+
+### Phase 2: Prune
+
+5. **Fetch and prune** — `git fetch --prune origin` to remove stale remote-tracking references.
+
+### Phase 3: Cleanup
+
+6. **Delete merged branches** — identify branches fully merged into the base branch.
+   - `git branch --merged <base>` excluding protected branches (`main`, `master`).
+   - Delete each with `git branch -d <branch>`.
+
+7. **Delete squash-merged branches** — identify branches whose remote tracking branch is gone.
+   - `git branch -v` and filter for `[gone]` status.
+   - Delete each with `git branch -D <branch>`.
+   - These are branches merged via squash merge on the remote, where `--merged` detection fails.
+
+8. **Report summary** — display results.
+   - Branches deleted (merged).
+   - Branches deleted (squash-merged / gone).
+   - Remote refs pruned.
+   - Branches skipped (if any).
+
+## Output Contract
+
+- Terminal output showing each phase result.
+- Summary table: deleted count, pruned count, skipped count.
+- Final confirmation: current branch and status.
+
+## Governance Notes
+
+- Protected branches (`main`, `master`) are never deleted.
+- Only `git branch -d` (safe delete) for merged branches; `git branch -D` (force) only for `[gone]` branches whose remote was already deleted.
+- No destructive git operations beyond branch deletion.
+- No `--no-verify` usage.
+- If `git pull --ff-only` fails (diverged history), warn and stop — do not force-pull.
+
+## References
+
+- `skills/workflows/pre-implementation.md` — full pre-implementation flow that includes cleanup + branch creation.
+- `skills/utils/git-helpers.md` — git helper patterns (protected branch check, default branch detection).
+- `standards/framework/core.md` — protected branch rules and enforcement.

--- a/.ai-engineering/skills/workflows/pre-implementation.md
+++ b/.ai-engineering/skills/workflows/pre-implementation.md
@@ -59,4 +59,5 @@ Execute branch hygiene before starting any new implementation work. Ensures the 
 
 - `standards/framework/core.md` — non-negotiables and branch protection rules.
 - `skills/workflows/commit.md` — commit flow that happens after implementation.
+- `skills/workflows/cleanup.md` — standalone cleanup without branch creation (Phases 1-3 counterpart).
 - `skills/govern/create-spec.md` — spec creation that precedes implementation.

--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -1,0 +1,5 @@
+Read and execute the skill defined in `.ai-engineering/skills/workflows/cleanup.md`.
+
+Follow the complete procedure. Do not skip steps. Apply all governance notes. If the skill references standards or other skills, read those as needed.
+
+$ARGUMENTS

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Cleanup workflow skill for branch cleanup and stale branch removal (`/cleanup`).
 - Contract-compliance skill for clause-by-clause framework contract validation.
 - Ownership-audit skill for ownership boundary and updater safety validation.
 - Docs-audit skill for documentation and content quality auditing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 
@@ -121,7 +122,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 Skills and agents are available as Claude Code slash commands via `.claude/commands/`. Each command is a thin wrapper that reads and executes the canonical skill or agent file. No content is duplicated — the command files are pointers only (decision S0-008).
 
-- `/commit`, `/pr`, `/acho`, `/pre-implementation` — workflow commands.
+- `/commit`, `/pr`, `/acho`, `/pre-implementation`, `/cleanup` — workflow commands.
 - `/dev:*` — dev skill commands (e.g., `/dev:debug`, `/dev:refactor`, `/dev:code-review`, `/dev:cicd-generate`, `/dev:multi-agent`).
 - `/review:*` — review skill commands (e.g., `/review:architecture`, `/review:security`, `/review:dast`, `/review:container-security`).
 - `/docs:*` — docs skill commands (e.g., `/docs:changelog`, `/docs:explain`).

--- a/codex.md
+++ b/codex.md
@@ -39,6 +39,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 

--- a/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/utils/git-helpers.md
@@ -53,4 +53,5 @@ Fallbacks:
 
 - `skills/workflows/commit.md` — primary consumer of git helper procedures.
 - `skills/workflows/pr.md` — PR workflow using git operations.
+- `skills/workflows/cleanup.md` — branch cleanup using git helper patterns.
 - `standards/framework/core.md` — protected branch rules and enforcement.

--- a/src/ai_engineering/templates/.ai-engineering/skills/workflows/cleanup.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/workflows/cleanup.md
@@ -1,0 +1,69 @@
+---
+name: cleanup
+version: 1.0.0
+category: workflows
+tags: [git, branch, cleanup, hygiene]
+requires:
+  bins: [git]
+---
+
+# Branch Cleanup Workflow
+
+## Purpose
+
+Execute branch cleanup after merging a PR or at the start of a new session. Switches to the base branch, pulls latest, prunes stale remote-tracking references, and deletes local branches that have been merged or squash-merged. Standalone counterpart to the cleanup phases of `/pre-implementation` — without creating a new branch.
+
+## Trigger
+
+- Command: `/cleanup`.
+- Context: after merging a pull request, between tasks, or when starting a session to clear stale branches.
+
+## Procedure
+
+### Phase 1: Sync
+
+1. **Identify base branch** — determine the default branch (`main` or `master`).
+2. **Check working tree** — if dirty, warn and stop. Do not stash automatically.
+3. **Switch to base** — `git checkout <base-branch>`.
+4. **Pull latest** — `git pull --ff-only origin <base-branch>`.
+
+### Phase 2: Prune
+
+5. **Fetch and prune** — `git fetch --prune origin` to remove stale remote-tracking references.
+
+### Phase 3: Cleanup
+
+6. **Delete merged branches** — identify branches fully merged into the base branch.
+   - `git branch --merged <base>` excluding protected branches (`main`, `master`).
+   - Delete each with `git branch -d <branch>`.
+
+7. **Delete squash-merged branches** — identify branches whose remote tracking branch is gone.
+   - `git branch -v` and filter for `[gone]` status.
+   - Delete each with `git branch -D <branch>`.
+   - These are branches merged via squash merge on the remote, where `--merged` detection fails.
+
+8. **Report summary** — display results.
+   - Branches deleted (merged).
+   - Branches deleted (squash-merged / gone).
+   - Remote refs pruned.
+   - Branches skipped (if any).
+
+## Output Contract
+
+- Terminal output showing each phase result.
+- Summary table: deleted count, pruned count, skipped count.
+- Final confirmation: current branch and status.
+
+## Governance Notes
+
+- Protected branches (`main`, `master`) are never deleted.
+- Only `git branch -d` (safe delete) for merged branches; `git branch -D` (force) only for `[gone]` branches whose remote was already deleted.
+- No destructive git operations beyond branch deletion.
+- No `--no-verify` usage.
+- If `git pull --ff-only` fails (diverged history), warn and stop — do not force-pull.
+
+## References
+
+- `skills/workflows/pre-implementation.md` — full pre-implementation flow that includes cleanup + branch creation.
+- `skills/utils/git-helpers.md` — git helper patterns (protected branch check, default branch detection).
+- `standards/framework/core.md` — protected branch rules and enforcement.

--- a/src/ai_engineering/templates/.ai-engineering/skills/workflows/pre-implementation.md
+++ b/src/ai_engineering/templates/.ai-engineering/skills/workflows/pre-implementation.md
@@ -59,4 +59,5 @@ Execute branch hygiene before starting any new implementation work. Ensures the 
 
 - `standards/framework/core.md` — non-negotiables and branch protection rules.
 - `skills/workflows/commit.md` — commit flow that happens after implementation.
+- `skills/workflows/cleanup.md` — standalone cleanup without branch creation (Phases 1-3 counterpart).
 - `skills/govern/create-spec.md` — spec creation that precedes implementation.

--- a/src/ai_engineering/templates/project/.claude/commands/cleanup.md
+++ b/src/ai_engineering/templates/project/.claude/commands/cleanup.md
@@ -1,0 +1,5 @@
+Read and execute the skill defined in `.ai-engineering/skills/workflows/cleanup.md`.
+
+Follow the complete procedure. Do not skip steps. Apply all governance notes. If the skill references standards or other skills, read those as needed.
+
+$ARGUMENTS

--- a/src/ai_engineering/templates/project/AGENTS.md
+++ b/src/ai_engineering/templates/project/AGENTS.md
@@ -42,6 +42,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 

--- a/src/ai_engineering/templates/project/CLAUDE.md
+++ b/src/ai_engineering/templates/project/CLAUDE.md
@@ -57,6 +57,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 
@@ -121,7 +122,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 
 Skills and agents are available as Claude Code slash commands via `.claude/commands/`. Each command is a thin wrapper that reads and executes the canonical skill or agent file. No content is duplicated — the command files are pointers only (decision S0-008).
 
-- `/commit`, `/pr`, `/acho`, `/pre-implementation` — workflow commands.
+- `/commit`, `/pr`, `/acho`, `/pre-implementation`, `/cleanup` — workflow commands.
 - `/dev:*` — dev skill commands (e.g., `/dev:debug`, `/dev:refactor`, `/dev:code-review`, `/dev:cicd-generate`, `/dev:multi-agent`).
 - `/review:*` — review skill commands (e.g., `/review:architecture`, `/review:security`, `/review:dast`, `/review:container-security`).
 - `/docs:*` — docs skill commands (e.g., `/docs:changelog`, `/docs:explain`).

--- a/src/ai_engineering/templates/project/codex.md
+++ b/src/ai_engineering/templates/project/codex.md
@@ -39,6 +39,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 

--- a/src/ai_engineering/templates/project/copilot-instructions.md
+++ b/src/ai_engineering/templates/project/copilot-instructions.md
@@ -34,6 +34,7 @@ Procedural skills guide structured execution. Reference the relevant skill befor
 - `.ai-engineering/skills/workflows/pr.md` — `/pr` flow.
 - `.ai-engineering/skills/workflows/acho.md` — `/acho` alias.
 - `.ai-engineering/skills/workflows/pre-implementation.md` — branch hygiene before implementation.
+- `.ai-engineering/skills/workflows/cleanup.md` — branch cleanup and stale branch removal.
 
 ### Dev Skills
 


### PR DESCRIPTION
## Summary

- New `/cleanup` workflow skill for branch hygiene: switch to main, pull, prune stale remote refs, delete merged and squash-merged local branches.
- Handles the `[gone]` branch case (squash-merged PRs not detected by `git branch --merged`).
- Full governed registration: skill file, template mirror, 8 instruction files, slash command, counters, changelog, cross-references.

## What changed

| File | Change |
|------|--------|
| `.ai-engineering/skills/workflows/cleanup.md` | New skill (canonical) |
| `.claude/commands/cleanup.md` | Slash command wrapper |
| 8 instruction files | Added skill reference (46 skills) |
| `product-contract.md` | Updated skill count 45→46 |
| `CHANGELOG.md` | Added entry |
| `pre-implementation.md`, `git-helpers.md` | Cross-references added |
| Template mirrors (4 files) | Byte-identical copies |

## Checklist

- [x] Follows create-skill governed procedure (8 phases)
- [x] `ai-eng validate` passes 7/7 categories
- [x] 46 skills consistent across all 8 instruction files
- [x] 55 Claude command mirrors in sync
- [x] 66 governance mirror pairs in sync
- [x] All pre-commit and pre-push gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)