### PR TITLE
fix: add download-artifact step to github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - name: Extract release notes from CHANGELOG
         id: notes
         run: |


### PR DESCRIPTION
## Summary

- Add missing `actions/download-artifact@v4` step to the `github-release` job in `release.yml`
- The v0.1.0 release workflow failed at the "Create Release" step with `no matches found for dist/*` because the dist artifacts were never downloaded

## Root cause

The `github-release` job depends on `publish` (which depends on `build`), but only the `publish` job had a `download-artifact` step. The `github-release` job checked out the repo and ran `gh release create ... dist/*` without downloading the artifacts first.

## Test plan

- [x] All local gates pass
- [ ] CI passes
- [ ] Next tag push creates GitHub release with attached dist files

🤖 Generated with [Claude Code](https://claude.com/claude-code)