### PR TITLE
fix(ci): send force as JSON boolean in ref update API call

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -95,7 +95,9 @@ jobs:
 
           # Fast-forward main ref to the new commit
           gh api "repos/${REPO}/git/refs/heads/main" \
-            -X PATCH -f sha="$COMMIT_SHA" -f force=false
+            -X PATCH --input - <<REFPATCH
+          {"sha":"${COMMIT_SHA}","force":false}
+          REFPATCH
 
           # Update local working tree to match
           git fetch origin main


### PR DESCRIPTION
## Summary
- `gh api -f force=false` sends string `"false"`, not boolean `false`
- GitHub API rejects: `"false" is not a boolean` (HTTP 422)
- Fix: use `--input` with raw JSON to send proper boolean

🤖 Generated with [Claude Code](https://claude.com/claude-code)