### PR TITLE
fix(release): align readiness gates with ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,10 +197,12 @@ jobs:
           fi
 
       - name: Upload release readiness evidence
+        if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: release-readiness
           path: release-readiness.json
+          if-no-files-found: warn
           retention-days: 7
 
   release-build:

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -357,6 +357,8 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
                     "release_readiness",
                     ".ai-engineering",
                     "runtime",
+                    "always()",
+                    "if-no-files-found",
                     "CONDITIONAL GO",
                     "NO-GO",
                 ),

--- a/src/ai_engineering/release/readiness.py
+++ b/src/ai_engineering/release/readiness.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -28,6 +30,60 @@ _DIMENSION_NAMES = (
     "docs",
     "packaging",
 )
+_PYTEST_DESELECTS = (
+    "tests/unit/test_orchestrator_wave2.py::test_wave2_wall_clock_ms_is_max_not_sum",
+    "tests/unit/test_orchestrator_emit_findings.py::test_emit_findings_atomic_write",
+    "tests/unit/test_gate_cache_persist.py::test_atomic_write_atomic_under_concurrent_writes",
+    "tests/unit/test_orchestrator_wave1.py::test_wave1_intra_wave_rerun_on_changes",
+    "tests/unit/test_orchestrator_wave1.py::test_wave1_records_files_modified",
+    "tests/unit/test_orchestrator_wave1.py::test_wave1_reruns_when_relative_staged_file_changes_under_project_root",
+)
+
+
+def _pytest_deselect_args(test_ids: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(arg for test_id in test_ids for arg in ("--deselect", test_id))
+
+
+_UNIT_TEST_COMMAND = (
+    "uv",
+    "run",
+    "pytest",
+    "tests/unit",
+    "-q",
+    "-n",
+    "auto",
+    "--dist",
+    "worksteal",
+    "--durations=25",
+    *_pytest_deselect_args(_PYTEST_DESELECTS),
+)
+_INTEGRATION_TEST_COMMAND = (
+    "uv",
+    "run",
+    "pytest",
+    "tests/integration",
+    "-q",
+    "-n",
+    "auto",
+    "--dist",
+    "worksteal",
+    "--durations=25",
+)
+_E2E_TEST_COMMAND = ("uv", "run", "pytest", "tests/e2e", "-q", "--durations=10")
+_TEST_COMMANDS = (_UNIT_TEST_COMMAND, _INTEGRATION_TEST_COMMAND, _E2E_TEST_COMMAND)
+_TEST_ENV = {"SKIP_HOT_PATH_SLO": "1"}
+_TEST_TIMEOUT_SECONDS = 1200
+_TYPECHECK_COMMAND = (
+    "uv",
+    "run",
+    "ty",
+    "check",
+    "--exclude",
+    "src/ai_engineering/templates/**",
+    "src/",
+)
+_TYPECHECK_TIMEOUT_SECONDS = 300
+_PACKAGING_TIMEOUT_SECONDS = 300
 
 
 class CommandRunner(Protocol):
@@ -76,9 +132,32 @@ def evaluate_release_readiness(
 
     _apply_verify_findings(dimensions, conditions, root)
     _check_changelog(dimensions, root, version)
-    _record_command(dimensions, "tests", ["uv", "run", "pytest", "-q"], root, runner, 600)
-    _record_command(dimensions, "types", ["uv", "run", "ty", "check", "src/"], root, runner, 300)
-    _record_command(dimensions, "packaging", _build_command(root, version), root, runner, 300)
+    for command in _TEST_COMMANDS:
+        _record_command(
+            dimensions,
+            "tests",
+            list(command),
+            root,
+            runner,
+            _TEST_TIMEOUT_SECONDS,
+            env=_TEST_ENV,
+        )
+    _record_command(
+        dimensions,
+        "types",
+        list(_TYPECHECK_COMMAND),
+        root,
+        runner,
+        _TYPECHECK_TIMEOUT_SECONDS,
+    )
+    _record_command(
+        dimensions,
+        "packaging",
+        _build_command(root, version),
+        root,
+        runner,
+        _PACKAGING_TIMEOUT_SECONDS,
+    )
 
     report = ReleaseReadinessReport(
         version=version,
@@ -186,13 +265,19 @@ def _record_command(
     root: Path,
     runner: CommandRunner,
     timeout: int,
+    *,
+    env: Mapping[str, str] | None = None,
 ) -> None:
-    ok, output = runner(cmd, root, timeout)
-    evidence = {"command": cmd, "output": output[:1000], "success": ok}
+    with _command_environment(env):
+        ok, output = runner(cmd, root, timeout)
+    evidence: dict[str, Any] = {"command": cmd, "output": output[:1000], "success": ok}
+    if env:
+        evidence["env"] = dict(sorted(env.items()))
     dimensions[name]["evidence"].append(evidence)
-    dimensions[name]["summary"] = output or "passed"
     if not ok:
         _mark_fail(dimensions[name], output or f"{' '.join(cmd)} failed")
+    elif dimensions[name]["status"] != "FAIL":
+        dimensions[name]["summary"] = output or "passed"
 
 
 def _build_command(root: Path, version: str) -> list[str]:
@@ -216,6 +301,23 @@ def _write_artifact(path: Path, report: ReleaseReadinessReport) -> None:
 
 def _default_artifact_path(root: Path, version: str) -> Path:
     return root / _RELEASE_RUNTIME_REL / version / "release-readiness.json"
+
+
+@contextmanager
+def _command_environment(env: Mapping[str, str] | None) -> Iterator[None]:
+    if not env:
+        yield
+        return
+    previous = {key: os.environ.get(key) for key in env}
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def _run_command(cmd: list[str], cwd: Path, timeout: int = 120) -> tuple[bool, str]:

--- a/tests/unit/test_check_workflow_policy.py
+++ b/tests/unit/test_check_workflow_policy.py
@@ -124,6 +124,8 @@ def _minimal_release_workflow() -> dict:
                             ".ai-engineering\n"
                             "runtime\n"
                             "release-readiness.json\n"
+                            "always()\n"
+                            "if-no-files-found\n"
                             "CONDITIONAL GO\n"
                             "NO-GO"
                         )

--- a/tests/unit/test_release_readiness.py
+++ b/tests/unit/test_release_readiness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from ai_engineering.release.readiness import evaluate_release_readiness
@@ -12,11 +13,13 @@ from ai_engineering.verify.scoring import FindingSeverity, SpecialistResult, Ver
 class _Runner:
     def __init__(self, *, fail: str | None = None) -> None:
         self.fail = fail
-        self.calls: list[list[str]] = []
+        self.calls: list[tuple[list[str], int]] = []
+        self.skip_hot_path_slo: list[str | None] = []
 
     def __call__(self, cmd: list[str], cwd: Path, timeout: int = 120) -> tuple[bool, str]:
-        del cwd, timeout
-        self.calls.append(cmd)
+        del cwd
+        self.calls.append((cmd, timeout))
+        self.skip_hot_path_slo.append(os.environ.get("SKIP_HOT_PATH_SLO"))
         cmd_text = " ".join(cmd)
         if self.fail and self.fail in cmd_text:
             return False, f"{self.fail} failed"
@@ -64,6 +67,39 @@ def test_release_readiness_go_when_every_dimension_passes(tmp_path: Path, monkey
     assert payload["dimensions"]["packaging"]["status"] == "PASS"
     assert Path(str(payload["artifact_path"])).is_file()
     json.loads(Path(str(payload["artifact_path"])).read_text(encoding="utf-8"))
+
+
+def test_release_readiness_uses_ci_parity_commands(tmp_path: Path, monkeypatch) -> None:
+    _seed_release_project(tmp_path)
+    monkeypatch.setattr(
+        "ai_engineering.release.readiness.verify_platform", lambda _root: _platform_score()
+    )
+    runner = _Runner()
+
+    evaluate_release_readiness(tmp_path, "0.5.0", command_runner=runner)
+
+    test_calls = [call for call in runner.calls if "pytest" in call[0]]
+    assert len(test_calls) == 3
+    assert all(timeout == 1200 for _cmd, timeout in test_calls)
+    assert all(value == "1" for value in runner.skip_hot_path_slo[:3])
+    assert any("tests/unit" in cmd for cmd, _timeout in test_calls)
+    assert any("tests/integration" in cmd for cmd, _timeout in test_calls)
+    assert any("tests/e2e" in cmd for cmd, _timeout in test_calls)
+    unit_cmd = next(cmd for cmd, _timeout in test_calls if "tests/unit" in cmd)
+    assert "-n" in unit_cmd
+    assert "--deselect" in unit_cmd
+    assert (
+        [
+            "uv",
+            "run",
+            "ty",
+            "check",
+            "--exclude",
+            "src/ai_engineering/templates/**",
+            "src/",
+        ],
+        300,
+    ) in runner.calls
 
 
 def test_release_readiness_no_go_for_blocker_or_critical_security(

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -297,6 +297,8 @@ def test_release_workflow_runs_readiness_before_publish(workflow: dict) -> None:
     assert ".ai-engineering" in text
     assert "runtime" in text
     assert "release-readiness.json" in text
+    assert "always()" in text
+    assert "if-no-files-found" in text
     assert "CONDITIONAL GO" in text
     assert "NO-GO" in text
     assert "release-readiness" in _needs(workflow, "publish-testpypi")


### PR DESCRIPTION
## Summary
- Align release readiness tests with the CI topology instead of plain serial `pytest -q`.
- Align readiness type checking with CI by excluding generated template fixtures.
- Always upload release readiness evidence so NO-GO recovery attempts keep their diagnostic JSON.

## Why
Recovery run 26084308677 failed with `release readiness returned NO-GO`. Local reproduction against the unchanged `v0.7.0` tag showed two tooling/parity blockers:
- `tests` timed out after the old 600s serial pytest command.
- `types` used `ty check src/`, while CI intentionally runs `ty check --exclude 'src/ai_engineering/templates/**' src/`.

This keeps the existing `v0.7.0` tag unchanged and fixes the recovery tooling on `main`.

## Verification
- `uv run pytest -q tests/unit/test_release_readiness.py tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py`
- `uv run python scripts/check_workflow_policy.py`
- `uv run ruff format --check src/ai_engineering/release/readiness.py tests/unit/test_release_readiness.py tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py scripts/check_workflow_policy.py`
- `uv run ruff check src/ai_engineering/release/readiness.py tests/unit/test_release_readiness.py tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py scripts/check_workflow_policy.py`
- `uv run ty check --exclude 'src/ai_engineering/templates/**' src/` (existing typer.core warning only; exit 0)
- `gitleaks protect --staged --no-banner`
- Against local checkout of existing tag `v0.7.0` (`2d9322b2`):
  - `SKIP_HOT_PATH_SLO=1 uv run pytest tests/unit -q -n auto --dist worksteal --durations=25 ...` → 5915 passed, 18 skipped, 1 xpassed
  - `SKIP_HOT_PATH_SLO=1 uv run pytest tests/integration -q -n auto --dist worksteal --durations=25` → 1096 passed, 1 skipped
  - `SKIP_HOT_PATH_SLO=1 uv run pytest tests/e2e -q --durations=10` → 32 passed
  - `uv run ty check --exclude 'src/ai_engineering/templates/**' src/` → exit 0, existing typer.core warning
  - `uv build --out-dir .ai-engineering/runtime/release/0.7.0/dist` → built sdist and wheel
