### PR TITLE
fix(ci): bump version locally before build so artifact matches tag

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Build
-        run: uv build
-
       - name: Determine version bump
         id: semrel
         run: |
@@ -51,6 +48,17 @@ jobs:
             echo "released=false" >> "$GITHUB_OUTPUT"
             echo "No version bump needed"
           fi
+
+      - name: Bump version locally for build
+        if: steps.semrel.outputs.released == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.semrel.outputs.version }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"${RELEASE_VERSION}\"/" pyproject.toml
+          echo "Bumped pyproject.toml to ${RELEASE_VERSION} (local only, not committed)"
+
+      - name: Build
+        run: uv build
 
       - name: Create tag via API
         if: steps.semrel.outputs.released == 'true'


### PR DESCRIPTION
## Summary
- pyproject.toml stays at 0.1.0 on main (protected branch, can't modify)
- CI Build now bumps version **locally in the runner** before `uv build`
- Artifact will correctly be versioned as 0.2.0 to match the v0.2.0 tag
- Reordered pipeline: detect version → bump locally → build → tag → attest
- Also cleaned up stale v0.2.0 tag/release from previous failed builds

## Test Plan
- [x] actionlint passes
- [x] All gates pass
- [ ] CI passes
- [ ] After merge: CI Build creates v0.2.0 artifact and tag
- [ ] Release workflow publishes v0.2.0 to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)