### PR TITLE
fix(pipeline): update injector.py fallback to sonarqube-scan-action (#132)

### DIFF
--- a/src/ai_engineering/pipeline/injector.py
+++ b/src/ai_engineering/pipeline/injector.py
@@ -71,7 +71,7 @@ def generate_github_sonar_step() -> str:
           if: >
             ${{ github.event_name != 'pull_request' ||
                 github.event.pull_request.head.repo.full_name == github.repository }}
-          uses: SonarSource/sonarcloud-github-action@v3
+          uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6
           env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           with:


### PR DESCRIPTION
## Summary
- Replace deprecated `SonarSource/sonarcloud-github-action@v3` fallback in `injector.py` with `SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602` (v6), matching the canonical template at `src/ai_engineering/templates/pipeline/github-sonar-step.yml`.

Closes #132

## Test plan
- [ ] `ruff check` and `ruff format --check` pass on `injector.py`
- [ ] `tests/unit/test_pipeline_compliance.py` — all 26 tests pass
- [ ] Full unit suite (1480 tests) passes
- [ ] Verify the fallback string matches the template SHA pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)