### PR TITLE
feat(agents): enable Copilot subagent orchestration for full Claude Code parity

### DIFF
--- a/.agents/agents/ai-autopilot.md
+++ b/.agents/agents/ai-autopilot.md
@@ -20,10 +20,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -39,8 +51,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -50,9 +62,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -65,7 +77,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/.agents/agents/ai-build.md
+++ b/.agents/agents/ai-build.md
@@ -15,7 +15,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -63,7 +63,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -80,8 +80,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/.agents/skills/dispatch/SKILL.md
+++ b/.agents/skills/dispatch/SKILL.md
@@ -81,7 +81,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -108,10 +108,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -125,7 +125,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS

--- a/.ai-engineering/specs/plan.md
+++ b/.ai-engineering/specs/plan.md
@@ -1,3 +1,183 @@
-# No active plan
+# Plan: Copilot Subagent Orchestration — Full Parity with Claude Code
 
-Run /ai-plan after brainstorm approval.
+## Pipeline: standard
+## Phases: 5
+## Tasks: 17 (build: 13, verify: 3, conditional: 1)
+
+---
+
+### Phase 1: Sync Pipeline Infrastructure
+**Gate**: `AgentMeta` extended, `AGENT_METADATA` updated, `generate_copilot_agent()` serializes new properties. `ruff check scripts/` passes.
+
+- [x] T-1.1: Extend `AgentMeta` dataclass with `copilot_agents`, `copilot_handoffs`, `copilot_hooks` fields (agent: build)
+  - File: `scripts/sync_command_mirrors.py` lines 63-72
+  - Add 3 optional fields with defaults (empty tuple, empty tuple, None)
+  - Constraint: frozen dataclass — use default_factory pattern or direct defaults
+
+- [x] T-1.2: Update `AGENT_METADATA` dict with subagent config for 5 orchestrators (agent: build)
+  - File: `scripts/sync_command_mirrors.py` lines 76-236
+  - Add `copilot_agents` to: autopilot, build, plan, review, verify
+  - Add `copilot_handoffs` to: autopilot, build, plan, review
+  - Add `copilot_hooks` to: build only
+  - 4 leaf agents (explore, guard, guide, simplify) keep empty defaults
+  - Note: autopilot handoff uses `agent: "agent"` (intentional — targets the built-in default Copilot chat agent for PR creation, returning control to user)
+
+- [x] T-1.3: Update `generate_copilot_agent()` to serialize new frontmatter properties (agent: build)
+  - File: `scripts/sync_command_mirrors.py` lines 584-600
+  - Inject `agent` into tools list when `copilot_agents` is non-empty
+  - Serialize `agents: [...]` when non-empty
+  - Serialize `handoffs:` block (list of dicts) when non-empty
+  - Serialize `hooks:` block (nested dict) when non-empty
+  - Use `_format_yaml_field()` (line 352) for dict/list serialization
+  - Constraint: DO NOT modify `_serialize_frontmatter()` — it's for skills, not agents
+
+- [x] T-1.4: Lint and type-check sync script changes (agent: build)
+  - Run: `ruff check scripts/sync_command_mirrors.py`
+  - Run: `ruff format --check scripts/sync_command_mirrors.py`
+  - Fix any issues before proceeding
+
+### Phase 2: Canonical Agent Body Updates
+**Gate**: All `Dispatch Agent(X)` replaced with "Use the X agent" syntax. Autopilot has "Subagent Orchestration" section. Build references Guard/Explorer as subagents. No `.claude/` contains Copilot-only properties.
+
+- [x] T-2.1: Add "Subagent Orchestration" section to autopilot canonical (agent: build)
+  - File: `.claude/agents/ai-autopilot.md`
+  - Add new section after "Capabilities" (after line 26)
+  - Content per spec R4: 5-point delegation protocol
+
+- [x] T-2.2: Replace all `Dispatch Agent(X)` references in autopilot AND build canonicals (agent: build)
+  - File: `.claude/agents/ai-autopilot.md` — 8 occurrences at lines: 23, 24, 25, 42, 43, 53, 55, 68
+  - File: `.claude/agents/ai-build.md` — scan for ANY `Dispatch Agent(` occurrences beyond lines 65-87
+  - Replace with "Use the X agent to..." pattern
+  - Constraint: preserve meaning and context of each reference
+
+- [x] T-2.3: Update Build canonical — guard.advise and dispatch pattern (agent: build)
+  - File: `.claude/agents/ai-build.md`
+  - Line 65-66: Replace `guard.advise` with Guard agent subagent reference
+  - Lines 81-87: Add Explorer as consultable subagent in dispatch pattern
+
+- [x] T-2.4: Investigate and fix autopilot skill path bug (agent: build)
+  - File: `.claude/skills/ai-autopilot/SKILL.md`
+  - Investigation found: line 83 mentions "watch-and-fix loop" — verify if there's a handler reference that the `translate_refs()` regex misses
+  - Check all `.claude/` path references in the skill that the regex `_XREF_CLAUDE_SKILL` might not match (e.g., handler paths not rooted at the skill's SKILL.md)
+  - Fix any path references that won't translate correctly via sync
+
+- [x] T-2.5: Update dispatch skill canonical with agent name references (agent: build)
+  - File: `.claude/skills/ai-dispatch/SKILL.md`
+  - Replace any generic "subagent" references with explicit agent names where appropriate
+  - Ensure names used will be translated by `translate_refs()` for each platform
+
+### Phase 3: Sync, Regenerate, and Validate
+**Gate**: `ai-eng sync --check` passes (exit 0). Generated mirrors have correct frontmatter. Validator doesn't flag false drift.
+
+- [x] T-3.1: Run sync to regenerate all mirrors (agent: build)
+  - Run: `python scripts/sync_command_mirrors.py --verbose`
+  - Verify output: 9 agents × 3 surfaces + 37 skills × 3 surfaces regenerated
+  - Check generated `.github/agents/autopilot.agent.md` — must have `agents`, `handoffs`, `agent` in tools
+  - Check generated `.github/agents/build.agent.md` — must have `agents`, `handoffs`, `hooks`, `agent` in tools
+
+- [x] T-3.2: Run sync check to verify parity (agent: verify)
+  - Run: `ai-eng sync --check` or `python scripts/sync_command_mirrors.py --check`
+  - Must exit 0 (no drift)
+  - If fails: the mirror_sync validator may need updating (T-3.3)
+
+- [x] T-3.3: Update mirror_sync validator if needed (agent: build) — NOT NEEDED (sync passes)
+  - File: `src/ai_engineering/validator/categories/mirror_sync.py`
+  - ONLY if T-3.2 fails due to Copilot-only properties
+  - The validator uses full-file SHA-256 comparison (line 315)
+  - Since sync script GENERATES the mirrors, the hashes should match after regeneration
+  - If validator compares canonical `.claude/` vs `.github/` directly (not via sync), it will fail — adjust comparison logic
+  - Blocked by: T-3.2 (only execute if T-3.2 fails)
+
+### Phase 4: Documentation and Governance
+**Gate**: `docs/copilot-subagents.md` exists with 3 environment examples. `copilot-instructions.md` has subagent section. DEC-024 registered.
+
+- [x] T-4.1: Create `docs/copilot-subagents.md` (agent: build)
+  - New file: `docs/copilot-subagents.md`
+  - Must include:
+    - Sync architecture explanation (canonical → mirrors)
+    - Copilot-specific properties (`agents`, `handoffs`, `hooks`)
+    - VS Code usage example (agent tool + agents property)
+    - Copilot CLI usage example (task tool with agent_type)
+    - Coding Agent usage example (auto-discovery from repo)
+    - Capabilities matrix by environment
+    - Handoff chain diagram
+    - Reference to official docs + returngis article
+
+- [x] T-4.2: Add "Subagent Orchestration" section to copilot-instructions.md (agent: build)
+  - File: `.github/copilot-instructions.md`
+  - Add section after "Observability" (after line 51)
+  - Document: orchestrator agents, subagent tool, handoffs, and roles
+
+- [x] T-4.3: Register DEC-024 in decision-store.json (agent: build)
+  - File: `.ai-engineering/state/decision-store.json`
+  - ID: DEC-024
+  - Title: "Copilot subagent orchestration via sync pipeline"
+  - Status: active, Criticality: high
+  - Record rationale: platform-specific properties injected via AGENT_METADATA
+
+### Phase 5: Final Verification
+**Gate**: All 20 acceptance criteria pass. Linters clean. No regressions.
+
+- [x] T-5.1: Run full linter suite (agent: verify)
+  - `ruff check src/ scripts/`
+  - `ruff format --check src/ scripts/`
+  - `gitleaks detect`
+  - All must pass
+
+- [x] T-5.2: Verify all 20 acceptance criteria (agent: verify) — 20/20 PASS
+  - Check AC 1-3: sync pipeline (AgentMeta, AGENT_METADATA, generate function)
+  - Check AC 4-8: generated mirrors (frontmatter properties, sync --check)
+  - Check AC 9-12: canonical body changes (sections, syntax, path fix)
+  - Check AC 13-16: docs and governance (files exist, DEC-024, validator)
+  - Check AC 17-20: negative checks (leaf agents clean, no Copilot props in canonical, linters)
+
+---
+
+## Agent Assignments Summary
+
+| Agent | Tasks | Purpose |
+|-------|-------|---------|
+| build | 13 | Sync script changes, canonical body updates, docs, governance |
+| verify | 3 | Sync check, lint suite, AC verification |
+
+## Dependencies
+
+```
+T-1.1 → T-1.2 → T-1.3 → T-1.4
+                              ↘
+T-2.1 ──┐                     T-3.1 → T-3.2 → T-3.3 (conditional)
+T-2.2 ──┤ (parallel)                              ↓
+T-2.3 ──┤                     T-4.1 ──┐
+T-2.4 ──┤                     T-4.2 ──┤ (parallel, after Phase 3)
+T-2.5 ──┘                     T-4.3 ──┘
+                                       ↓
+                               T-5.1 → T-5.2
+```
+
+Phase 1 and Phase 2 can run in parallel (different files).
+Phase 3 requires both Phase 1 and Phase 2 complete.
+Phase 4 can start after Phase 3.
+Phase 5 runs last.
+
+## Files Modified (Expected)
+
+| File | Phase | Change Type |
+|------|-------|-------------|
+| `scripts/sync_command_mirrors.py` | 1 | Extend dataclass, metadata, generator |
+| `.claude/agents/ai-autopilot.md` | 2 | Add section, unify syntax |
+| `.claude/agents/ai-build.md` | 2 | Update guard.advise, add Explorer |
+| `.claude/skills/ai-autopilot/SKILL.md` | 2 | Fix path bug |
+| `.claude/skills/ai-dispatch/SKILL.md` | 2 | Update agent references |
+| `src/ai_engineering/validator/categories/mirror_sync.py` | 3 | Conditional — only if validator fails |
+| `docs/copilot-subagents.md` | 4 | New file |
+| `.github/copilot-instructions.md` | 4 | Add section |
+| `.ai-engineering/state/decision-store.json` | 4 | Add DEC-024 |
+
+## Auto-generated (via sync, NOT manually edited)
+
+| File | Source |
+|------|--------|
+| `.github/agents/*.agent.md` (9 files) | sync from `.claude/agents/` + `AGENT_METADATA` |
+| `.github/prompts/*.prompt.md` (37 files) | sync from `.claude/skills/` |
+| `.agents/agents/*.md` (9 files) | sync from `.claude/agents/` |
+| `.agents/skills/*/SKILL.md` (37 dirs) | sync from `.claude/skills/` |

--- a/.ai-engineering/specs/spec.md
+++ b/.ai-engineering/specs/spec.md
@@ -1,3 +1,438 @@
-# No active spec
+# SPEC: GitHub Copilot Subagent Orchestration — Full Parity with Claude Code
 
-Run /ai-brainstorm to start a new spec.
+## Status: APPROVED
+
+## Refs
+
+- Official docs: https://code.visualstudio.com/docs/copilot/customization/custom-agents (Mar 2026)
+- Inspiration: returngis.net — "Haz que tus custom agents sean subagents de GitHub Copilot" (Feb 2026)
+- Decisions: DEC-022 (GitHub Agentic Workflows), DEC-023 (Autopilot invocation-as-approval)
+- Manifest: `.ai-engineering/manifest.yml` → `providers.ides: [claude_code, github_copilot]`
+
+---
+
+## Problem Statement
+
+ai-engineering tiene **paridad 100% en lógica** entre Claude Code y GitHub Copilot (9 agentes, 37 skills, hooks configurados). Sin embargo, los agentes de Copilot **no orquestan subagentes** porque:
+
+1. **Ningún agente orquestador tiene el tool `agent`** en su frontmatter — requerido por Copilot para delegar a subagentes.
+2. **Ningún agente orquestador declara la propiedad `agents`** — la lista explícita de subagentes permitidos que Copilot necesita para el routing.
+3. **No hay `handoffs` configurados** — la funcionalidad nativa de Copilot para transiciones guiadas entre agentes (Plan → Build → Verify) no se aprovecha.
+4. **Las instrucciones usan sintaxis genérica** (`Dispatch Agent(Build)`) sin referenciar el mecanismo nativo de delegación de Copilot.
+5. **No hay documentación** sobre cómo usar subagentes en los 3 entornos (VS Code, CLI terminal, Coding Agent cloud).
+6. **No se usa `hooks` per-agent** — Copilot soporta hooks scoped al agente (e.g., auto-format en Build) via `chat.useCustomAgentHooks`.
+
+### Hallazgo clave de la documentación oficial
+
+La propiedad `infer` está **DEPRECATED**. Las propiedades correctas son:
+
+| Propiedad | Default | Propósito |
+|-----------|---------|-----------|
+| `user-invocable` | `true` | Visible en el picker de agentes |
+| `disable-model-invocation` | `false` | Permite/bloquea invocación como subagente |
+| `agents` | (none) | Lista explícita de subagentes permitidos |
+| `handoffs` | (none) | Transiciones guiadas entre agentes |
+
+La propiedad `isSticky` **NO EXISTE** en Copilot.
+
+**Nota sobre defaults**: Los 9 agentes usan los valores por defecto de `user-invocable` (true) y `disable-model-invocation` (false). No se necesitan overrides porque todos los agentes deben ser: (a) visibles en el picker para invocación directa, y (b) invocables como subagentes por agentes orquestadores. La delegación se controla via la propiedad `agents` del orquestador (allowlist explícita), no bloqueando el subagente.
+
+## Goal
+
+Alcanzar **paridad funcional completa** con Claude Code en orquestación multi-agente, usando las APIs nativas de Copilot (`agents`, `handoffs`, `agent` tool, per-agent `hooks`), en los tres entornos: VS Code, Copilot CLI terminal, y Coding Agent (cloud).
+
+## Non-Goals
+
+- Modificar la lógica de los skills (ya son idénticos cross-platform)
+- Cambiar agentes de Claude Code (`.claude/agents/`)
+- Crear nuevos agentes (los 9 existentes cubren todos los roles)
+- Implementar hooks globales de Claude en Copilot (scope de otro spec)
+- Añadir `infer` (deprecated) — usar las propiedades modernas
+- Modificar `AGENTS.md` o `CLAUDE.md` (root instruction files)
+- Modificar `.agents/agents/` mirror (propiedades `agents`, `handoffs` y `hooks` son Copilot-específicas)
+
+---
+
+## Sync Architecture (Critical Context)
+
+**El flujo de cambios es unidireccional**:
+
+```
+.claude/ (CANONICAL)
+    │
+    │  scripts/sync_command_mirrors.py
+    │  + AGENT_METADATA dict (static mapping)
+    │
+    ├──▶ .agents/     (generic mirror — tools stripped, refs translated)
+    ├──▶ .github/     (Copilot mirror — tools translated, skills flattened)
+    └──▶ templates/   (install templates)
+```
+
+**Regla fundamental**: NUNCA editar mirrors directamente. Todos los cambios van a:
+1. `.claude/` (para lógica de agentes/skills — body text, instrucciones)
+2. `scripts/sync_command_mirrors.py` (para metadata platform-specific — `agents`, `handoffs`, `hooks`)
+
+El sync script tiene:
+- `AgentMeta` dataclass (line 63-72) — metadata per-agent
+- `AGENT_METADATA` dict (line 76-236) — `copilot_tools`, `claude_tools` per agent
+- `generate_copilot_agent()` (line 584-600) — genera frontmatter Copilot
+
+**Las propiedades `agents`, `handoffs`, `hooks` son Copilot-only** — se inyectan SOLO en la generación de `.github/agents/` via el sync script.
+
+---
+
+## Requirements
+
+### R1: Extender `AgentMeta` dataclass con propiedades Copilot subagent
+
+**Archivo**: `scripts/sync_command_mirrors.py` (line 63-72)
+
+Añadir campos opcionales a `AgentMeta`:
+
+```python
+@dataclass(frozen=True)
+class AgentMeta:
+    display_name: str
+    description: str
+    model: str
+    color: str
+    copilot_tools: tuple[str, ...]
+    claude_tools: tuple[str, ...]
+    # NEW: Copilot subagent orchestration
+    copilot_agents: tuple[str, ...] = ()      # Allowed subagent names
+    copilot_handoffs: tuple[dict, ...] = ()    # Handoff transitions
+    copilot_hooks: dict | None = None          # Per-agent hooks
+```
+
+### R2: Actualizar `AGENT_METADATA` con datos de subagentes
+
+**Archivo**: `scripts/sync_command_mirrors.py` (line 76-236)
+
+Actualizar las entradas de los 5 agentes orquestadores:
+
+| Agente | `copilot_agents` | `copilot_handoffs` | `copilot_hooks` |
+|--------|-------------------|--------------------|-----------------| 
+| `autopilot` | `('Build', 'Explorer', 'Verify', 'Plan', 'Guard')` | `[{label: "📋 Create PR", agent: "agent", ...}]` | None |
+| `build` | `('Guard', 'Explorer')` | `[{label: "✅ Verify", agent: "Verify", ...}, {label: "🔍 Review", agent: "Review", ...}]` | `{PostToolUse: [{type: command, command: "ruff format --quiet"}]}` |
+| `plan` | `('Explorer', 'Guard')` | `[{label: "▶ Dispatch", agent: "Autopilot", ...}]` | None |
+| `review` | `('Explorer',)` | `[{label: "🔧 Fix Issues", agent: "Build", ...}]` | None |
+| `verify` | `('Explorer',)` | None | None |
+
+Los 4 agentes leaf (explore, guard, guide, simplify) mantienen defaults vacíos.
+
+### R3: Actualizar `generate_copilot_agent()` para serializar nuevas propiedades
+
+**Archivo**: `scripts/sync_command_mirrors.py` (line 584-600)
+
+Modificar la función para:
+1. Añadir `agent` al array de `tools` cuando `copilot_agents` no está vacío
+2. Serializar `agents: [...]` en frontmatter cuando `copilot_agents` existe
+3. Serializar `handoffs: [...]` en frontmatter cuando `copilot_handoffs` existe
+4. Serializar `hooks: {...}` en frontmatter cuando `copilot_hooks` existe
+
+Considerar migrar de frontmatter manual a usar `_serialize_frontmatter()` para mantener consistencia.
+
+### R4: Actualizar body del autopilot CANONICAL con orquestación explícita
+
+**Archivo**: `.claude/agents/ai-autopilot.md` (CANONICAL)
+
+Añadir sección "Subagent Orchestration" al body:
+
+```markdown
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates
+4. **Govern**: Use the Guard agent for governance advisory (optional)
+5. **Plan**: Use the Plan agent for sub-spec decomposition (optional)
+```
+
+El sync script traducirá los nombres automáticamente para cada plataforma.
+
+### R5: Actualizar body del build CANONICAL con delegación
+
+**Archivo**: `.claude/agents/ai-build.md` (CANONICAL)
+
+Actualizar dos puntos:
+
+1. **Step 2 (guard.advise)**: Cambiar a referencia de subagente
+2. **Step 6 (Dispatch Pattern)**: Añadir Explorer como subagente consultable
+
+### R6: Unificar sintaxis de delegación en CANONICAL
+
+**Archivos**: `.claude/agents/ai-autopilot.md`, `.claude/agents/ai-build.md` (CANONICAL)
+
+Reemplazar TODAS las referencias legacy `Dispatch Agent(X)` por la sintaxis "Use the X agent to..." en los archivos canónicos. El sync propagará el cambio a todos los mirrors.
+
+### R7: Fix bug de path cruzado en autopilot CANONICAL
+
+**Archivo**: `.claude/skills/ai-autopilot/SKILL.md` (CANONICAL)
+
+Verificar y corregir cualquier referencia que cause el bug descubierto en la investigación (`.claude/` path en skill que debería usar path relativo a la plataforma). El sync script traduce paths automáticamente — el bug está en el CANONICAL si el sync lo genera mal, o en el sync script si no traduce correctamente.
+
+### R8: Actualizar dispatch skill CANONICAL con nombres de agentes
+
+**Archivo**: `.claude/skills/ai-dispatch/SKILL.md` (CANONICAL)
+
+Actualizar las referencias genéricas de `Agent(Build)`, `Agent(Verify)`, etc. para usar nombres descriptivos que el sync pueda traducir correctamente.
+
+### R9: Ejecutar sync y verificar mirrors
+
+Después de todos los cambios en canonical + sync script:
+
+```bash
+python scripts/sync_command_mirrors.py --verbose
+ai-eng sync --check  # Debe pasar (exit 0)
+```
+
+Verificar que los `.github/agents/*.agent.md` generados tienen:
+- `agent` en tools (orquestadores)
+- `agents: [...]` con nombres correctos
+- `handoffs: [...]` donde aplique
+- `hooks: {...}` en build
+
+### R10: Documentación de subagentes
+
+Crear `docs/copilot-subagents.md` con guía que incluya:
+- Cómo funciona el sync (canonical → mirrors)
+- Propiedades Copilot-specific inyectadas por el sync
+- Patrones de orquestación por entorno (VS Code, CLI, Coding Agent)
+- Matriz de capacidades
+- Al menos 1 ejemplo por entorno
+
+### R11: Actualizar copilot-instructions.md
+
+Añadir sección "Subagent Orchestration" en `.github/copilot-instructions.md` documentando la capacidad de delegación.
+
+### R12: Decisión en decision-store.json
+
+Registrar como DEC-024:
+- Title: "Copilot subagent orchestration via sync pipeline"
+- Rationale: Propiedades Copilot-only (`agents`, `handoffs`, `hooks`) se inyectan via `AGENT_METADATA` en el sync script, manteniendo `.claude/` como canonical source sin contaminar con propiedades platform-specific
+- Status: active
+- Criticality: high
+
+### R13: Actualizar mirror_sync validator si necesario
+
+**Archivo**: `src/ai_engineering/validator/categories/mirror_sync.py`
+
+Verificar que el parity validator (spec-006) NO flagee drift por las propiedades Copilot-only (`agents`, `handoffs`, `hooks`) que solo existen en `.github/agents/`. Si flagea, ajustar la lógica de comparación.
+
+> **Nota sobre interacción de hooks**: Los per-agent hooks y los global hooks (`.github/hooks/hooks.json`) son pipelines independientes. El hook global `postToolUse` (telemetría) y el per-agent hook (auto-format) se ejecutan ambos sin bloquearse mutuamente.
+
+> **Requisito VS Code**: Per-agent hooks requieren `chat.useCustomAgentHooks: true` en VS Code settings. Esto es **opcional** — la delegación de subagentes (R1-R3) funciona SIN este setting.
+
+---
+
+## Architecture
+
+### Change Flow (Sync Pipeline)
+
+```
+┌──────────────────────────────────────────────────────┐
+│  STEP 1: Edit canonical sources                       │
+│                                                       │
+│  .claude/agents/ai-autopilot.md   (body text)        │
+│  .claude/agents/ai-build.md      (body text)         │
+│  .claude/skills/ai-dispatch/     (skill logic)       │
+│  .claude/skills/ai-autopilot/    (fix path bug)      │
+│                                                       │
+│  scripts/sync_command_mirrors.py  (AGENT_METADATA)   │
+│    ├── AgentMeta: +copilot_agents, +copilot_handoffs │
+│    ├── AGENT_METADATA: per-agent subagent config     │
+│    └── generate_copilot_agent(): serialize new props  │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼  python scripts/sync_command_mirrors.py
+┌──────────────────────────────────────────────────────┐
+│  STEP 2: Auto-generated mirrors                       │
+│                                                       │
+│  .github/agents/autopilot.agent.md  ← agents, handoffs│
+│  .github/agents/build.agent.md     ← agents, handoffs, hooks│
+│  .github/agents/plan.agent.md      ← agents, handoffs│
+│  .github/agents/review.agent.md    ← agents, handoffs│
+│  .github/agents/verify.agent.md    ← agents          │
+│  .github/prompts/ai-dispatch.prompt.md  ← updated refs│
+│  .github/prompts/ai-autopilot.prompt.md ← fixed path │
+│                                                       │
+│  .agents/agents/ai-*.md            ← body only (no   │
+│  .agents/skills/*/SKILL.md           Copilot props)   │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼  ai-eng sync --check
+┌──────────────────────────────────────────────────────┐
+│  STEP 3: Validation                                   │
+│                                                       │
+│  ✓ SHA-256 parity check (canonical vs mirrors)       │
+│  ✓ Manifest coherence (37 skills, 9 agents)          │
+│  ✓ Cross-reference validation (no broken paths)      │
+│  ✓ CI gate: exit 0 = all mirrors in sync             │
+└──────────────────────────────────────────────────────┘
+```
+
+### Delegation Model (3 entornos)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                      VS Code Chat                         │
+│                                                           │
+│  User → @Autopilot (tools: [agent], agents: [Build,...]) │
+│           ├── Build agent (implementation)                │
+│           │     └── handoff → Verify                     │
+│           ├── Verify agent (anti-hallucination gates)    │
+│           ├── Explorer agent (codebase research)         │
+│           └── Guard agent (governance advisory)          │
+│                                                           │
+│  Handoffs: Plan ──▶ Autopilot ──▶ PR                    │
+│            Build ──▶ Verify / Review                     │
+│            Review ──▶ Build (fix issues)                 │
+│                                                           │
+│  No special VS Code setting needed — works by default    │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│                   Copilot CLI Terminal                     │
+│                                                           │
+│  User → /ai-autopilot → task tool delegation              │
+│           ├── task(agent_type: "build", ...)              │
+│           ├── task(agent_type: "verify", ...)             │
+│           └── task(agent_type: "explore", ...)            │
+│                                                           │
+│  Agents auto-registered from .github/agents/*.agent.md   │
+│  Handoffs not applicable (CLI uses task tool directly)    │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│                Coding Agent (Cloud)                        │
+│                                                           │
+│  Issue → Coding Agent → repo .agent.md discovery          │
+│           ├── Discovers agents from .github/agents/       │
+│           ├── Uses agents property for delegation         │
+│           └── Handoffs available for workflow transitions  │
+│                                                           │
+│  No config needed — agents discovered from repo           │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Orchestration Flow (Autopilot with subagents)
+
+```
+autopilot.agent.md
+  tools: [agent, codebase, githubRepo, readFile, runCommands, search]
+  agents: [Build, Explorer, Verify, Plan, Guard]
+    │
+    ├── Split Phase: decompose spec into sub-specs
+    │
+    ├── Explore Phase: delegate to Explorer agent (parallel)
+    │     └── Explorer reads codebase, returns findings
+    │
+    ├── Execute Loop (per sub-spec):
+    │     ├── Plan: read sub-spec + skill SKILL.md
+    │     ├── Implement: delegate to Build agent (fresh context)
+    │     │     └── Build.hooks.PostToolUse: auto-format via ruff
+    │     ├── Verify: delegate to Verify agent (anti-hallucination)
+    │     └── Commit: if verify passes, incremental commit
+    │
+    ├── Deliver: handoff → PR creation
+    │
+    └── Handoff buttons:
+          └── [📋 Create PR] → default agent with PR prompt
+```
+
+### Handoff Chain (VS Code)
+
+```
+@Plan ──[▶ Dispatch Implementation]──▶ @Autopilot
+                                          │
+                        ┌─────────────────┼─────────────────┐
+                        ▼                 ▼                 ▼
+                   @Explorer          @Build            @Verify
+                                        │
+                              ┌─────────┼─────────┐
+                              ▼                   ▼
+                   [✅ Verify Changes]    [🔍 Review Changes]
+                         │                      │
+                         ▼                      ▼
+                      @Verify              @Review
+                                              │
+                                    [🔧 Fix Issues]
+                                              │
+                                              ▼
+                                           @Build
+```
+
+---
+
+## Acceptance Criteria
+
+### Sync Pipeline (R1-R3)
+1. `AgentMeta` dataclass tiene campos `copilot_agents`, `copilot_handoffs`, `copilot_hooks`
+2. `AGENT_METADATA` tiene subagent data para los 5 orquestadores (autopilot, build, plan, review, verify)
+3. `generate_copilot_agent()` serializa `agents`, `handoffs`, `hooks` en frontmatter generado
+
+### Generated Mirrors (R9 — verificado post-sync)
+4. Los 5 `.github/agents/*.agent.md` generados tienen `agent` en `tools`
+5. Los 5 `.github/agents/*.agent.md` generados tienen `agents: [...]` correctos
+6. Los 4 con handoffs tienen `handoffs: [...]` (plan, autopilot, build, review)
+7. `build.agent.md` generado tiene `hooks: {PostToolUse: ...}`
+8. `ai-eng sync --check` pasa (exit 0) después de regenerar mirrors
+
+### Canonical Body Changes (R4-R8)
+9. `.claude/agents/ai-autopilot.md` tiene sección "Subagent Orchestration"
+10. `.claude/agents/ai-build.md` referencia Guard y Explorer como subagentes
+11. No coexisten `Dispatch Agent(X)` y "Use the X agent" en ningún archivo canonical
+12. El bug de path `.claude/` en la skill autopilot está corregido en canonical
+
+### Documentation & Governance (R10-R13)
+13. `docs/copilot-subagents.md` existe con ≥1 ejemplo por entorno
+14. `.github/copilot-instructions.md` tiene sección "Subagent Orchestration"
+15. `decision-store.json` tiene DEC-024
+16. Mirror sync validator no flagea drift por propiedades Copilot-only
+
+### Negative Checks
+17. Los 4 leaf agents (explore, guard, guide, simplify) NO tienen `agent` en tools, `agents`, `handoffs`, ni `hooks`
+18. `.claude/agents/` no contiene propiedades Copilot-only (`agents`, `handoffs`, `hooks`)
+19. `.agents/agents/` no contiene propiedades Copilot-only
+20. Linters pasan: `ruff check src/ scripts/` y `gitleaks detect`
+
+---
+
+## Rollback Plan
+
+Si la delegación de subagentes causa mis-routing (agentes incorrectos reciben tareas):
+
+1. Revertir los cambios de frontmatter (git revert del commit)
+2. Los agentes siguen funcionando como invocación directa sin delegación
+3. Los handoffs desaparecen — no hay side effects
+4. Los per-agent hooks se desactivan al revertir
+
+---
+
+## Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Copilot CLI no soporta `agents` property | Media | Bajo | CLI usa `task` tool directamente; `agents` es solo para VS Code routing |
+| Handoffs no soportados en Coding Agent | Baja | Bajo | Fail-open: agentes siguen delegando via `agents` property |
+| `chat.useCustomAgentHooks` deshabilitado por defecto | Alta | Bajo | Documentar en guide; hooks son enhancement, no requisito |
+| Agente incorrecto recibe delegación | Baja | Medio | `agents` property es allowlist explícita — limita routing |
+| Coding Agent ignora per-agent hooks | Alta | Bajo | Hooks son VS Code-only enhancement; no bloquea funcionalidad core |
+| Parity validator (spec-006) flag drift en `.agents/` mirror | Media | Bajo | Si el validator flagea drift por `agents`/`handoffs`/`hooks` (propiedades Copilot-specific), ajustar la lógica de comparación del validator para ignorar estas propiedades. Esto es un fix menor, no un spec separado |
+
+---
+
+## Out of Scope
+
+- Hooks globales de seguridad (prompt-injection-guard para Copilot)
+- Cost tracking para Copilot
+- Instinct extraction para Copilot
+- Nuevos agentes o skills
+- Editar `.github/agents/` o `.github/prompts/` directamente (son mirrors auto-generados)
+- Editar `.agents/agents/` directamente (es mirror auto-generado)
+- Añadir propiedades Copilot-only a `.claude/` canonical (se inyectan via sync script)
+- Cambios en `AGENTS.md` o `CLAUDE.md` (root instruction files)
+- Cambios en `manifest.yml` (agent count y names no cambian)
+- Crear `.vscode/settings.json` (subagentes funcionan por defecto)

--- a/.ai-engineering/state/decision-store.json
+++ b/.ai-engineering/state/decision-store.json
@@ -398,6 +398,24 @@
       "decision": "When invoked via /ai-autopilot, the user invocation serves as the single approval gate for the entire pipeline (brainstorm split -> plan -> dispatch -> verify -> PR). This overrides DEC-003 human gates between phases. Automatic spec-review and verify gates compensate. Failure after 2 retries restores manual control.",
       "decidedAt": "2026-03-24T00:00:00Z",
       "context": "governance"
+    },
+    {
+      "id": "DEC-024",
+      "title": "Copilot subagent orchestration via sync pipeline",
+      "description": "Copilot-specific subagent properties (agents, handoffs, hooks) are injected via AGENT_METADATA in scripts/sync_command_mirrors.py during mirror generation. This keeps .claude/ canonical sources clean of platform-specific properties while enabling full orchestration in GitHub Copilot VS Code, CLI, and Coding Agent. Properties: agents (allowlist of delegatable subagents), handoffs (guided workflow transitions), hooks (per-agent lifecycle hooks). Based on official VS Code docs (Mar 2026) — uses modern properties instead of deprecated infer.",
+      "category": "architecture",
+      "status": "active",
+      "criticality": "high",
+      "source": "spec-064",
+      "spec": "064",
+      "created_at": "2026-03-24",
+      "expires_at": "2027-03-24T00:00:00Z",
+      "context_hash": "",
+      "acknowledged_by": "plan",
+      "decision": "Copilot-specific subagent properties (agents, handoffs, hooks) are injected via AGENT_METADATA in scripts/sync_command_mirrors.py during mirror generation. This keeps .claude/ canonical sources clean of platform-specific properties while enabling full orchestration in GitHub Copilot VS Code, CLI, and Coding Agent. Properties: agents (allowlist of delegatable subagents), handoffs (guided workflow transitions), hooks (per-agent lifecycle hooks). Based on official VS Code docs (Mar 2026) — uses modern properties instead of deprecated infer.",
+      "decidedAt": "2026-03-24T00:00:00Z",
+      "context": "architecture",
+      "refs": ["https://code.visualstudio.com/docs/copilot/customization/custom-agents"]
     }
   ]
 }

--- a/.claude/agents/ai-autopilot.md
+++ b/.claude/agents/ai-autopilot.md
@@ -20,10 +20,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -39,8 +51,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -50,9 +62,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -65,7 +77,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/.claude/agents/ai-build.md
+++ b/.claude/agents/ai-build.md
@@ -15,7 +15,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -63,7 +63,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -80,8 +80,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/.claude/skills/ai-autopilot/handlers/phase-pr.md
+++ b/.claude/skills/ai-autopilot/handlers/phase-pr.md
@@ -72,7 +72,7 @@ If existing PR found: extend body per ai-pr protocol (append, never overwrite).
 
 If `--no-watch` flag was passed: skip to Step 6.
 
-Read `.claude/skills/ai-pr/handlers/watch.md` and execute the full watch-and-fix loop:
+Read `.claude/skills/ai-pr/SKILL.md` step 14 and execute the full watch-and-fix loop:
 
 - Poll every 60s (active) or 180s (passive)
 - Autonomously fix CI failures via commit pipeline (ai-commit steps 0-6)

--- a/.claude/skills/ai-dispatch/SKILL.md
+++ b/.claude/skills/ai-dispatch/SKILL.md
@@ -80,7 +80,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -107,10 +107,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -124,7 +124,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS

--- a/.github/agents/autopilot.agent.md
+++ b/.github/agents/autopilot.agent.md
@@ -3,7 +3,13 @@ name: "Autopilot"
 description: "Autonomous multi-spec orchestrator -- splits large specs into focused sub-specs, executes sequentially with fresh-context agents, verifies anti-hallucination gates, delivers via PR."
 color: purple
 model: opus
-tools: [codebase, githubRepo, readFile, runCommands, search]
+tools: [codebase, githubRepo, readFile, runCommands, search, agent]
+agents: [Build, Explorer, Verify, Plan, Guard]
+handoffs:
+- label: 📋 Create PR
+  agent: agent
+  prompt: Create a PR with the changes from the autopilot execution.
+  send: false
 ---
 
 
@@ -21,10 +27,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -40,8 +58,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -51,9 +69,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -66,7 +84,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/.github/agents/build.agent.md
+++ b/.github/agents/build.agent.md
@@ -3,7 +3,21 @@ name: "Build"
 description: "Implementation across all stacks -- the only code write agent"
 color: blue
 model: opus
-tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures]
+tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures, agent]
+agents: [Guard, Explorer]
+handoffs:
+- label: ✅ Verify Changes
+  agent: Verify
+  prompt: Verify the implementation changes made above.
+  send: false
+- label: 🔍 Review Changes
+  agent: Review
+  prompt: Review the code changes made above.
+  send: false
+hooks:
+  PostToolUse:
+  - type: command
+    command: ruff format --quiet
 ---
 
 
@@ -16,7 +30,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -64,7 +78,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -81,8 +95,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/.github/agents/plan.agent.md
+++ b/.github/agents/plan.agent.md
@@ -3,7 +3,13 @@ name: "Plan"
 description: "Advisory planning: classify scope, assess risks, and recommend pipeline"
 color: purple
 model: opus
-tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures]
+tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures, agent]
+agents: [Explorer, Guard]
+handoffs:
+- label: ▶ Dispatch Implementation
+  agent: Autopilot
+  prompt: Execute the plan outlined above following the approved spec.
+  send: false
 ---
 
 

--- a/.github/agents/review.agent.md
+++ b/.github/agents/review.agent.md
@@ -3,7 +3,13 @@ name: "Review"
 description: "Code review agent -- multi-pass review with architecture, security, quality, and style checks."
 color: red
 model: opus
-tools: [codebase, githubRepo, problems, readFile, search]
+tools: [codebase, githubRepo, problems, readFile, search, agent]
+agents: [Explorer]
+handoffs:
+- label: 🔧 Fix Issues
+  agent: Build
+  prompt: Fix the issues identified in the review above.
+  send: false
 ---
 
 

--- a/.github/agents/verify.agent.md
+++ b/.github/agents/verify.agent.md
@@ -3,7 +3,8 @@ name: "Verify"
 description: "7-mode assessment: governance, security, quality, performance, a11y, feature-gap, architecture -- produces GO/NO-GO verdicts."
 color: green
 model: opus
-tools: [codebase, githubRepo, problems, readFile, runCommands, search]
+tools: [codebase, githubRepo, problems, readFile, runCommands, search, agent]
+agents: [Explorer]
 ---
 
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,23 @@ Telemetry is **automatic via hooks** — configured in `.github/hooks/hooks.json
 - All events → `.ai-engineering/state/audit-log.ndjson`
 - Dashboards: `ai-eng observe [engineer|team|ai|dora|health]`
 
+## Subagent Orchestration
+
+Orchestrator agents can delegate tasks to specialized subagents via the `agent` tool:
+
+| Orchestrator | Delegates To | Handoffs |
+|-------------|-------------|----------|
+| Autopilot | Build, Explorer, Verify, Plan, Guard | → Create PR |
+| Build | Guard, Explorer | → Verify, → Review |
+| Plan | Explorer, Guard | → Autopilot |
+| Review | Explorer | → Build |
+| Verify | Explorer | — |
+
+Leaf agents (Explorer, Guard, Guide, Simplifier) cannot delegate — they are terminal nodes.
+
+Handoffs provide guided transitions between agents in VS Code (buttons after responses).
+Per-agent hooks (e.g., auto-format in Build) require `chat.useCustomAgentHooks: true`.
+
 ## Quick Reference
 
 - Skills (37): `.github/prompts/ai-<name>.prompt.md`

--- a/.github/prompts/ai-autopilot.prompt.md
+++ b/.github/prompts/ai-autopilot.prompt.md
@@ -506,7 +506,7 @@ If existing PR found: extend body per ai-pr protocol (append, never overwrite).
 
 If `--no-watch` flag was passed: skip to Step 6.
 
-Read `.claude/skills/ai-pr/handlers/watch.md` and execute the full watch-and-fix loop:
+Read `.github/prompts/ai-pr.prompt.md` step 14 and execute the full watch-and-fix loop:
 
 - Poll every 60s (active) or 180s (passive)
 - Autonomously fix CI failures via commit pipeline (ai-commit steps 0-6)

--- a/.github/prompts/ai-dispatch.prompt.md
+++ b/.github/prompts/ai-dispatch.prompt.md
@@ -82,7 +82,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -109,10 +109,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -126,7 +126,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Copilot subagent orchestration (spec-064)** -- full parity with Claude Code multi-agent delegation. 5 orchestrator agents (Autopilot, Build, Plan, Review, Verify) can now delegate to subagents via `agents` property, `handoffs` (guided transitions), and per-agent `hooks`. Sync pipeline injects Copilot-specific properties via `AGENT_METADATA` — canonical `.claude/` sources remain clean. Works across VS Code, CLI, and Coding Agent.
+- **`docs/copilot-subagents.md`** -- comprehensive guide covering sync architecture, Copilot properties, usage examples for all 3 environments, capabilities matrix, and handoff chain diagram.
+- **DEC-024** -- Copilot subagent orchestration via sync pipeline (architecture decision, active, high criticality).
 - **`/ai-autopilot` skill (spec-063)** -- multi-spec autonomous orchestrator that splits large specs into focused sub-specs, executes sequentially with fresh-context agents, verifies anti-hallucination gates, and delivers via PR. 5 phase handlers (split, explore, execute, verify, pr) with `--resume` and `--no-watch` flags.
 - **`ai-autopilot` agent** -- 9th agent (orchestrator role), read-only + bash tools, delegates all code changes to subagents.
 - **DEC-023 governance override** -- autopilot invocation is approval for the full pipeline; internal gates are automatic with 2-failure stop.
@@ -18,11 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Strategic compact hook** -- `scripts/hooks/strategic-compact.py` with Claude Code `Edit|Write|MultiEdit` hook for strategic context management during long sessions.
 
 ### Changed
+- **Sync script (`sync_command_mirrors.py`)** -- extended `AgentMeta` dataclass with `copilot_agents`, `copilot_handoffs`, `copilot_hooks` fields; `generate_copilot_agent()` serializes new frontmatter properties for 5 orchestrator agents.
+- **Canonical agent instructions** -- replaced `Dispatch Agent(X)` syntax with "Use the X agent" pattern in `ai-autopilot.md` and `ai-build.md`; added "Subagent Orchestration" section to autopilot; added Guard/Explorer delegation references to Build.
+- **Copilot instructions** -- added "Subagent Orchestration" section to `.github/copilot-instructions.md` with orchestrator delegation table.
 - **Manifest registry** -- skill count 32 -> 37, agent count 8 -> 9, all new skills registered with types and tags.
 - **Skill frontmatter validator** -- added `mcp` and `skills` as valid keys in `requires` block.
 - **All IDE mirrors updated** -- `.claude/`, `.github/`, `.agents/`, and template mirrors regenerated for all new and modified skills.
 
 ### Fixed
+- **Autopilot skill cross-platform path bug** -- `.claude/skills/ai-pr/handlers/watch.md` handler path in `phase-pr.md` replaced with `.claude/skills/ai-pr/SKILL.md step 14` (handler paths aren't translated by sync regex).
+- **Dispatch skill agent names** -- normalized generic "subagent" references to canonical agent names (`ai-build`, `ai-verify`, `ai-guard`) for consistent cross-platform translation.
 - **Mirror sync: 46 handler files added to `.agents/` mirrors** -- write (4), review (8), debug (8), create (3), solution-intent (3) handlers were missing from Codex/Gemini mirrors (root + template). Routing tables referenced nonexistent files.
 - **Skill count synced to 32 across all instruction files** -- CLAUDE.md, AGENTS.md, copilot-instructions.md, and template manifest updated. `ai-instinct` added to Meta group and Effort Levels table (max: 8 -> 9).
 - **Handler separators in sync script** -- `sync_command_mirrors.py` now inserts `---` between handler sections in concatenated `.prompt.md` files, matching the existing `ai-debug` convention.

--- a/docs/copilot-subagents.md
+++ b/docs/copilot-subagents.md
@@ -1,0 +1,138 @@
+# Copilot Subagent Orchestration
+
+How ai-engineering enables multi-agent orchestration in GitHub Copilot, achieving feature parity with Claude Code.
+
+## How It Works
+
+All agent definitions live in `.claude/` as the **canonical source**. The sync script (`scripts/sync_command_mirrors.py`) reads each canonical agent file, enriches it with Copilot-specific properties from the `AGENT_METADATA` dict, and writes the result to `.github/agents/*.agent.md`. These properties — `agents`, `handoffs`, `hooks` — are **only** injected into the GitHub Copilot surface; other mirrors (`.agents/`, templates) receive the base content without them.
+
+The sync is deterministic: run `python scripts/sync_command_mirrors.py` to regenerate all mirrors, or `--check` to verify no drift exists.
+
+## Copilot-Specific Properties
+
+| Property | Purpose | Example |
+|----------|---------|---------|
+| `agents` | Allowlist of subagent names this agent can invoke | `[Build, Explorer, Verify]` |
+| `handoffs` | Guided transitions between agents (buttons in VS Code) | `label: "✅ Verify Changes"` → Verify |
+| `hooks` | Per-agent hooks scoped to this agent only | `PostToolUse: ruff format --quiet` |
+| `agent` (tool) | Must be in the tools list to enable delegation | Added automatically by sync |
+
+The sync script reads `copilot_agents`, `copilot_handoffs`, and `copilot_hooks` from each `AgentMeta` entry and writes them as YAML frontmatter in the generated `.agent.md` files.
+
+## Agent Roles
+
+| Agent | Role | Can Delegate To | Handoffs |
+|-------|------|-----------------|----------|
+| Autopilot | Multi-spec orchestrator | Build, Explorer, Verify, Plan, Guard | → Create PR |
+| Build | Implementation (only write agent) | Guard, Explorer | → Verify Changes, → Review Changes |
+| Plan | Spec decomposition | Explorer, Guard | → Dispatch Implementation → Autopilot |
+| Review | Code review | Explorer | → Fix Issues → Build |
+| Verify | Quality + security assessment | Explorer | — |
+| Explorer | Codebase research (leaf) | — | — |
+| Guard | Governance advisory (leaf) | — | — |
+| Guide | Teaching & onboarding (leaf) | — | — |
+| Simplifier | Code simplification (leaf) | — | — |
+
+**Leaf agents** have no `agents` or `handoffs` — they execute and return results to the caller.
+
+## Environment Capabilities
+
+| Feature | VS Code | Copilot CLI | Coding Agent |
+|---------|:-------:|:-----------:|:------------:|
+| Subagent delegation (`agents`) | ✅ Native | ❌ Uses `task` tool | ✅ Auto-discovery |
+| Handoffs (transition buttons) | ✅ Native | ❌ Not applicable | ⚠️ Unconfirmed |
+| Per-agent hooks | ✅ Requires setting | ⚠️ Unconfirmed | ⚠️ Unconfirmed |
+| Agent discovery from repo | ✅ | ✅ | ✅ |
+
+## VS Code Usage
+
+Select **@Autopilot** in VS Code chat to start an orchestrated session. It delegates automatically to Build, Explorer, Verify, Plan, and Guard based on the task.
+
+After each agent response, handoff buttons appear in the chat:
+
+- **@Plan** → `[▶ Dispatch Implementation]` → **@Autopilot**
+- **@Build** → `[✅ Verify Changes]` or `[🔍 Review Changes]`
+- **@Review** → `[🔧 Fix Issues]` → **@Build**
+
+Per-agent hooks (e.g., auto-format after Build edits) require this VS Code setting:
+
+```jsonc
+// .vscode/settings.json (optional)
+{ "chat.useCustomAgentHooks": true }
+```
+
+With hooks enabled, Build's `PostToolUse` hook runs `ruff format --quiet` after every file edit — keeping code formatted without manual intervention.
+
+## Copilot CLI Usage
+
+In Copilot CLI, agents are dispatched via the `task` tool rather than the `agents` property:
+
+```
+User: /ai-autopilot "Implement feature X"
+CLI: → task(agent: "build", prompt: "Implement sub-spec 1...")
+     → task(agent: "verify", prompt: "Verify implementation...")
+     → task(agent: "explore", prompt: "Research dependencies...")
+```
+
+The `agents` and `handoffs` frontmatter properties are ignored in CLI mode — the CLI dispatches agents directly through tool calls. Agent discovery still works: the CLI reads `.github/agents/` from the repository.
+
+## Coding Agent Usage
+
+When Coding Agent processes a GitHub issue, it discovers agents from `.github/agents/` in the repository. The `agents` property enables it to delegate to specialized agents automatically — Autopilot can split work across Build, Verify, and Explorer just like in VS Code. Handoff buttons are not rendered in the cloud environment, but the delegation chain still functions.
+
+## Handoff Chain
+
+```
+@Plan ──[▶ Dispatch]──▶ @Autopilot
+                            │
+              ┌─────────────┼─────────────┐
+              ▼             ▼             ▼
+         @Explorer      @Build        @Verify
+                          │
+                ┌─────────┼─────────┐
+                ▼                   ▼
+     [✅ Verify Changes]    [🔍 Review Changes]
+           │                      │
+           ▼                      ▼
+        @Verify              @Review
+                                │
+                      [🔧 Fix Issues]
+                                │
+                                ▼
+                             @Build
+```
+
+## Sync Architecture
+
+```
+.claude/ (CANONICAL SOURCE)
+    │
+    │  scripts/sync_command_mirrors.py
+    │  + AGENT_METADATA (copilot_agents, copilot_handoffs, copilot_hooks)
+    │
+    ├──▶ .github/agents/*.agent.md   (with agents, handoffs, hooks)
+    ├──▶ .agents/agents/ai-*.md      (without Copilot-specific props)
+    └──▶ templates/                   (install templates)
+```
+
+**Rule**: changes always go to `.claude/` canonical sources. Never edit mirrors directly — they are overwritten on every sync run.
+
+To add or modify orchestration properties, edit the `AGENT_METADATA` dict in `scripts/sync_command_mirrors.py` and re-run the sync.
+
+## Comparison with Claude Code
+
+| Aspect | Claude Code | GitHub Copilot |
+|--------|-------------|----------------|
+| Dispatch mechanism | `Agent(Build)` in agent instructions | `agents` property + `agent` tool |
+| Handoffs | Not applicable (inline dispatch) | Native button transitions |
+| Per-agent hooks | Global hooks in `.claude/settings.json` | Per-agent `hooks` in frontmatter |
+| Context management | Fresh context per subagent dispatch | Fresh context via agent tool |
+| Discovery | Reads `.claude/agents/` directly | Reads `.github/agents/` (synced mirror) |
+
+Both environments achieve the same orchestration outcome — specialized agents with scoped permissions executing focused tasks — through different mechanisms.
+
+## References
+
+- [VS Code Custom Agents Docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents)
+- [returngis: Custom agents como subagents](https://www.returngis.net/2026/02/haz-que-tus-custom-agents-sean-subagents-de-github-copilot/)
+- Decision: DEC-024 in `.ai-engineering/state/decision-store.json`

--- a/scripts/sync_command_mirrors.py
+++ b/scripts/sync_command_mirrors.py
@@ -70,6 +70,9 @@ class AgentMeta:
     color: str
     copilot_tools: tuple[str, ...]
     claude_tools: tuple[str, ...]
+    copilot_agents: tuple[str, ...] = ()
+    copilot_handoffs: tuple[dict, ...] = ()
+    copilot_hooks: dict | None = None
 
 
 # ── Agent metadata (single source for all surfaces) ────────────────────────
@@ -92,6 +95,22 @@ AGENT_METADATA: dict[str, AgentMeta] = {
             "testFailures",
         ),
         claude_tools=("Read", "Write", "Edit", "Bash", "Glob", "Grep"),
+        copilot_agents=("Guard", "Explorer"),
+        copilot_handoffs=(
+            {
+                "label": "✅ Verify Changes",
+                "agent": "Verify",
+                "prompt": "Verify the implementation changes made above.",
+                "send": False,
+            },
+            {
+                "label": "🔍 Review Changes",
+                "agent": "Review",
+                "prompt": "Review the code changes made above.",
+                "send": False,
+            },
+        ),
+        copilot_hooks={"PostToolUse": [{"type": "command", "command": "ruff format --quiet"}]},
     ),
     "explore": AgentMeta(
         display_name="Explorer",
@@ -158,6 +177,15 @@ AGENT_METADATA: dict[str, AgentMeta] = {
             "testFailures",
         ),
         claude_tools=("Read", "Glob", "Grep", "Bash", "Write", "Edit"),
+        copilot_agents=("Explorer", "Guard"),
+        copilot_handoffs=(
+            {
+                "label": "▶ Dispatch Implementation",
+                "agent": "Autopilot",
+                "prompt": "Execute the plan outlined above following the approved spec.",
+                "send": False,
+            },
+        ),
     ),
     "review": AgentMeta(
         display_name="Review",
@@ -175,6 +203,15 @@ AGENT_METADATA: dict[str, AgentMeta] = {
             "search",
         ),
         claude_tools=("Read", "Glob", "Grep"),
+        copilot_agents=("Explorer",),
+        copilot_handoffs=(
+            {
+                "label": "🔧 Fix Issues",
+                "agent": "Build",
+                "prompt": "Fix the issues identified in the review above.",
+                "send": False,
+            },
+        ),
     ),
     "simplify": AgentMeta(
         display_name="Simplifier",
@@ -214,6 +251,7 @@ AGENT_METADATA: dict[str, AgentMeta] = {
             "search",
         ),
         claude_tools=("Read", "Glob", "Grep", "Bash"),
+        copilot_agents=("Explorer",),
     ),
     "autopilot": AgentMeta(
         display_name="Autopilot",
@@ -232,6 +270,15 @@ AGENT_METADATA: dict[str, AgentMeta] = {
             "search",
         ),
         claude_tools=("Read", "Glob", "Grep", "Bash"),
+        copilot_agents=("Build", "Explorer", "Verify", "Plan", "Guard"),
+        copilot_handoffs=(
+            {
+                "label": "📋 Create PR",
+                "agent": "agent",
+                "prompt": "Create a PR with the changes from the autopilot execution.",
+                "send": False,
+            },
+        ),
     ),
 }
 
@@ -583,21 +630,51 @@ def generate_copilot_prompt(name: str, skill_path: Path) -> str:
 
 def generate_copilot_agent(name: str, meta: AgentMeta, agent_path: Path) -> str:
     """Generate .github/agents/<name>.agent.md with full embedded content."""
+    import yaml
+
     body = read_body(agent_path)
     body = translate_refs(body, "copilot")
 
-    tools_str = ", ".join(meta.copilot_tools)
-    return (
-        f"---\n"
-        f'name: "{meta.display_name}"\n'
-        f'description: "{meta.description}"\n'
-        f"color: {meta.color}\n"
-        f"model: {meta.model}\n"
-        f"tools: [{tools_str}]\n"
-        f"---\n"
-        f"\n"
-        f"{body.rstrip()}\n"
-    )
+    # Build tools list — inject "agent" when subagents are declared
+    tools = list(meta.copilot_tools)
+    if meta.copilot_agents:
+        tools.append("agent")
+    tools_str = ", ".join(tools)
+
+    lines = [
+        "---",
+        f'name: "{meta.display_name}"',
+        f'description: "{meta.description}"',
+        f"color: {meta.color}",
+        f"model: {meta.model}",
+        f"tools: [{tools_str}]",
+    ]
+
+    if meta.copilot_agents:
+        agents_str = ", ".join(meta.copilot_agents)
+        lines.append(f"agents: [{agents_str}]")
+
+    if meta.copilot_handoffs:
+        handoffs_yaml = yaml.dump(
+            {"handoffs": [dict(h) for h in meta.copilot_handoffs]},
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        ).rstrip()
+        lines.append(handoffs_yaml)
+
+    if meta.copilot_hooks is not None:
+        hooks_yaml = yaml.dump(
+            {"hooks": meta.copilot_hooks},
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        ).rstrip()
+        lines.append(hooks_yaml)
+
+    lines.append("---")
+
+    return "\n".join(lines) + f"\n\n{body.rstrip()}\n"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/ai_engineering/templates/project/.agents/agents/ai-autopilot.md
+++ b/src/ai_engineering/templates/project/.agents/agents/ai-autopilot.md
@@ -20,10 +20,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -39,8 +51,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -50,9 +62,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -65,7 +77,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/src/ai_engineering/templates/project/.agents/agents/ai-build.md
+++ b/src/ai_engineering/templates/project/.agents/agents/ai-build.md
@@ -15,7 +15,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -63,7 +63,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -80,8 +80,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/src/ai_engineering/templates/project/.agents/skills/dispatch/SKILL.md
+++ b/src/ai_engineering/templates/project/.agents/skills/dispatch/SKILL.md
@@ -81,7 +81,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -108,10 +108,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -125,7 +125,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS

--- a/src/ai_engineering/templates/project/.claude/agents/ai-autopilot.md
+++ b/src/ai_engineering/templates/project/.claude/agents/ai-autopilot.md
@@ -20,10 +20,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -39,8 +51,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -50,9 +62,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -65,7 +77,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/src/ai_engineering/templates/project/.claude/agents/ai-build.md
+++ b/src/ai_engineering/templates/project/.claude/agents/ai-build.md
@@ -15,7 +15,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -63,7 +63,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -80,8 +80,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/src/ai_engineering/templates/project/.claude/skills/ai-autopilot/handlers/phase-pr.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-autopilot/handlers/phase-pr.md
@@ -72,7 +72,7 @@ If existing PR found: extend body per ai-pr protocol (append, never overwrite).
 
 If `--no-watch` flag was passed: skip to Step 6.
 
-Read `.claude/skills/ai-pr/handlers/watch.md` and execute the full watch-and-fix loop:
+Read `.claude/skills/ai-pr/SKILL.md` step 14 and execute the full watch-and-fix loop:
 
 - Poll every 60s (active) or 180s (passive)
 - Autonomously fix CI failures via commit pipeline (ai-commit steps 0-6)

--- a/src/ai_engineering/templates/project/.claude/skills/ai-dispatch/SKILL.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-dispatch/SKILL.md
@@ -80,7 +80,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -107,10 +107,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -124,7 +124,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS

--- a/src/ai_engineering/templates/project/agents/autopilot.agent.md
+++ b/src/ai_engineering/templates/project/agents/autopilot.agent.md
@@ -3,7 +3,13 @@ name: "Autopilot"
 description: "Autonomous multi-spec orchestrator -- splits large specs into focused sub-specs, executes sequentially with fresh-context agents, verifies anti-hallucination gates, delivers via PR."
 color: purple
 model: opus
-tools: [codebase, githubRepo, readFile, runCommands, search]
+tools: [codebase, githubRepo, readFile, runCommands, search, agent]
+agents: [Build, Explorer, Verify, Plan, Guard]
+handoffs:
+- label: 📋 Create PR
+  agent: agent
+  prompt: Create a PR with the changes from the autopilot execution.
+  send: false
 ---
 
 
@@ -21,10 +27,22 @@ Take an approved spec with N work units. Split into focused sub-specs. Execute e
 ## Capabilities
 
 - Read skill SKILL.md files and embed their instructions into subagent prompts (thin orchestrator -- skills carry the logic, this agent carries the sequence)
-- Dispatch Agent(Explore) in parallel for deep codebase research before execution begins
-- Dispatch Agent(Build) for implementation with fresh context per sub-spec
-- Dispatch Agent(Verify) for anti-hallucination gates after each sub-spec
+- Use the Explorer agent in parallel for deep codebase research before execution begins
+- Use the Build agent for implementation with fresh context per sub-spec
+- Use the Verify agent for anti-hallucination gates after each sub-spec
 - Git operations (commit, status, log, diff) for incremental commits between phases
+
+## Subagent Orchestration
+
+You coordinate specialized agents for multi-phase delivery:
+
+1. **Research**: Use the Explorer agent to gather codebase context before implementation begins
+2. **Implement**: Use the Build agent for code changes (fresh context per sub-spec)
+3. **Verify**: Use the Verify agent for anti-hallucination gates after each sub-spec
+4. **Govern**: Use the Guard agent for governance advisory checks (optional, fail-open)
+5. **Plan**: Use the Plan agent for sub-spec decomposition when needed (optional)
+
+Each agent receives scoped context: sub-spec description, file paths, constraints, and verify checklist. No carry-over between sub-specs — each invocation starts fresh.
 
 ## Behavior
 
@@ -40,8 +58,8 @@ Decompose the approved spec into ordered sub-specs:
 ### 2. Explore Phase
 
 Before any implementation begins, launch parallel exploration:
-1. Dispatch Agent(Explore) to map current codebase state relevant to each sub-spec
-2. Dispatch Agent(Explore) to identify patterns, conventions, and existing implementations that sub-specs must follow
+1. Use the Explorer agent to map current codebase state relevant to each sub-spec
+2. Use the Explorer agent to identify patterns, conventions, and existing implementations that sub-specs must follow
 3. Collect findings into `.ai-engineering/specs/autopilot/exploration.md`
 4. Update sub-specs with exploration findings (file paths, patterns, constraints discovered)
 
@@ -51,9 +69,9 @@ For each sub-spec in manifest order:
 
 **3a. Plan** -- Read the sub-spec. Read the relevant skill SKILL.md files. Compose the build prompt with all necessary context embedded (file paths, patterns, constraints, acceptance criteria).
 
-**3b. Implement** -- Dispatch Agent(Build) with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
+**3b. Implement** -- Use the Build agent with the composed prompt. Build agent receives fresh context: sub-spec scope, referenced files, stack standards, and verify checklist. No carry-over from previous sub-specs.
 
-**3c. Verify** -- Dispatch Agent(Verify) against the sub-spec's acceptance criteria. The verify checklist must include:
+**3c. Verify** -- Use the Verify agent against the sub-spec's acceptance criteria. The verify checklist must include:
 - Functional correctness (does the implementation match the sub-spec?)
 - Anti-hallucination gate (do referenced files, functions, and imports actually exist?)
 - Stack validation (linters, type checks pass?)
@@ -66,7 +84,7 @@ For each sub-spec in manifest order:
 ### 4. Final Verify Phase
 
 After all sub-specs complete:
-1. Dispatch Agent(Verify) on the full changeset against the original spec
+1. Use the Verify agent on the full changeset against the original spec
 2. Run full test suite and lint pass
 3. Confirm no regressions against main branch
 4. If final verify fails, escalate -- do not attempt to fix at this stage

--- a/src/ai_engineering/templates/project/agents/build.agent.md
+++ b/src/ai_engineering/templates/project/agents/build.agent.md
@@ -3,7 +3,21 @@ name: "Build"
 description: "Implementation across all stacks -- the only code write agent"
 color: blue
 model: opus
-tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures]
+tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures, agent]
+agents: [Guard, Explorer]
+handoffs:
+- label: ✅ Verify Changes
+  agent: Verify
+  prompt: Verify the implementation changes made above.
+  send: false
+- label: 🔍 Review Changes
+  agent: Review
+  prompt: Review the code changes made above.
+  send: false
+hooks:
+  PostToolUse:
+  - type: command
+    command: ruff format --quiet
 ---
 
 
@@ -16,7 +30,7 @@ Distinguished principal engineer (18+ years) specializing in multi-stack platfor
 
 ## Mandate
 
-Execute approved plans with discipline. Write code that passes every gate on the first commit. Dispatch subagents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
+Execute approved plans with discipline. Write code that passes every gate on the first commit. Use specialized agents per task with fresh context. Escalate after 2 failed attempts -- never brute force.
 
 ## Supported Stacks (20)
 
@@ -64,7 +78,7 @@ Follow the loaded skill's procedure. After every file modification, run post-edi
 - **Terraform**: `terraform fmt -check` + `terraform validate`
 
 **Step 2 -- Guard advisory** (intelligent governance check):
-- Invoke `guard.advise` on changed files (shift-left governance)
+- Use the Guard agent to check changed files for governance issues (shift-left advisory)
 - Address warnings before proceeding. Fail-open: if guard unavailable, continue.
 
 Fix validation failures before proceeding (max 3 attempts).
@@ -81,8 +95,10 @@ Fix validation failures before proceeding (max 3 attempts).
 
 ### 6. Dispatch Pattern
 
-For multi-task plans, dispatch subagents per task with fresh context:
+For multi-task plans, use specialized agents per task with fresh context:
 - Each task gets its own agent invocation with scoped instructions
+- Use the Explorer agent to gather context before complex implementations
+- Use the Guard agent for governance advisory on changed files (fail-open)
 - Task dependencies are respected (blocked tasks wait)
 - Two-stage review per task: spec compliance + code quality
 - If stuck after 2 attempts on any task, escalate immediately

--- a/src/ai_engineering/templates/project/agents/plan.agent.md
+++ b/src/ai_engineering/templates/project/agents/plan.agent.md
@@ -3,7 +3,13 @@ name: "Plan"
 description: "Advisory planning: classify scope, assess risks, and recommend pipeline"
 color: purple
 model: opus
-tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures]
+tools: [codebase, editFiles, fetch, githubRepo, problems, readFile, runCommands, search, terminalLastCommand, testFailures, agent]
+agents: [Explorer, Guard]
+handoffs:
+- label: ▶ Dispatch Implementation
+  agent: Autopilot
+  prompt: Execute the plan outlined above following the approved spec.
+  send: false
 ---
 
 

--- a/src/ai_engineering/templates/project/agents/review.agent.md
+++ b/src/ai_engineering/templates/project/agents/review.agent.md
@@ -3,7 +3,13 @@ name: "Review"
 description: "Code review agent -- multi-pass review with architecture, security, quality, and style checks."
 color: red
 model: opus
-tools: [codebase, githubRepo, problems, readFile, search]
+tools: [codebase, githubRepo, problems, readFile, search, agent]
+agents: [Explorer]
+handoffs:
+- label: 🔧 Fix Issues
+  agent: Build
+  prompt: Fix the issues identified in the review above.
+  send: false
 ---
 
 

--- a/src/ai_engineering/templates/project/agents/verify.agent.md
+++ b/src/ai_engineering/templates/project/agents/verify.agent.md
@@ -3,7 +3,8 @@ name: "Verify"
 description: "7-mode assessment: governance, security, quality, performance, a11y, feature-gap, architecture -- produces GO/NO-GO verdicts."
 color: green
 model: opus
-tools: [codebase, githubRepo, problems, readFile, runCommands, search]
+tools: [codebase, githubRepo, problems, readFile, runCommands, search, agent]
+agents: [Explorer]
 ---
 
 

--- a/src/ai_engineering/templates/project/prompts/ai-autopilot.prompt.md
+++ b/src/ai_engineering/templates/project/prompts/ai-autopilot.prompt.md
@@ -506,7 +506,7 @@ If existing PR found: extend body per ai-pr protocol (append, never overwrite).
 
 If `--no-watch` flag was passed: skip to Step 6.
 
-Read `.claude/skills/ai-pr/handlers/watch.md` and execute the full watch-and-fix loop:
+Read `.github/prompts/ai-pr.prompt.md` step 14 and execute the full watch-and-fix loop:
 
 - Poll every 60s (active) or 180s (passive)
 - Autonomously fix CI failures via commit pipeline (ai-commit steps 0-6)

--- a/src/ai_engineering/templates/project/prompts/ai-dispatch.prompt.md
+++ b/src/ai_engineering/templates/project/prompts/ai-dispatch.prompt.md
@@ -82,7 +82,7 @@ Each subagent receives a focused context window:
 ```yaml
 task: T-2.1
 description: "Implement the parse_config function"
-agent: build
+agent: ai-build
 scope:
   files: ["src/config.py", "tests/test_config.py"]
   boundaries: ["Do NOT modify src/main.py", "Do NOT touch hooks/"]
@@ -109,10 +109,10 @@ Never loop silently. Never retry the same approach more than twice.
 Update tasks.md in real-time:
 
 ```markdown
-- [x] T-1.1: Create config module @build -- DONE
-- [x] T-1.2: Add validation logic @build -- DONE_WITH_CONCERNS (perf warning)
-- [ ] T-2.1: Write integration tests @build -- IN PROGRESS
-- [ ] T-2.2: Security scan @verify -- PENDING
+- [x] T-1.1: Create config module @ai-build -- DONE
+- [x] T-1.2: Add validation logic @ai-build -- DONE_WITH_CONCERNS (perf warning)
+- [ ] T-2.1: Write integration tests @ai-build -- IN PROGRESS
+- [ ] T-2.2: Security scan @ai-verify -- PENDING
 ```
 
 ## Common Mistakes
@@ -126,7 +126,7 @@ Update tasks.md in real-time:
 ## Integration
 
 - **Called by**: user directly (after `/ai-plan` approval)
-- **Calls**: `ai-build agent` (build tasks), `/ai-verify` (scan tasks), `/ai-guard` (gate checks)
+- **Calls**: `ai-build` (build tasks), `ai-verify` (scan tasks), `ai-guard` (gate checks)
 - **Transitions to**: `/ai-commit` (after all tasks DONE), or back to `/ai-plan` (if re-plan needed)
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary

- **Copilot subagent orchestration** — 5 orchestrator agents (Autopilot, Build, Plan, Review, Verify) can now delegate to specialized subagents via `agents` property, `handoffs` (guided transitions), and per-agent `hooks` in GitHub Copilot VS Code, CLI, and Coding Agent.
- **Sync pipeline injection** — Copilot-specific properties are injected via `AGENT_METADATA` in `sync_command_mirrors.py` during mirror generation, keeping canonical `.claude/` sources clean of platform-specific fields.
- **Bug fixes** — autopilot skill handler path (sync regex compatibility) and dispatch skill agent name normalization.

## Test Plan

- [x] `ruff check src/ scripts/` — All checks passed
- [x] `ruff format --check src/ scripts/` — 147 files already formatted
- [x] `gitleaks protect --staged` — no leaks found
- [x] `python scripts/sync_command_mirrors.py --check` — All 295 mirror files in sync
- [x] 20/20 acceptance criteria verified (AC-1 through AC-20)
- [ ] CI pipeline (pytest, ty, semgrep, pip-audit)

## Key Changes

### Sync Pipeline
- Extended `AgentMeta` dataclass with `copilot_agents`, `copilot_handoffs`, `copilot_hooks`
- Populated `AGENT_METADATA` for 5 orchestrators with delegation config
- Updated `generate_copilot_agent()` to serialize new frontmatter properties

### Generated Mirrors (5 orchestrator agents)
- `autopilot.agent.md`: agents=[Build, Explorer, Verify, Plan, Guard], handoffs, agent tool
- `build.agent.md`: agents=[Guard, Explorer], handoffs to Verify/Review, per-agent hooks
- `plan.agent.md`: agents=[Explorer, Guard], handoff to Autopilot
- `review.agent.md`: agents=[Explorer], handoff to Build
- `verify.agent.md`: agents=[Explorer]

### Bug Fixes
- `phase-pr.md`: Fixed handler path for sync regex compatibility
- `ai-dispatch/SKILL.md`: Normalized to canonical agent names

### Documentation
- New: `docs/copilot-subagents.md` (3-environment guide)
- Updated: `.github/copilot-instructions.md` (Subagent Orchestration section)
- Registered: DEC-024 in `decision-store.json`

## Checklist

- [x] Lint and format pass
- [x] Secret scan clean
- [x] Mirror sync verified (295 files)
- [x] CHANGELOG updated
- [x] DEC-024 registered
- [x] Spec-064: 20/20 ACs verified