### PR TITLE
fix(spec-lifecycle): Python 3.9 timezone compat

### DIFF
--- a/.ai-engineering/scripts/spec_lifecycle.py
+++ b/.ai-engineering/scripts/spec_lifecycle.py
@@ -35,7 +35,7 @@ import tempfile
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 
@@ -150,7 +150,7 @@ def _events_path(project_root: Path) -> Path:
 
 
 def _utcnow_iso() -> str:
-    return datetime.now(UTC).isoformat()
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _atomic_write(target: Path, payload: str) -> None:
@@ -399,7 +399,7 @@ def sweep(project_root: Path) -> dict:
     if not d.exists():
         _append_event(project_root, "spec_sweep", summary)
         return summary
-    cutoff = datetime.now(UTC) - timedelta(days=14)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=14)
     for path in sorted(d.glob("*.json")):
         try:
             record = SpecRecord.from_json(json.loads(path.read_text(encoding="utf-8")))
@@ -411,7 +411,7 @@ def sweep(project_root: Path) -> dict:
             except ValueError:
                 continue
             if created.tzinfo is None:
-                created = created.replace(tzinfo=UTC)
+                created = created.replace(tzinfo=timezone.utc)
             if created < cutoff:
                 record.state = transition(record.state, LifecycleState.ABANDONED)
                 _write_state(project_root, record)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,16 @@ extend-exclude = ["tests/fixtures/**/*.json"]
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "C4", "RUF"]
 
+[tool.ruff.lint.per-file-ignores]
+# D-135-13 — `.ai-engineering/scripts/spec_lifecycle.py` is invoked via
+# `#!/usr/bin/env python3` from hooks; on macOS that shebang resolves to
+# system Python 3.9, where `datetime.UTC` does not exist. UP017 would force
+# the 3.11-only alias and crash the spec lifecycle bootstrap during
+# `/ai-brainstorm` and `/ai-spec-draft`. The script uses `timezone.utc` so it
+# remains 3.9-importable; the regression is guarded by
+# `tests/unit/scripts/test_spec_lifecycle_python_compat.py`.
+".ai-engineering/scripts/spec_lifecycle.py" = ["UP017"]
+
 [tool.ruff.lint.isort]
 known-first-party = [
   "ai_engineering",

--- a/tests/unit/scripts/test_spec_lifecycle_python_compat.py
+++ b/tests/unit/scripts/test_spec_lifecycle_python_compat.py
@@ -1,0 +1,38 @@
+"""Python 3.9 import-compatibility guard for ``spec_lifecycle.py`` (D-135-13).
+
+The script is invoked from hooks via ``#!/usr/bin/env python3``. On macOS that
+shebang resolves to the system Python 3.9, even though the framework wheel
+declares ``requires-python = ">=3.11"``. Importing the 3.11-only ``UTC``
+symbol from ``datetime`` makes the script crash silently (fail-open per skill
+contract), which leaves spec lifecycle sidecars unwritten during
+``/ai-brainstorm`` and ``/ai-spec-draft`` bootstrap. See D-135-13.
+
+This test parses the script as AST and forbids ``from datetime import UTC``,
+so the regression is caught under any pytest interpreter — no need to install
+Python 3.9 on contributor machines or CI runners.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / ".ai-engineering" / "scripts" / "spec_lifecycle.py"
+)
+
+
+@pytest.mark.unit
+def test_script_does_not_import_utc_symbol_from_datetime() -> None:
+    tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "datetime":
+            imported = {alias.name for alias in node.names}
+            assert "UTC" not in imported, (
+                "spec_lifecycle.py must not import `UTC` from `datetime` — "
+                "it is Python 3.11+ only and the script runs under the host "
+                "shebang (macOS system Python 3.9). Use `timezone.utc`. See "
+                "D-135-13."
+            )


### PR DESCRIPTION
## Summary

Preserves the spec-lifecycle Python 3.9 timezone compatibility fix from the `claude/jovial-bhabha-978324` working branch.

- Imports `timezone` (Python 3.9 compatible) instead of `UTC` (3.11+) in `.ai-engineering/scripts/spec_lifecycle.py`.
- Adds `tests/unit/scripts/test_spec_lifecycle_python_compat.py` covering the import path on supported Python versions.
- Adds matching `pyproject.toml` constraint metadata.

## Test plan

- [ ] `pytest tests/unit/scripts/test_spec_lifecycle_python_compat.py` passes.
- [ ] CI green on `claude/jovial-bhabha-978324`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Bi3SrDygJ6zL8joFL82a3)_