### PR TITLE
fix(ci): resolve detached HEAD preventing semantic-release version bump

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: main
           fetch-depth: 0
           token: ${{ github.token }}
 
@@ -54,7 +54,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.semrel.outputs.tag }}"
-          git tag "$TAG" "${{ github.event.workflow_run.head_sha }}"
+          git tag "$TAG" HEAD
           git push origin "$TAG"
 
       - name: Attest build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ build-backend = "hatchling.build"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-commit_parser = "angular"
+commit_parser = "conventional"
 tag_format = "v{version}"
 major_on_zero = false
 changelog_file = false


### PR DESCRIPTION
## Summary
- CI Build workflow checked out `workflow_run.head_sha` causing **detached HEAD** — semantic-release couldn't match the `main` release group
- Result: "No version bump needed" despite 270+ commits with `feat(...)` since `v0.1.0`, so no tag/attest/SBOM/checksums/release were created
- **Fix**: checkout `ref: main` instead of specific SHA, tag `HEAD` instead of workflow_run SHA
- Migrates `commit_parser` from deprecated `angular` to `conventional` (suppresses v11 deprecation warning)

## Test Plan
- [x] All pre-push gates pass (semgrep, pip-audit, tests, ty-check, sonar)
- [ ] CI passes on this PR
- [ ] After merge, CI Build detects version bump (0.1.0 → 0.2.0)
- [ ] Tag `v0.2.0` created, attestation + SBOM + checksums in draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)