### PR TITLE
fix(release): isolate recovery tooling checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout workflow tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout release tag source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.resolve-version.outputs.tag-name }}
+          path: release-source
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-env
@@ -111,7 +118,7 @@ jobs:
         run: |
           set -euo pipefail
           set +e
-          uv run ai-eng --json verify --release "${VERSION}" > release-readiness-envelope.json
+          uv run ai-eng --json verify --release "${VERSION}" --target release-source > release-readiness-envelope.json
           VERIFY_STATUS=$?
           set -e
           python - <<'PY'
@@ -141,7 +148,8 @@ jobs:
           payload = find_readiness(envelope)
           if payload is None:
               cli_artifact = (
-                  Path(".ai-engineering")
+                  Path("release-source")
+                  / ".ai-engineering"
                   / "runtime"
                   / "release"
                   / version
@@ -152,10 +160,12 @@ jobs:
 
           if payload is None:
               result = envelope.get("result") if isinstance(envelope, dict) else None
+              error = envelope.get("error") if isinstance(envelope, dict) else None
               print(
                   "::error::release readiness JSON missing release_readiness payload; "
                   f"top-level keys={sorted(envelope) if isinstance(envelope, dict) else type(envelope).__name__}; "
-                  f"result keys={sorted(result) if isinstance(result, dict) else type(result).__name__}"
+                  f"result keys={sorted(result) if isinstance(result, dict) else type(result).__name__}; "
+                  f"error={error!r}"
               )
               sys.exit(1)
 

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -341,6 +341,10 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
                 _steps_text(readiness),
                 (
                     "ai-eng --json verify --release",
+                    "--target release-source",
+                    "Checkout workflow tooling",
+                    "Checkout release tag source",
+                    "path: release-source",
                     "release-readiness-envelope.json",
                     "release-readiness.json",
                     "find_readiness",

--- a/tests/unit/test_check_workflow_policy.py
+++ b/tests/unit/test_check_workflow_policy.py
@@ -111,6 +111,10 @@ def _minimal_release_workflow() -> dict:
                     {
                         "run": (
                             'uv run ai-eng --json verify --release "$VERSION" '
+                            "--target release-source\n"
+                            "Checkout workflow tooling\n"
+                            "Checkout release tag source\n"
+                            "path: release-source\n"
                             "> release-readiness-envelope.json\n"
                             "find_readiness\n"
                             "release_readiness\n"

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -283,6 +283,10 @@ def test_release_workflow_runs_readiness_before_publish(workflow: dict) -> None:
     """T-32 — readiness JSON is generated before either publish job."""
     text = _step_text(workflow, "release-readiness")
     assert "ai-eng --json verify --release" in text
+    assert "--target release-source" in text
+    assert "Checkout workflow tooling" in text
+    assert "Checkout release tag source" in text
+    assert "path: release-source" in text
     assert "release-readiness-envelope.json" in text
     assert "find_readiness" in text
     assert "release_readiness" in text


### PR DESCRIPTION
## Summary
- keep the Release recovery workflow tooling checkout on the workflow ref (`main` for `workflow_dispatch`)
- checkout the release tag into `release-source/` instead of replacing the workspace before readiness verification
- run `ai-eng --json verify --release ... --target release-source` so the fixed recovery workflow/tooling validates the existing tag source
- update readiness diagnostics and workflow policy tests for the split checkout

## Verification
- `uv run pytest -q tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py`
- `uv run python scripts/check_workflow_policy.py`
- `git diff --check`
- `gitleaks protect --staged --config .gitleaks.toml --no-banner --redact`
- commit/push gates passed

## Release recovery context
Recovery run `26068498497` still failed because the job checked out tag `v0.7.0` over the workspace before executing `ai-eng`, so it used the tag's pre-recovery CLI/workflow state and produced an error envelope. This keeps `v0.7.0` unchanged and lets the `workflow_dispatch` recovery path use fixed `main` tooling while validating/building the existing tag source.
