### PR TITLE
feat(hooks): add GitHub Copilot hooks parity with Claude Code

### DIFF
--- a/.agents/skills/create/handlers/create-agent.md
+++ b/.agents/skills/create/handlers/create-agent.md
@@ -1,0 +1,44 @@
+# Handler: create-agent
+
+## Purpose
+
+Scaffold a new agent with standardized frontmatter, defined mandate, referenced skills, and mirror generation.
+
+## Procedure
+
+### 1. Validate name
+- Must not conflict with existing agents (check `.agents/agents/`)
+
+### 2. Define identity
+- What is the agent's singular responsibility?
+- What model? (opus for complex tasks, sonnet for simple/fast)
+- What color? (check existing agents to avoid duplicates)
+- What tools? (Read, Write, Edit, Bash, Glob, Grep — pick minimum needed)
+
+### 3. Scaffold agent file
+Frontmatter order (mandatory):
+```yaml
+---
+name: ai-<name>
+description: "[Mandate in one sentence]."
+color: <color>
+model: <opus|sonnet>
+tools: [Read, Glob, Grep, ...]
+---
+```
+
+Body structure:
+1. `# <Name>` (no prefix)
+2. `## Identity` — 3-4 sentences defining expertise and perspective
+3. `## Mandate` — singular responsibility, 1-2 sentences
+4. `## Behavior` — numbered sections for the agent's workflow
+5. `## Referenced Skills` — list of skill paths (validate they exist!)
+6. `## Boundaries` — what the agent does NOT do
+7. `### Escalation Protocol` — iteration limit, never loop silently
+
+### 4. Register
+- Add to `.ai-engineering/manifest.yml` agents section
+- Increment `total` count
+
+### 5. Generate mirrors
+- Run `python scripts/sync_command_mirrors.py`

--- a/.agents/skills/create/handlers/create-skill.md
+++ b/.agents/skills/create/handlers/create-skill.md
@@ -1,0 +1,55 @@
+# Handler: create-skill
+
+## Purpose
+
+Scaffold a new skill with standardized frontmatter, CSO-optimized description, optional handlers, manifest registration, and mirror generation.
+
+## Procedure
+
+### 1. Validate name
+- Must not conflict with existing skills (check `.agents/skills/`)
+- Prefix with `ai-` automatically if not provided
+
+### 2. Interrogate (max 3 questions)
+- What does the skill do? (→ Purpose)
+- What triggers it? (→ CSO description: "Use when...")
+- Does it have multiple modes? (→ handlers needed?)
+
+### 3. Scaffold SKILL.md
+Frontmatter order (mandatory):
+```yaml
+---
+name: ai-<name>
+description: "Use when [trigger condition]. [What it does]."
+argument-hint: "[args]"
+---
+```
+
+Body structure:
+1. `# <Name>` (no prefix)
+2. `## Purpose` — 2-3 sentences
+3. `## When to Use` — bullet list of trigger conditions
+4. `## Process` — numbered steps or mode dispatch
+5. `## Quick Reference` — code block with invocation examples
+6. `## Integration` — Called by, Calls, Transitions to
+7. `## References` — related skills/files
+8. `$ARGUMENTS`
+
+### 4. Create handlers (if multi-mode)
+For each mode: create `handlers/<mode>.md` with Purpose, Procedure sections.
+
+### 5. Register
+- Add to `.ai-engineering/manifest.yml` skills registry
+- Increment `total` count
+
+### 6. Generate mirrors
+- Run `python scripts/sync_command_mirrors.py`
+
+### 7. Pressure-test
+Present 5 example prompts that SHOULD trigger this skill. Verify the CSO description would match.
+
+## CSO Description Rules
+
+- Start with "Use when" (trigger-focused, not summary-focused)
+- Bad: "Generates standup notes from PR activity"
+- Good: "Use when preparing daily standup notes or summarizing recent PR and commit activity for team updates"

--- a/.agents/skills/create/handlers/validate.md
+++ b/.agents/skills/create/handlers/validate.md
@@ -1,0 +1,41 @@
+# Handler: validate
+
+## Purpose
+
+Post-creation validation. Verifies a skill or agent is correctly configured across all surfaces.
+
+## Procedure
+
+### 1. CSO Description Quality
+- Does description start with "Use when"?
+- Does it describe a trigger condition, not a summary?
+- Is it specific enough to distinguish from other skills?
+
+### 2. Frontmatter Order
+- Check field order matches canonical:
+  - Agents: name, description, color, model, tools
+  - Skills: name, description, [optional fields], argument-hint
+
+### 3. Mirror Parity
+- Verify skill/agent exists in all 3 surfaces:
+  - `.agents/skills/<name>/SKILL.md` or `.agents/agents/ai-<name>.md`
+  - `.agents/skills/<name>/SKILL.md` or `.agents/agents/ai-<name>.md`
+  - `.github/prompts/ai-<name>.prompt.md` or `.github/agents/<name>.agent.md`
+- Verify handlers are mirrored too (if any)
+
+### 4. Manifest Registration
+- Verify skill/agent is in `.ai-engineering/manifest.yml`
+- Verify `total` count matches actual count
+
+### 5. Cross-Reference Integrity
+- All Referenced Skills paths point to existing files
+- No ghost skill references
+
+### 6. Report
+```
+✓ CSO description: PASS
+✓ Frontmatter order: PASS
+✓ Mirror parity: 3/3 surfaces
+✓ Manifest registered: PASS
+✓ Cross-references: PASS (0 broken)
+```

