### PR TITLE
fix(ci): add workflow_dispatch to ci-build for manual recovery

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["CI Check"]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,9 +17,11 @@ jobs:
     name: Build Package
     # Skip when the trigger commit is a version bump commit-back (prevents loops).
     # Native [skip ci] does not apply to workflow_run triggers.
+    # workflow_dispatch bypasses the conclusion check for manual recovery.
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      !contains(github.event.workflow_run.head_commit.message, '[skip ci]')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `ci-build.yml` so it can be manually triggered when CI Check fails due to infrastructure issues (flaky tests on Python 3.12/Windows, SonarCloud artifact digest mismatches)
- Adjusts the `if` condition to bypass the `workflow_run.conclusion` check on manual dispatch

## Context

PR #361 was merged but ci-build cannot trigger because CI Check on main is failing due to:
1. Flaky `test_setup_cli.py` tests on Python 3.12/Windows (mock patching issues)
2. SonarCloud artifact `digest-mismatch` errors

These are pre-existing infrastructure issues unrelated to code changes. This fix unblocks the release pipeline.

## Test plan

- [x] All local gates pass (pre-commit, pre-push)
- [ ] CI passes
- [ ] Manual `gh workflow run ci-build.yml` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)