### PR TITLE
docs(ci): add explanatory comment to ci-build skip-ci guard

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build:
     name: Build Package
+    # Skip when the trigger commit is a version bump commit-back (prevents loops).
+    # Native [skip ci] does not apply to workflow_run triggers.
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       !contains(github.event.workflow_run.head_commit.message, '[skip ci]')


### PR DESCRIPTION
## Summary
- Adds inline comment explaining why the `[skip ci]` guard exists on the `workflow_run` trigger in ci-build.yml

Trigger commit to activate CI pipeline on main after spec-100 merge (admin merge bypassed push events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)