### PR TITLE
fix(ci): make commit-back step non-fatal in ci-build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -142,6 +142,7 @@ jobs:
 
       - name: Commit version bump back to main
         if: steps.semrel.outputs.released == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Branch protection blocks the Git Data API commit-back to main (HTTP 422). Adding `continue-on-error: true` ensures CI Build concludes as `success` so the release workflow can use the artifact.

## Test Plan
- [ ] CI Build completes successfully even when commit-back fails
- [ ] Release workflow can proceed with the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)