--- a/.agents/skills/solution-intent/handlers/init.md
+++ b/.agents/skills/solution-intent/handlers/init.md
@@ -1,0 +1,106 @@
+# Handler: init
+
+## Purpose
+
+Scaffold a comprehensive `docs/solution-intent.md` from real project state. This is the Solution Intent — defines what you are building, how, and why.
+
+## Prerequisites
+
+- Run `/ai-explore` or equivalent deep audit of the repo BEFORE writing. Every data point must come from verified sources (code, config, state files).
+- Use `/ai-write` patterns: visual priority (diagrams > tables > text), audience = technical team, no filler.
+
+## Procedure
+
+### 1. Check existence
+If `docs/solution-intent.md` exists, warn and ask user to confirm overwrite.
+
+### 2. Deep audit
+Gather data from REAL project state — never from old documentation:
+
+| Source | What to extract |
+|--------|----------------|
+| `pyproject.toml` | Name, version, description, license, Python version, dependencies |
+| `.ai-engineering/manifest.yml` | Skills count, agents, stacks, providers, IDEs, quality gates, tooling, ownership |
+| `.ai-engineering/state/decision-store.json` | Active decisions, risk acceptances |
+| `.ai-engineering/specs/spec.md` | Current spec, status |
+| `.ai-engineering/contexts/` | Available language/framework/team contexts |
+| `.ai-engineering/runbooks/` | Available operational runbooks |
+| `src/ai_engineering/` | Module structure, CLI commands, services, layers |
+| `.agents/skills/` | Actual skill count and categories |
+| `.agents/agents/` | Actual agent count, models, colors |
+| `.github/hooks/` | Telemetry hook configuration |
+| `scripts/` | Sync, validation, work item scripts |
+
+### 3. Scaffold 7 sections
+
+Each section MUST have at least one Mermaid diagram or table. If data is not available, mark as **TBD — pending team definition**.
+
+**Section 1: Introduction**
+- 1.1 Identity (table: name, org/repo, version, status, model, license)
+- 1.2 Objective (1 paragraph from pyproject.toml description + manifest purpose)
+- 1.3 Problem Statement (why this framework exists)
+- 1.4 Desired Outcomes (bullet list of measurable goals)
+- 1.5 Scope (in/out explicit lists)
+- 1.6 Stakeholders and Personas (table: persona, journey, primary actions)
+
+**Section 2: Requirements (Solution Intent)**
+- 2.1 High-Level Solution Architecture (mermaid flowchart TB — real component map)
+- 2.2 Functional Requirements by Domain (table: domain, requirement, priority, status)
+  - Include Skills table (by type, with actual count)
+  - Include Agents table (name, purpose, scope)
+  - Include CLI commands table (from actual `src/ai_engineering/cli_commands/`)
+- 2.3 Non-Functional Requirements (table: category, requirement, threshold, measurement)
+- 2.4 Integrations (mermaid flowchart LR + contracts table: system A/B, protocol, contract, SLA)
+
+**Section 3: Technical Design**
+- 3.1 Stack and Architecture (mermaid: real module dependency graph from `src/`)
+  - Stack table (layer, component, technology)
+- 3.2 Environments (table: environment, purpose, variables, secrets, network)
+- 3.3 API and Gateway Policies (table: surface, auth, rate limit, versioning)
+- 3.4 Publication and Deployment (mermaid flowchart: dev -> gates -> PR -> CI -> release -> PyPI)
+  - Artifacts table (artifact, method, target, trigger)
+
+**Section 4: Observability Plan**
+- 4.1 What We Measure (mermaid mindmap from real telemetry events)
+- 4.2 SLIs / SLOs / Alerts (table: signal, SLI, SLO, alert threshold, action)
+- 4.3 Logging and Reporting (table: log type, format, retention, location)
+- 4.4 Runbooks (table from real `.ai-engineering/runbooks/` files)
+
+**Section 5: Security**
+- 5.1 Authentication and Authorization (mermaid flowchart + provider table)
+- 5.2 Exposure Model (table: surface, visibility, data classification, controls)
+- 5.3 Compromised Process Recovery (mermaid sequence diagram)
+- 5.4 Hardening Checklist (table: check, tool, gate, status)
+
+**Section 6: Quality**
+- 6.1 Quality Gates (mermaid sequence diagram + gates table)
+- 6.2 Architecture Patterns (table: pattern, where applied, why)
+- 6.3 Testing Strategy (table: level, tool, coverage target, current)
+- 6.4 Scalability Plan (table: dimension, current, target, strategy)
+
+**Section 7: Next Objectives**
+- 7.1 Roadmap (table: phase, description, status)
+- 7.2 Active Epics / Features (table: epic, description, priority, status, target)
+- 7.3 KPIs (table: metric, target, current)
+- 7.4 Active Spec (pointer to `specs/spec.md`)
+- 7.5 Blockers and Risks (table: ID, description, severity, owner, expiry)
+
+### 4. Write
+Save to `docs/solution-intent.md` with header:
+```
+> Status: Evolving
+> Last Review: YYYY-MM-DD
+```
+
+### 5. Report
+Show sections populated vs TBD.
+
+## Governance Notes
+
+**Visual priority**: diagrams > tables > text. Every section MUST have at least one Mermaid diagram or table. Text accompanies but does not substitute visual representation.
+
+**TBD policy**: if a section's data is not defined, implemented, or in scope, mark it explicitly as TBD. NEVER invent data.
+
+**Writing patterns**: use `/ai-write` conventions — audience = technical team, concise, no filler.
+
+**Ownership**: `docs/solution-intent.md` is project-managed. The sync mode updates data fields but never removes user-authored content. The framework updater (`ai-eng update`) does not touch this file.

