### PR TITLE
fix(release): unwrap readiness json envelope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          uv run ai-eng verify --release "${VERSION}" --json > release-readiness.json
+          uv run ai-eng --json verify --release "${VERSION}" > release-readiness-envelope.json
           VERIFY_STATUS=$?
           set -e
           python - <<'PY'
@@ -119,12 +119,20 @@ jobs:
           import sys
           from pathlib import Path
 
-          path = Path("release-readiness.json")
-          payload = json.loads(path.read_text(encoding="utf-8"))
+          envelope_path = Path("release-readiness-envelope.json")
+          envelope = json.loads(envelope_path.read_text(encoding="utf-8"))
+          payload = envelope.get("result", {}).get("release_readiness", envelope)
+          Path("release-readiness.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
           verdict = str(payload.get("verdict", "")).upper().replace("_", "-")
           print(f"Release readiness verdict: {verdict}")
           if verdict == "NO-GO":
               print("::error::release readiness returned NO-GO")
+              sys.exit(1)
+          if verdict not in {"GO", "CONDITIONAL GO"}:
+              print(f"::error::release readiness JSON missing valid verdict: {verdict!r}")
               sys.exit(1)
           PY
           if [ "${VERIFY_STATUS}" -ne 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `python_env.mode`, and `14 stacks` stay documented here so the most
   recent BREAKING block preserves those required keywords.
 
+### Fixed
+
+- Release recovery hardening: remove a secret-shaped fixture literal from
+  `.gitleaksignore` comments so the Security Audit does not self-detect the
+  allowlist file, and unwrap `ai-eng --json verify --release` output into the
+  direct `release-readiness.json` evidence payload consumed by the Release
+  workflow.
+
 ### Run summary — multi-spec autonomous orchestration
 
 This Unreleased section captures a single multi-spec autonomous `--no-hitl`

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -339,7 +339,14 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
         failures.extend(
             _expect_text(
                 _steps_text(readiness),
-                ("ai-eng verify --release", "--json", "release-readiness.json", "NO-GO"),
+                (
+                    "ai-eng --json verify --release",
+                    "release-readiness-envelope.json",
+                    "release-readiness.json",
+                    "release_readiness",
+                    "CONDITIONAL GO",
+                    "NO-GO",
+                ),
                 f"{workflow}: release-readiness",
             )
         )

--- a/tests/unit/test_check_workflow_policy.py
+++ b/tests/unit/test_check_workflow_policy.py
@@ -110,8 +110,12 @@ def _minimal_release_workflow() -> dict:
                 "steps": [
                     {
                         "run": (
-                            'uv run ai-eng verify --release "$VERSION" --json '
-                            "> release-readiness.json\nNO-GO"
+                            'uv run ai-eng --json verify --release "$VERSION" '
+                            "> release-readiness-envelope.json\n"
+                            "release_readiness\n"
+                            "release-readiness.json\n"
+                            "CONDITIONAL GO\n"
+                            "NO-GO"
                         )
                     }
                 ],

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -282,9 +282,11 @@ def test_github_release_packet_finalization(workflow: dict) -> None:
 def test_release_workflow_runs_readiness_before_publish(workflow: dict) -> None:
     """T-32 — readiness JSON is generated before either publish job."""
     text = _step_text(workflow, "release-readiness")
-    assert "ai-eng verify --release" in text
-    assert "--json" in text
+    assert "ai-eng --json verify --release" in text
+    assert "release-readiness-envelope.json" in text
+    assert "release_readiness" in text
     assert "release-readiness.json" in text
+    assert "CONDITIONAL GO" in text
     assert "NO-GO" in text
     assert "release-readiness" in _needs(workflow, "publish-testpypi")
     assert "release-readiness" in _needs(workflow, "publish-pypi")


### PR DESCRIPTION
## Summary
- call release readiness with global JSON mode: `ai-eng --json verify --release`
- unwrap `result.release_readiness` into the direct `release-readiness.json` artifact
- fail the Release workflow when the readiness verdict is missing or invalid
- document the v0.7.0 release recovery hardening in the release notes

## Verification
- uv run pytest -q tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py
- uv run python scripts/check_workflow_policy.py
- gitleaks detect --source . --config .gitleaks.toml --no-banner --redact --no-git
- gitleaks protect --staged --config .gitleaks.toml --no-banner --redact
- commit/push gates passed