### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,16 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag" CHANGELOG.md > release-notes.md
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --generate-notes \
+            --notes-file release-notes.md \
             dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-01
+
+*First MVP release (Phase 1)*
+
 ### Added
 - **CLI UX skill** (`dev/cli-ux`) — agent-first CLI design patterns: JSON envelopes, Rich human output, dual-mode routing, progress indicators.
 - **CLI UX modules** — `cli_envelope.py` (structured JSON envelopes with NextAction), `cli_output.py` (JSON mode detection), `cli_progress.py` (Rich spinners), `cli_ui.py` (terminal formatting helpers: error, info, kv, success).
@@ -21,25 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spec reset module (`maintenance/spec_reset.py`): active spec detection, completed spec archival to `specs/archive/`, `_active.md` reset.
 - CLI commands: `ai-eng maintenance repo-status`, `ai-eng maintenance spec-reset`.
 - `/create-spec` now composes `/cleanup` before branch creation for automatic pre-spec hygiene.
-
-### Changed
-- **CLI commands migrated to UX modules** — all 10 CLI command modules (`cicd`, `core`, `gate`, `maintenance`, `review`, `setup`, `skills`, `stack_ide`, `validate`, `vcs`) refactored to use `cli_envelope`, `cli_output`, `cli_progress`, and `cli_ui` for consistent terminal output, JSON mode support, and Rich spinners.
-- **Governance surface: 49→50 skills** — `dev/cli-ux` registered across all instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, copilot-instructions.md).
-- **Documentation gate always evaluates** — removed binary "internal-only → skip" classification from `/commit`, `/pr`, and `/acho` workflows. The gate now classifies scope (CHANGELOG + README, CHANGELOG only, or no updates needed) but never auto-skips entirely. Skill, agent, and governance surface changes are no longer blanket-exempt.
-- **`/cleanup` mandates CLI commands** — Phase 0 (repo-status), Phase 3 (branch-cleanup), and Phase 4 (spec-reset) now require `uv run ai-eng maintenance <command>` instead of ad-hoc shell commands. Prevents zsh `!=` operator escaping failures during stale branch detection.
-
-### Fixed
-- **Template product-contract.md** — committed version shipped ai-engineering-specific content instead of generic `<project-name>` placeholders, causing `ai-eng install` to copy project-specific data to new installations.
-- **12 template mirrors synced** — agents, skills, standards, and project templates restored to generic form for clean installations.
-- Content Integrity CI: synced `create-spec/SKILL.md` template mirror with canonical (missing cleanup step).
-- Content Integrity CI: corrected skill count in `product-contract.md` from 50 to 49.
-- `ai-eng install` no longer crashes (exit code 1) when platform onboarding prompt is aborted or running in non-interactive mode.
-- Setup CLI commands now correctly registered on module-level Typer instance (fixes unit test isolation).
-- Doctor platform check test uses correct patch path for `GitHubSetup`.
-- Template mirror for `dev/sonar-gate/SKILL.md` synced with canonical source.
-- Lint fixes: `str, Enum` → `StrEnum`, combined `with` statements, ternary simplifications.
-
-### Added
 - **Spec-025: OSS Documentation Gate** — mandatory documentation gate in `/commit`, `/pr`, and `/acho` workflows for OSS GitHub users.
 - Documentation gate classifies changes as user-visible vs internal-only and enforces CHANGELOG.md and README.md updates for user-visible changes.
 - External documentation portal support: asks for docs repo URL, clones, updates documentation, creates PR with auto-complete.
@@ -112,6 +97,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installer coverage for full bundled non-state governance template tree.
 
 ### Changed
+- **CLI commands migrated to UX modules** — all 10 CLI command modules (`cicd`, `core`, `gate`, `maintenance`, `review`, `setup`, `skills`, `stack_ide`, `validate`, `vcs`) refactored to use `cli_envelope`, `cli_output`, `cli_progress`, and `cli_ui` for consistent terminal output, JSON mode support, and Rich spinners.
+- **Governance surface: 49→50 skills** — `dev/cli-ux` registered across all instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, copilot-instructions.md).
+- **Documentation gate always evaluates** — removed binary "internal-only → skip" classification from `/commit`, `/pr`, and `/acho` workflows. The gate now classifies scope (CHANGELOG + README, CHANGELOG only, or no updates needed) but never auto-skips entirely. Skill, agent, and governance surface changes are no longer blanket-exempt.
+- **`/cleanup` mandates CLI commands** — Phase 0 (repo-status), Phase 3 (branch-cleanup), and Phase 4 (spec-reset) now require `uv run ai-eng maintenance <command>` instead of ad-hoc shell commands. Prevents zsh `!=` operator escaping failures during stale branch detection.
 - `/cleanup` upgraded from branch-only cleanup to full repository hygiene primitive (status + sync + prune + cleanup + spec reset).
 - Session Start Protocol updated: "Run `/cleanup`" replaces "Run `/pre-implementation`" across all provider instruction files.
 - Maintenance report includes remote branch, open PR, and stale branch counts.
@@ -131,6 +120,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/pre-implementation` skill — functionality absorbed into `/cleanup` and `/create-spec`.
 - `poetry.lock` and empty e2e test package placeholder.
 
-## [0.1.0] - TBD
-
-*First MVP release (Phase 1)*
+### Fixed
+- **Template product-contract.md** — committed version shipped ai-engineering-specific content instead of generic `<project-name>` placeholders, causing `ai-eng install` to copy project-specific data to new installations.
+- **12 template mirrors synced** — agents, skills, standards, and project templates restored to generic form for clean installations.
+- Content Integrity CI: synced `create-spec/SKILL.md` template mirror with canonical (missing cleanup step).
+- Content Integrity CI: corrected skill count in `product-contract.md` from 50 to 49.
+- `ai-eng install` no longer crashes (exit code 1) when platform onboarding prompt is aborted or running in non-interactive mode.
+- Setup CLI commands now correctly registered on module-level Typer instance (fixes unit test isolation).
+- Doctor platform check test uses correct patch path for `GitHubSetup`.
+- Template mirror for `dev/sonar-gate/SKILL.md` synced with canonical source.
+- Lint fixes: `str, Enum` → `StrEnum`, combined `with` statements, ternary simplifications.


### PR DESCRIPTION
## Summary

- Move all `[Unreleased]` CHANGELOG content into `[0.1.0] - 2026-03-01` section
- Consolidate duplicate `Added`/`Changed` sections into a single, clean release entry
- Update `release.yml` to extract release notes from CHANGELOG.md instead of `--generate-notes`

## What this enables

After merge, tag `v0.1.0` on `main` to trigger the release workflow:
1. Build: lint + tests + `uv build`
2. Publish: upload to PyPI via Trusted Publisher (OIDC)
3. GitHub Release: create release with notes extracted from CHANGELOG

## Test plan

- [x] Local `uv build` produces `ai_engineering-0.1.0-py3-none-any.whl`
- [x] Templates included in wheel
- [x] All pre-commit gates pass (gitleaks, ruff, hook-integrity)
- [x] All pre-push gates pass (semgrep, pip-audit, stack-tests, ty-check, duplication)
- [ ] CI passes on PR
- [ ] After merge: `git tag v0.1.0 && git push origin v0.1.0` triggers release workflow
- [ ] `pip install ai-engineering` works from PyPI
- [ ] `ai-eng version` shows `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)