--- a/.agents/skills/solution-intent/handlers/sync.md
+++ b/.agents/skills/solution-intent/handlers/sync.md
@@ -1,0 +1,46 @@
+# Handler: sync
+
+## Purpose
+
+Surgical update of specific sections based on project changes. Never rewrites the entire document. Never deletes user-authored content.
+
+## Trigger Table
+
+| Trigger | Sections Affected | Source |
+|---------|-------------------|--------|
+| Spec closure (done.md created) | 7.2 epic status, 7.4 active spec | spec lifecycle |
+| Release completion | 7.1 roadmap, 7.3 KPIs | release skill |
+| Stack add/remove | 3.1 stack & architecture | manifest.yml |
+| Security scan delta | 5.4 hardening checklist, 7.3 KPIs | verify agent |
+| Decision store update | 2.2 if domain-relevant | decision-store.json |
+| Skill/agent add/remove | 2.2 AI Ecosystem, 6.4 scalability | manifest.yml |
+| Quality gate change | 6.1 quality gates, 2.3 NFRs | manifest.yml |
+
+## Procedure
+
+1. **Read current document** -- load `docs/solution-intent.md`.
+
+2. **Detect changes** -- compare current project state against document content:
+   - Parse manifest.yml for stack/skill/agent counts
+   - Parse decision-store.json for active decisions
+   - Check specs/spec.md for current spec
+   - Check recent spec closures (done.md files)
+   - Run quality/security tools if available for fresh data
+
+3. **Apply updates** -- for each affected section:
+   - Read existing section content
+   - Merge new data (update tables, status fields, counts, diagrams)
+   - Preserve all user-authored text and custom content
+   - Update `Last Review: YYYY-MM-DD` in header
+
+4. **Stage** -- `git add docs/solution-intent.md`.
+
+5. **Report** -- list sections updated with before/after summary.
+
+## Rules
+
+- **Surgical only** -- update specific fields/tables, never rewrite paragraphs
+- **Preserve user content** -- if a section has been manually edited, merge carefully
+- **Idempotent** -- running sync twice with no changes produces no diff
+- **Diagrams** -- update Mermaid diagrams if the underlying data changed (e.g., new module in architecture)
+- **TBD sections** -- do NOT fill TBD sections during sync. Only init or user can populate those.

--- a/.agents/skills/solution-intent/handlers/validate.md
+++ b/.agents/skills/solution-intent/handlers/validate.md
@@ -1,0 +1,71 @@
+# Handler: validate
+
+## Purpose
+
+Read-only completeness and freshness check. Produces a scorecard without modifying files.
+
+## Procedure
+
+### 1. Read document
+Load `docs/solution-intent.md`.
+
+### 2. Check completeness per section
+
+For each of the 7 sections and their subsections:
+
+| Section | Subsections to check |
+|---------|---------------------|
+| 1. Introduction | 1.1 Identity, 1.2 Objective, 1.3 Problem, 1.4 Outcomes, 1.5 Scope, 1.6 Personas |
+| 2. Requirements | 2.1 Architecture, 2.2 Functional, 2.3 NFRs, 2.4 Integrations |
+| 3. Technical Design | 3.1 Stack, 3.2 Environments, 3.3 API Policies, 3.4 Publication |
+| 4. Observability | 4.1 Measurements, 4.2 SLIs/SLOs, 4.3 Logging, 4.4 Runbooks |
+| 5. Security | 5.1 Auth, 5.2 Exposure, 5.3 Recovery, 5.4 Hardening |
+| 6. Quality | 6.1 Gates, 6.2 Patterns, 6.3 Testing, 6.4 Scalability |
+| 7. Next Objectives | 7.1 Roadmap, 7.2 Epics, 7.3 KPIs, 7.4 Active Spec, 7.5 Risks |
+
+Per subsection, verify:
+- Header exists
+- At least one table OR Mermaid diagram present
+- No placeholder markers (`<...>`) remain
+- Content is populated (not empty)
+- TBD markers are allowed (they indicate intentional gaps)
+
+### 3. Check freshness
+Parse `Last Review:` date in header:
+- If > 30 days ago: WARNING (stale)
+- If > 60 days ago: CRITICAL (very stale)
+- If missing: INFO (never reviewed)
+
+### 4. Check consistency
+Cross-reference with project state:
+- manifest.yml skill count vs Section 2.2 skill count
+- manifest.yml agent count vs Section 2.2 agent count
+- manifest.yml tooling vs Section 3.1 tooling
+- manifest.yml quality gates vs Section 6.1 gates
+- Active spec pointer vs Section 7.4
+- decision-store.json active count vs Section 2.2 decisions
+
+### 5. Produce scorecard
+
+```
+| Section | Status | Notes |
+|---------|--------|-------|
+| 1.1 Identity | COMPLETE | |
+| 1.2 Objective | COMPLETE | |
+| 1.3 Problem Statement | COMPLETE | |
+| 1.4 Desired Outcomes | COMPLETE | |
+| 1.5 Scope | COMPLETE | |
+| 1.6 Personas | PARTIAL | Missing DevSecOps journey |
+| 2.1 Architecture | COMPLETE | Diagram present |
+| 2.2 Functional Requirements | COMPLETE | |
+| ... | ... | ... |
+| --- | --- | --- |
+| Freshness | OK | Last review: 5 days ago |
+| Consistency | WARN | Skill count mismatch (30 vs 28) |
+```
+
+### 6. Report
+
+- Scorecard table
+- Summary: N/M sections COMPLETE, N TBD, N PARTIAL
+- Recommended actions (if any)

--- a/.ai-engineering/manifest.yml
+++ b/.ai-engineering/manifest.yml
@@ -111,7 +111,7 @@ agents:
 
 # Ownership
 ownership:
-  framework: [".claude/skills/**", ".claude/agents/**", ".ai-engineering/**"]
+  framework: [".claude/skills/**", ".claude/agents/**", ".ai-engineering/**", ".github/agents/**", ".github/prompts/**", ".github/hooks/**", ".github/copilot-instructions.md", ".agents/**"]
   team: [".ai-engineering/contexts/team/**"]
   system: [".ai-engineering/state/**"]
 

--- a/.ai-engineering/specs/_history.md
+++ b/.ai-engineering/specs/_history.md
@@ -62,3 +62,4 @@ Completed specs. Details in git history.
 | 003 | Governance Enforcement | done | 2026-02-10 | spec/003-governance-enforcement |
 | 002 | Cross-Reference Hardening + Skill Registration | done | 2026-02-09 | spec/002-cross-ref-hardening |
 | 001 | AI-Engineering Framework: Rewrite from Scratch | done | 2026-02-08 | spec/001-rewrite-v2 |
