### PR TITLE
fix(release): extend readiness timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     name: Release readiness
     needs: resolve-version
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -165,6 +165,9 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
             continue
         if "timeout-minutes" not in job:
             failures.append(f"{workflow}: job {job_name!r} missing timeout-minutes")
+    readiness_timeout = (jobs.get("release-readiness") or {}).get("timeout-minutes")
+    if not isinstance(readiness_timeout, int) or readiness_timeout < 30:
+        failures.append(f"{workflow}: release-readiness timeout-minutes must be at least 30")
 
     expected_needs: dict[str, set[str]] = {
         "release-readiness": {"resolve-version"},

--- a/tests/unit/test_check_workflow_policy.py
+++ b/tests/unit/test_check_workflow_policy.py
@@ -105,7 +105,7 @@ def _minimal_release_workflow() -> dict:
             "resolve-version": {"runs-on": "ubuntu-latest", "timeout-minutes": 5, "steps": []},
             "release-readiness": {
                 "runs-on": "ubuntu-latest",
-                "timeout-minutes": 10,
+                "timeout-minutes": 30,
                 "needs": "resolve-version",
                 "steps": [
                     {
@@ -278,6 +278,12 @@ class TestReleaseWorkflowPolicy:
         data["permissions"]["id-token"] = "write"
         failures = check_release_workflow_policy(Path(".github/workflows/release.yml"), data)
         assert any("top-level permissions" in failure for failure in failures)
+
+    def test_release_workflow_requires_readiness_timeout_budget(self):
+        data = _minimal_release_workflow()
+        data["jobs"]["release-readiness"]["timeout-minutes"] = 10
+        failures = check_release_workflow_policy(Path(".github/workflows/release.yml"), data)
+        assert any("release-readiness timeout-minutes" in failure for failure in failures)
 
     def test_release_workflow_rejects_cross_run_artifact_download(self):
         data = _minimal_release_workflow()

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -136,6 +136,7 @@ def test_release_workflow_permissions_are_job_scoped(workflow: dict) -> None:
 
     for job_name, job in (workflow.get("jobs") or {}).items():
         assert "timeout-minutes" in job, f"job {job_name!r} must set timeout-minutes"
+    assert _job(workflow, "release-readiness")["timeout-minutes"] >= 30
 
     concurrency = yaml.safe_dump(workflow.get("concurrency"), sort_keys=False)
     assert "github.ref_name" in concurrency or "version" in concurrency


### PR DESCRIPTION
## Summary
- extend the Release readiness job timeout from 10 to 30 minutes
- add workflow policy/test coverage so the readiness timeout cannot regress below 30 minutes

## Why
Recovery run 26069730031 reached the fixed readiness path but GitHub cancelled the job at 10 minutes while `ai-eng verify --release` was still running. The readiness command can run pytest with a 600s budget plus type-check/build commands, so the job-level timeout must be larger than 10 minutes.

## Verification
- `uv run pytest -q tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py`
- `uv run python scripts/check_workflow_policy.py`
- `git diff --check`
- `gitleaks protect --staged --no-banner`
- commit hook gate: PASS