+| 055 | GitHub Copilot Parity — Hooks, Deny-List, Multi-Platform Completeness | done | 2026-03-20 | feat/spec-055-copilot-hooks-parity |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,8 +41,12 @@ Gate failure: diagnose → fix → retry.
 ## Observability
 
 Telemetry is **automatic via hooks** — configured in `.github/hooks/hooks.json`.
-- `post_tool_call` hook emits `skill_invoked` events automatically
-- `session_end` hook emits `session_end` events automatically
+- `sessionStart` hook emits `session_start` events on session initialization
+- `sessionEnd` hook emits `session_end` events on session close
+- `userPromptSubmitted` hook emits `skill_invoked` events on `/ai-*` commands
+- `preToolUse` hook enforces deny-list (blocks dangerous operations)
+- `postToolUse` hook emits `agent_dispatched` events on agent use
+- `errorOccurred` hook emits `error_occurred` events on failures
 - All events → `.ai-engineering/state/audit-log.ndjson`
 - Dashboards: `ai-eng observe [engineer|team|ai|dora|health]`
 

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -1,19 +1,59 @@
 {
-  "hooks": [
-    {
-      "type": "post_tool_call",
-      "script": "scripts/hooks/telemetry-skill.sh",
-      "description": "Emit skill_invoked telemetry after tool use"
-    },
-    {
-      "type": "session_end",
-      "script": "scripts/hooks/telemetry-session.sh end",
-      "description": "Emit session_end telemetry when session closes"
-    },
-    {
-      "type": "post_tool_call",
-      "script": "scripts/hooks/telemetry-agent.sh",
-      "description": "Emit agent_dispatched telemetry after agent use"
-    }
-  ]
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-session-start.sh",
+        "powershell": "./scripts/hooks/copilot-session-start.ps1",
+        "timeoutSec": 10,
+        "comment": "Emit session_start telemetry on session initialization"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-session-end.sh",
+        "powershell": "./scripts/hooks/copilot-session-end.ps1",
+        "timeoutSec": 10,
+        "comment": "Emit session_end telemetry when session closes"
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-skill.sh",
+        "powershell": "./scripts/hooks/copilot-skill.ps1",
+        "timeoutSec": 10,
+        "comment": "Emit skill_invoked telemetry on /ai-* commands"
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-deny.sh",
+        "powershell": "./scripts/hooks/copilot-deny.ps1",
+        "timeoutSec": 5,
+        "comment": "Enforce deny-list: block dangerous operations (rm -rf, force push, --no-verify)"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-agent.sh",
+        "powershell": "./scripts/hooks/copilot-agent.ps1",
+        "timeoutSec": 10,
+        "comment": "Emit agent_dispatched telemetry on agent tool use"
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "./scripts/hooks/copilot-error.sh",
+        "powershell": "./scripts/hooks/copilot-error.ps1",
+        "timeoutSec": 10,
+        "comment": "Emit error_occurred telemetry on failures"
+      }
+    ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **GitHub Copilot hooks parity** — migrated `.github/hooks/hooks.json` from broken flat-array format to Copilot's native `{ version: 1, hooks: { eventType: [...] } }` schema with all 6 hook types: `sessionStart`, `sessionEnd`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `errorOccurred`.
+- **Copilot preToolUse deny-list** — new `copilot-deny.sh` script enforces the same 13 dangerous-operation patterns blocked by Claude Code's `settings.json` (force push, `rm -rf *`, `--no-verify`, etc.) via Copilot's native `preToolUse` hook with `permissionDecision: "deny"` output.
+- **Copilot telemetry scripts** — 5 new hook scripts (`copilot-skill.sh`, `copilot-agent.sh`, `copilot-session-start.sh`, `copilot-session-end.sh`, `copilot-error.sh`) emit NDJSON events to `audit-log.ndjson` matching existing Claude telemetry format. Each has a PowerShell fail-open stub.
+- **Codex handler parity** — adapted 6 missing handler files for `.agents/skills/` (create: 3, solution-intent: 3) from Claude sources with provider-neutral paths (zero `.claude/` references).
+- **Manifest ownership expansion** — `ownership.framework` now includes `.github/agents/**`, `.github/prompts/**`, `.github/hooks/**`, `.github/copilot-instructions.md`, and `.agents/**`.
+
+### Changed
+- **copilot-instructions.md** — Observability section now lists all 6 Copilot-native camelCase hook event types instead of old `post_tool_call`/`session_end` naming.
+
+### Added
 - **Watch & fix loop for /ai-pr** — step 14 now autonomously monitors PR until merge: diagnoses and fixes failing CI checks, resolves merge conflicts via rebase, and handles review comments (team/org-internal bot = autonomous, external = user confirmation). Polls every 1 min (active) or 3 min (passive). Escalates after 3 failed fix attempts. Full GitHub and Azure DevOps VCS support. New `handlers/watch.md` handler with 7-step procedure.
 - **Work items integration** — expanded `manifest.yml` `work_items` section with provider-specific config (Azure DevOps `area_path`, GitHub `team_label`), hierarchy rules (`never_close` for features, `close_on_pr` for user stories/tasks/bugs), and spec frontmatter `refs` for traceability from specs to work items.
 - **Sprint review skill** — new `/ai-sprint-review` skill (31st skill) that gathers sprint data from work items and git, generates a python-pptx script with the ai-engineering dark-mode brand, and produces a PowerPoint slide deck for stakeholders.

--- a/scripts/hooks/copilot-agent.ps1
+++ b/scripts/hooks/copilot-agent.ps1
@@ -1,0 +1,11 @@
+# Copilot postToolUse telemetry hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement telemetry for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-agent.sh
+++ b/scripts/hooks/copilot-agent.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copilot telemetry hook: emit agent_dispatched on postToolUse matching agent tools.
+# Called by GitHub Copilot hooks (postToolUse event).
+# Fail-open: exit 0 always — never blocks IDE.
+set -uo pipefail
+
+main() {
+    # Read JSON from stdin (postToolUse event data)
+    INPUT=$(cat)
+
+    # Resolve project root from script location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_LOG="$PROJECT_DIR/.ai-engineering/state/audit-log.ndjson"
+
+    # Extract toolName from stdin JSON
+    TOOL_NAME=""
+    if command -v jq >/dev/null 2>&1; then
+        TOOL_NAME=$(echo "$INPUT" | jq -r '.toolName // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        TOOL_NAME=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('toolName', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Only proceed if toolName matches "task" or contains "agent" (case-insensitive)
+    TOOL_LOWER=$(echo "$TOOL_NAME" | tr '[:upper:]' '[:lower:]')
+    [[ "$TOOL_LOWER" == "task" || "$TOOL_LOWER" == *"agent"* ]] || return 0
+
+    # Extract agent type from .toolArgs (parse as JSON, look for agent_type field)
+    AGENT_TYPE=""
+    if command -v jq >/dev/null 2>&1; then
+        AGENT_TYPE=$(echo "$INPUT" | jq -r '.toolArgs | if type == "string" then fromjson else . end | .agent_type // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        AGENT_TYPE=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    args = d.get('toolArgs', {})
+    if isinstance(args, str):
+        args = json.loads(args)
+    print(args.get('agent_type', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Skip if no agent type extracted
+    [ -z "$AGENT_TYPE" ] && return 0
+
+    # Normalize: lowercase, strip existing ai-/ai: prefix, re-add ai- prefix
+    AGENT_TYPE=$(echo "$AGENT_TYPE" | tr '[:upper:]' '[:lower:]')
+    AGENT_TYPE="${AGENT_TYPE#ai-}"
+    AGENT_TYPE="${AGENT_TYPE#ai:}"
+    AGENT_TYPE="ai-${AGENT_TYPE}"
+
+    # Git metadata (fail gracefully if not in a repo)
+    BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    # Timestamp: use stdin JSON timestamp if available, otherwise generate ISO-8601
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Emit NDJSON event to audit log
+    if command -v jq >/dev/null 2>&1; then
+        jq -n -c \
+            --arg agent "$AGENT_TYPE" \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg ts "$TIMESTAMP" \
+            '{actor:"ai",agent:$agent,branch:$branch,commit_sha:$commit,detail:{agent:$agent},event:"agent_dispatched",source:"hook",timestamp:$ts}' \
+            >> "$AUDIT_LOG" 2>/dev/null
+    else
+        printf '{"actor":"ai","agent":"%s","branch":"%s","commit_sha":"%s","detail":{"agent":"%s"},"event":"agent_dispatched","source":"hook","timestamp":"%s"}\n' \
+            "$AGENT_TYPE" "$BRANCH" "$COMMIT" "$AGENT_TYPE" "$TIMESTAMP" >> "$AUDIT_LOG" 2>/dev/null
+    fi
+}
+
+main || exit 0
+exit 0

--- a/scripts/hooks/copilot-deny.ps1
+++ b/scripts/hooks/copilot-deny.ps1
@@ -1,0 +1,11 @@
+# Copilot preToolUse deny-list hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement deny logic for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-deny.sh
+++ b/scripts/hooks/copilot-deny.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Copilot preToolUse deny-list hook.
+# Blocks dangerous CLI operations matching the project deny-list.
+# Fail-open: exit 0 on any error — never blocks the IDE.
+#
+# Input:  JSON on stdin (Copilot preToolUse event)
+# Output: JSON on stdout only when denying; silent when allowing
+#
+# Deny patterns (13):
+#   1.  rm -rf with dangerous targets (/, *, ~, .)
+#   2.  git push --force
+#   3.  git push -f
+#   4.  git reset --hard
+#   5.  git checkout -- .
+#   6.  git checkout .
+#   7.  git restore .
+#   8.  git clean -f
+#   9.  git commit --no-verify
+#   10. git push --no-verify
+#   11. git merge --no-verify
+#   12. git rebase --no-verify
+#   13. any command with --no-verify flag (catch-all)
+
+set -euo pipefail
+
+# Fail-open: any unhandled error allows the operation
+trap 'exit 0' ERR
+
+# ── Input parsing ──────────────────────────────────────────────
+
+INPUT=$(cat) || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL_NAME=$(jq -r '.toolName // empty' 2>/dev/null <<< "$INPUT") || exit 0
+[[ "${TOOL_NAME:-}" == "bash" ]] || exit 0
+
+COMMAND=$(jq -r '
+    if (.toolArgs | type) == "string" then
+        (.toolArgs | fromjson | .command // empty)
+    else
+        (.toolArgs.command // empty)
+    end' 2>/dev/null <<< "$INPUT") || exit 0
+[[ -n "${COMMAND:-}" ]] || exit 0
+
+# ── Helpers ────────────────────────────────────────────────────
+
+deny() {
+    local reason="$1"
+    printf '{"permissionDecision":"deny","permissionDecisionReason":"Blocked: %s"}\n' "$reason"
+    exit 0
+}
+
+# Remove content inside quotes to prevent false-positive flag detection.
+# E.g. git commit -m "about --no-verify" → git commit -m
+strip_quoted_strings() {
+    sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g" <<< "$1"
+}
+
+# Return 0 (true) when the rm target is a broad/destructive path.
+is_dangerous_rm_target() {
+    local t="$1"
+    [[ "$t" == "/" ]]  && return 0
+    [[ "$t" == "/*" ]] && return 0
+    [[ "$t" == "*" ]]  && return 0
+    [[ "$t" == "~" ]]  && return 0
+    # shellcheck disable=SC2088
+    [[ "$t" == "~/" ]] && return 0
+    [[ "$t" == "." ]]  && return 0
+    [[ "$t" == "./" ]] && return 0
+    [[ "$t" == ".." ]] && return 0
+    return 1
+}
+
+# ── Deny checks ───────────────────────────────────────────────
+
+# Pattern 1: rm -rf with dangerous targets
+# Block: rm -rf /, rm -rf *, rm -rf ~
+# Allow: rm -rf node_modules/, rm -rf dist/, rm -rf .cache/
+check_rm_rf() {
+    local cmd="$1"
+
+    # Combined flags (-rf, -fr, -rfv, etc.) with optional -- separator
+    local re='rm[[:space:]]+(-[[:alpha:]]*r[[:alpha:]]*f[[:alpha:]]*|-[[:alpha:]]*f[[:alpha:]]*r[[:alpha:]]*)[[:space:]]+(--[[:space:]]+)?([^[:space:]]+)'
+    if [[ "$cmd" =~ $re ]]; then
+        if is_dangerous_rm_target "${BASH_REMATCH[3]}"; then
+            deny "destructive operation 'rm -rf ${BASH_REMATCH[3]}'"
+        fi
+    fi
+
+    # Separate flags: -r ... -f
+    local re_rf='rm[[:space:]]+-[[:alpha:]]*r[[:alpha:]]*[[:space:]]+-[[:alpha:]]*f[[:alpha:]]*[[:space:]]+(--[[:space:]]+)?([^[:space:]]+)'
+    if [[ "$cmd" =~ $re_rf ]]; then
+        if is_dangerous_rm_target "${BASH_REMATCH[2]}"; then
+            deny "destructive operation 'rm -rf ${BASH_REMATCH[2]}'"
+        fi
+    fi
+
+    # Separate flags: -f ... -r
+    local re_fr='rm[[:space:]]+-[[:alpha:]]*f[[:alpha:]]*[[:space:]]+-[[:alpha:]]*r[[:alpha:]]*[[:space:]]+(--[[:space:]]+)?([^[:space:]]+)'
+    if [[ "$cmd" =~ $re_fr ]]; then
+        if is_dangerous_rm_target "${BASH_REMATCH[2]}"; then
+            deny "destructive operation 'rm -rf ${BASH_REMATCH[2]}'"
+        fi
+    fi
+}
+
+# Patterns 2-3: git push --force / -f
+# Allows --force-with-lease and --force-if-includes (safe variants).
+check_git_force_push() {
+    local cmd="$1"
+    local re_force='git[[:space:]]+(.*[[:space:]])?push[[:space:]]+(.*[[:space:]])?--force([[:space:]]|$)'
+    local re_f='git[[:space:]]+(.*[[:space:]])?push[[:space:]]+(.*[[:space:]])?-f([[:space:]]|$)'
+    if [[ "$cmd" =~ $re_force ]] || [[ "$cmd" =~ $re_f ]]; then
+        deny "force push 'git push --force'"
+    fi
+}
+
+# Pattern 4: git reset --hard
+check_git_reset_hard() {
+    local cmd="$1"
+    local re='git[[:space:]]+(.*[[:space:]])?reset[[:space:]]+(.*[[:space:]])?--hard([[:space:]]|$)'
+    if [[ "$cmd" =~ $re ]]; then
+        deny "destructive reset 'git reset --hard'"
+    fi
+}
+
+# Patterns 5-6: git checkout [--] .
+check_git_checkout_dot() {
+    local cmd="$1"
+    local re_dd='git[[:space:]]+(.*[[:space:]])?checkout[[:space:]]+(.*[[:space:]])?--[[:space:]]+\.([[:space:]]|$)'
+    local re_dot='git[[:space:]]+(.*[[:space:]])?checkout[[:space:]]+(.*[[:space:]])?\.([[:space:]]|$)'
+    if [[ "$cmd" =~ $re_dd ]] || [[ "$cmd" =~ $re_dot ]]; then
+        deny "destructive checkout 'git checkout .'"
+    fi
+}
+
+# Pattern 7: git restore .
+check_git_restore_dot() {
+    local cmd="$1"
+    local re='git[[:space:]]+(.*[[:space:]])?restore[[:space:]]+(.*[[:space:]])?\.([[:space:]]|$)'
+    if [[ "$cmd" =~ $re ]]; then
+        deny "destructive restore 'git restore .'"
+    fi
+}
+
+# Pattern 8: git clean -f
+check_git_clean_f() {
+    local cmd="$1"
+    local re='git[[:space:]]+(.*[[:space:]])?clean[[:space:]]+(.*[[:space:]])?-[[:alpha:]]*f[[:alpha:]]*([[:space:]]|$)'
+    if [[ "$cmd" =~ $re ]]; then
+        deny "destructive clean 'git clean -f'"
+    fi
+}
+
+# Patterns 9-13: --no-verify as a standalone flag (not inside quoted strings)
+check_no_verify() {
+    local cmd="$1"
+    local stripped
+    stripped=$(strip_quoted_strings "$cmd") || return
+    if [[ "$stripped" =~ (^|[[:space:]])--no-verify([[:space:]]|$) ]]; then
+        deny "verification bypass '--no-verify'"
+    fi
+}
+
+# ── Execute all checks ────────────────────────────────────────
+
+check_rm_rf "$COMMAND"
+check_git_force_push "$COMMAND"
+check_git_reset_hard "$COMMAND"
+check_git_checkout_dot "$COMMAND"
+check_git_restore_dot "$COMMAND"
+check_git_clean_f "$COMMAND"
+check_no_verify "$COMMAND"
+
+# All checks passed — allow the operation
+exit 0

--- a/scripts/hooks/copilot-error.ps1
+++ b/scripts/hooks/copilot-error.ps1
@@ -1,0 +1,11 @@
+# Copilot errorOccurred telemetry hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement telemetry for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-error.sh
+++ b/scripts/hooks/copilot-error.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copilot telemetry hook: emit error_occurred on errorOccurred event.
+# Called by GitHub Copilot hooks (errorOccurred event).
+# Fail-open: exit 0 always — never blocks IDE.
+set -uo pipefail
+
+main() {
+    # Read JSON from stdin (errorOccurred event data)
+    INPUT=$(cat)
+
+    # Resolve project root from script location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_LOG="$PROJECT_DIR/.ai-engineering/state/audit-log.ndjson"
+
+    # Extract error.message and error.name from stdin JSON
+    ERROR_NAME=""
+    ERROR_MESSAGE=""
+    if command -v jq >/dev/null 2>&1; then
+        ERROR_NAME=$(echo "$INPUT" | jq -r '.error.name // empty' 2>/dev/null)
+        ERROR_MESSAGE=$(echo "$INPUT" | jq -r '.error.message // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        ERROR_NAME=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('error', {}).get('name', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+        ERROR_MESSAGE=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('error', {}).get('message', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Default values if not provided
+    [ -z "$ERROR_NAME" ] && ERROR_NAME="unknown"
+    [ -z "$ERROR_MESSAGE" ] && ERROR_MESSAGE="unknown"
+
+    # Git metadata (fail gracefully if not in a repo)
+    BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    # Timestamp: use stdin JSON timestamp if available, otherwise generate ISO-8601
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Emit NDJSON event to audit log
+    if command -v jq >/dev/null 2>&1; then
+        jq -n -c \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg ename "$ERROR_NAME" \
+            --arg emsg "$ERROR_MESSAGE" \
+            --arg ts "$TIMESTAMP" \
+            '{actor:"ai-session",branch:$branch,commit_sha:$commit,detail:{type:"error_occurred",error_name:$ename,error_message:$emsg},event:"error_occurred",source:"hook",timestamp:$ts}' \
+            >> "$AUDIT_LOG" 2>/dev/null
+    else
+        # Escape double quotes in error message for JSON safety
+        SAFE_MSG=$(echo "$ERROR_MESSAGE" | tr '"' "'")
+        printf '{"actor":"ai-session","branch":"%s","commit_sha":"%s","detail":{"type":"error_occurred","error_name":"%s","error_message":"%s"},"event":"error_occurred","source":"hook","timestamp":"%s"}\n' \
+            "$BRANCH" "$COMMIT" "$ERROR_NAME" "$SAFE_MSG" "$TIMESTAMP" >> "$AUDIT_LOG" 2>/dev/null
+    fi
+}
+
+main || exit 0
+exit 0

--- a/scripts/hooks/copilot-session-end.ps1
+++ b/scripts/hooks/copilot-session-end.ps1
@@ -1,0 +1,11 @@
+# Copilot sessionEnd telemetry hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement telemetry for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-session-end.sh
+++ b/scripts/hooks/copilot-session-end.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copilot telemetry hook: emit session_end on sessionEnd event.
+# Called by GitHub Copilot hooks (sessionEnd event).
+# Fail-open: exit 0 always — never blocks IDE.
+set -uo pipefail
+
+main() {
+    # Read JSON from stdin (sessionEnd event data)
+    INPUT=$(cat)
+
+    # Resolve project root from script location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_LOG="$PROJECT_DIR/.ai-engineering/state/audit-log.ndjson"
+
+    # Extract reason from stdin JSON (complete/error/abort/timeout/user_exit)
+    REASON=""
+    if command -v jq >/dev/null 2>&1; then
+        REASON=$(echo "$INPUT" | jq -r '.reason // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        REASON=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('reason', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Default reason if not provided
+    [ -z "$REASON" ] && REASON="unknown"
+
+    # Git metadata (fail gracefully if not in a repo)
+    BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    # Timestamp: use stdin JSON timestamp if available, otherwise generate ISO-8601
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Emit NDJSON event to audit log
+    if command -v jq >/dev/null 2>&1; then
+        jq -n -c \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg reason "$REASON" \
+            --arg ts "$TIMESTAMP" \
+            '{actor:"ai-session",branch:$branch,commit_sha:$commit,detail:{type:"session_end",reason:$reason},event:"session_end",source:"hook",timestamp:$ts}' \
+            >> "$AUDIT_LOG" 2>/dev/null
+    else
+        printf '{"actor":"ai-session","branch":"%s","commit_sha":"%s","detail":{"type":"session_end","reason":"%s"},"event":"session_end","source":"hook","timestamp":"%s"}\n' \
+            "$BRANCH" "$COMMIT" "$REASON" "$TIMESTAMP" >> "$AUDIT_LOG" 2>/dev/null
+    fi
+}
+
+main || exit 0
+exit 0

--- a/scripts/hooks/copilot-session-start.ps1
+++ b/scripts/hooks/copilot-session-start.ps1
@@ -1,0 +1,11 @@
+# Copilot sessionStart telemetry hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement telemetry for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-session-start.sh
+++ b/scripts/hooks/copilot-session-start.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copilot telemetry hook: emit session_start on sessionStart event.
+# Called by GitHub Copilot hooks (sessionStart event).
+# Fail-open: exit 0 always — never blocks IDE.
+set -uo pipefail
+
+main() {
+    # Read JSON from stdin (sessionStart event data)
+    INPUT=$(cat)
+
+    # Resolve project root from script location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_LOG="$PROJECT_DIR/.ai-engineering/state/audit-log.ndjson"
+
+    # Extract source from stdin JSON (new/resume/startup)
+    SOURCE=""
+    if command -v jq >/dev/null 2>&1; then
+        SOURCE=$(echo "$INPUT" | jq -r '.source // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        SOURCE=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('source', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Default source if not provided
+    [ -z "$SOURCE" ] && SOURCE="unknown"
+
+    # Git metadata (fail gracefully if not in a repo)
+    BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    # Timestamp: use stdin JSON timestamp if available, otherwise generate ISO-8601
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Emit NDJSON event to audit log
+    if command -v jq >/dev/null 2>&1; then
+        jq -n -c \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg source "$SOURCE" \
+            --arg ts "$TIMESTAMP" \
+            '{actor:"ai-session",branch:$branch,commit_sha:$commit,detail:{type:"session_start",source:$source},event:"session_start",source:"hook",timestamp:$ts}' \
+            >> "$AUDIT_LOG" 2>/dev/null
+    else
+        printf '{"actor":"ai-session","branch":"%s","commit_sha":"%s","detail":{"type":"session_start","source":"%s"},"event":"session_start","source":"hook","timestamp":"%s"}\n' \
+            "$BRANCH" "$COMMIT" "$SOURCE" "$TIMESTAMP" >> "$AUDIT_LOG" 2>/dev/null
+    fi
+}
+
+main || exit 0
+exit 0

--- a/scripts/hooks/copilot-skill.ps1
+++ b/scripts/hooks/copilot-skill.ps1
@@ -1,0 +1,11 @@
+# Copilot userPromptSubmitted telemetry hook.
+# PowerShell stub for Windows compatibility.
+# Fail-open: exit 0 always.
+
+$ErrorActionPreference = "SilentlyContinue"
+try {
+    # TODO: implement telemetry for Windows
+    exit 0
+} catch {
+    exit 0
+}

--- a/scripts/hooks/copilot-skill.sh
+++ b/scripts/hooks/copilot-skill.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copilot telemetry hook: emit skill_invoked on userPromptSubmitted matching /ai-*.
+# Called by GitHub Copilot hooks (userPromptSubmitted event).
+# Fail-open: exit 0 always — never blocks IDE.
+set -uo pipefail
+
+main() {
+    # Read JSON from stdin (userPromptSubmitted event data)
+    INPUT=$(cat)
+
+    # Resolve project root from script location
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    AUDIT_LOG="$PROJECT_DIR/.ai-engineering/state/audit-log.ndjson"
+
+    # Extract prompt from stdin JSON
+    PROMPT=""
+    if command -v jq >/dev/null 2>&1; then
+        PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        PROMPT=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    print(json.load(sys.stdin).get('prompt', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+    fi
+
+    # Only match /ai-* slash commands (with optional args after space)
+    [[ "$PROMPT" =~ ^/ai-([a-zA-Z-]+) ]] || return 0
+    RAW="${BASH_REMATCH[1]}"
+
+    # Normalize: lowercase, ensure ai- prefix
+    SKILL_NAME="ai-$(echo "$RAW" | tr '[:upper:]' '[:lower:]')"
+
+    # Git metadata (fail gracefully if not in a repo)
+    BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    COMMIT=$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    # Timestamp: use stdin JSON timestamp if available, otherwise generate ISO-8601
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Emit NDJSON event to audit log
+    if command -v jq >/dev/null 2>&1; then
+        jq -n -c \
+            --arg branch "$BRANCH" \
+            --arg commit "$COMMIT" \
+            --arg skill "$SKILL_NAME" \
+            --arg ts "$TIMESTAMP" \
+            '{actor:"ai",branch:$branch,commit_sha:$commit,detail:{skill:$skill},event:"skill_invoked",source:"hook",timestamp:$ts}' \
+            >> "$AUDIT_LOG" 2>/dev/null
+    else
+        printf '{"actor":"ai","branch":"%s","commit_sha":"%s","detail":{"skill":"%s"},"event":"skill_invoked","source":"hook","timestamp":"%s"}\n' \
+            "$BRANCH" "$COMMIT" "$SKILL_NAME" "$TIMESTAMP" >> "$AUDIT_LOG" 2>/dev/null
+    fi
+}
+
+main || exit 0
+exit 0

--- a/src/ai_engineering/templates/.ai-engineering/manifest.yml
+++ b/src/ai_engineering/templates/.ai-engineering/manifest.yml
@@ -111,7 +111,7 @@ agents:
 
 # Ownership
 ownership:
-  framework: [".claude/skills/**", ".claude/agents/**", ".ai-engineering/**"]
+  framework: [".claude/skills/**", ".claude/agents/**", ".ai-engineering/**", ".github/agents/**", ".github/prompts/**", ".github/hooks/**", ".github/copilot-instructions.md", ".agents/**"]
   team: [".ai-engineering/contexts/team/**"]
   system: [".ai-engineering/state/**"]
 


### PR DESCRIPTION
## Summary
- Migrated `.github/hooks/hooks.json` from broken flat-array format to Copilot native `{ version: 1, hooks: { eventType: [...] } }` schema with all 6 hook types
- Created `preToolUse` deny-list hook (`copilot-deny.sh`) enforcing the same 13 dangerous-operation patterns blocked by Claude Code `settings.json` (force push, rm -rf *, --no-verify, etc.)
- Added 5 telemetry hook scripts emitting NDJSON events to `audit-log.ndjson` matching existing Claude telemetry format
- Adapted 6 missing handler files for `.agents/skills/` (create: 3, solution-intent: 3) with provider-neutral paths
- Expanded `manifest.yml` ownership to include `.github/` and `.agents/` paths

## Test Plan
- [x] All 6 bash scripts pass syntax check (`bash -n`)
- [x] Deny-list blocks all 13 patterns (positive test: rm -rf *, git push --force, --no-verify, etc.)
- [x] Deny-list allows legitimate commands (negative test: rm -rf node_modules/, commit messages with "no-verify", non-bash tools)
- [x] hooks.json validates: version 1, 6 object-keyed event types, bash + powershell paths
- [x] Handler files: zero `.claude/` references in `.agents/skills/`
- [x] Manifest ownership: 5 new paths present
- [x] copilot-instructions.md: 6 camelCase hook names, no old format refs
- [x] 1256 tests pass, 0 failures
- [x] Pre-commit, commit-msg, pre-push gates all PASS

## Spec
spec-055: GitHub Copilot Parity — Hooks, Deny-List, and Multi-Platform Completeness

## Checklist
- [x] Lint and format pass (ruff)
- [x] Secret scan clean (gitleaks)
- [x] Tests pass (1256/1256)
- [x] CHANGELOG updated
- [x] No changes to `.claude/` directory
- [x] Template mirror synced (`manifest.yml`)