### PR TITLE
fix(release): scope gitleaks readiness scan

### DIFF
--- a/src/ai_engineering/release/readiness.py
+++ b/src/ai_engineering/release/readiness.py
@@ -180,7 +180,7 @@ def _initial_dimensions() -> dict[str, dict[str, Any]]:
 def _apply_verify_findings(
     dimensions: dict[str, dict[str, Any]], conditions: list[str], root: Path
 ) -> None:
-    score = verify_platform(root)
+    score = verify_platform(root, profile="release")
     for finding in score.findings:
         dimension = _dimension_for_finding(finding)
         if dimension is None:

--- a/src/ai_engineering/verify/service.py
+++ b/src/ai_engineering/verify/service.py
@@ -292,29 +292,18 @@ def verify_security(project_root: Path, *, profile: str = "normal") -> VerifySco
     document = _load_gate_findings_document(project_root)
     if document is not None:
         _record_security_gate_findings(specialist, document)
-    _record_gitleaks_findings(specialist, project_root)
+    _record_gitleaks_findings(specialist, project_root, profile=profile)
     if _project_has_dependency_manifest(project_root):
         _record_pip_audit_findings(specialist, project_root)
 
     return _finalize_specialist(report, specialist)
 
 
-def _record_gitleaks_findings(specialist: SpecialistResult, project_root: Path) -> None:
+def _record_gitleaks_findings(
+    specialist: SpecialistResult, project_root: Path, *, profile: str
+) -> None:
     """Add secret-scan findings to the security specialist."""
-    tool_result = _run(
-        [
-            "gitleaks",
-            "detect",
-            "--source",
-            ".",
-            "--no-banner",
-            "--report-format",
-            "json",
-            "--report-path",
-            "/dev/stdout",
-        ],
-        project_root,
-    )
+    tool_result = _run(_gitleaks_command(project_root, profile=profile), project_root)
     if tool_result.returncode == 0 or not tool_result.stdout:
         return
 
@@ -331,6 +320,26 @@ def _record_gitleaks_findings(specialist: SpecialistResult, project_root: Path) 
             file=leak.get("File"),
             line=leak.get("StartLine"),
         )
+
+
+def _gitleaks_command(project_root: Path, *, profile: str) -> list[str]:
+    """Return the gitleaks command for the verification profile."""
+    command = [
+        "gitleaks",
+        "detect",
+        "--source",
+        ".",
+        "--no-banner",
+        "--report-format",
+        "json",
+        "--report-path",
+        "-",
+    ]
+    if (project_root / ".gitleaks.toml").is_file():
+        command.extend(("--config", ".gitleaks.toml"))
+    if profile == "release":
+        command.append("--no-git")
+    return command
 
 
 def _record_pip_audit_findings(specialist: SpecialistResult, project_root: Path) -> None:

--- a/tests/unit/test_release_readiness.py
+++ b/tests/unit/test_release_readiness.py
@@ -54,7 +54,8 @@ def _platform_score(*findings: tuple[FindingSeverity, str, str, str]) -> VerifyS
 def test_release_readiness_go_when_every_dimension_passes(tmp_path: Path, monkeypatch) -> None:
     _seed_release_project(tmp_path)
     monkeypatch.setattr(
-        "ai_engineering.release.readiness.verify_platform", lambda _root: _platform_score()
+        "ai_engineering.release.readiness.verify_platform",
+        lambda _root, **_kwargs: _platform_score(),
     )
 
     report = evaluate_release_readiness(tmp_path, "0.5.0", command_runner=_Runner())
@@ -72,7 +73,8 @@ def test_release_readiness_go_when_every_dimension_passes(tmp_path: Path, monkey
 def test_release_readiness_uses_ci_parity_commands(tmp_path: Path, monkeypatch) -> None:
     _seed_release_project(tmp_path)
     monkeypatch.setattr(
-        "ai_engineering.release.readiness.verify_platform", lambda _root: _platform_score()
+        "ai_engineering.release.readiness.verify_platform",
+        lambda _root, **_kwargs: _platform_score(),
     )
     runner = _Runner()
 
@@ -102,13 +104,28 @@ def test_release_readiness_uses_ci_parity_commands(tmp_path: Path, monkeypatch) 
     ) in runner.calls
 
 
+def test_release_readiness_uses_release_verify_profile(tmp_path: Path, monkeypatch) -> None:
+    _seed_release_project(tmp_path)
+    profiles: list[str] = []
+
+    def _fake_verify_platform(_root: Path, *, profile: str = "normal") -> VerifyScore:
+        profiles.append(profile)
+        return _platform_score()
+
+    monkeypatch.setattr("ai_engineering.release.readiness.verify_platform", _fake_verify_platform)
+
+    evaluate_release_readiness(tmp_path, "0.5.0", command_runner=_Runner())
+
+    assert profiles == ["release"]
+
+
 def test_release_readiness_no_go_for_blocker_or_critical_security(
     tmp_path: Path, monkeypatch
 ) -> None:
     _seed_release_project(tmp_path)
     monkeypatch.setattr(
         "ai_engineering.release.readiness.verify_platform",
-        lambda _root: _platform_score(
+        lambda _root, **_kwargs: _platform_score(
             (FindingSeverity.CRITICAL, "security", "dependency", "CVE blocks release")
         ),
     )
@@ -123,7 +140,8 @@ def test_release_readiness_no_go_for_failed_tests_package_or_missing_changelog(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(
-        "ai_engineering.release.readiness.verify_platform", lambda _root: _platform_score()
+        "ai_engineering.release.readiness.verify_platform",
+        lambda _root, **_kwargs: _platform_score(),
     )
 
     tests_project = tmp_path / "tests"
@@ -158,7 +176,7 @@ def test_release_readiness_conditional_go_for_accepted_or_advisory_findings(
     _seed_release_project(tmp_path)
     monkeypatch.setattr(
         "ai_engineering.release.readiness.verify_platform",
-        lambda _root: _platform_score(
+        lambda _root, **_kwargs: _platform_score(
             (
                 FindingSeverity.INFO,
                 "security",

--- a/tests/unit/test_verify_service.py
+++ b/tests/unit/test_verify_service.py
@@ -277,6 +277,30 @@ class TestVerifySecurity:
         assert len(secret_findings) == 1
         assert secret_findings[0].severity == FindingSeverity.BLOCKER
 
+    def test_release_profile_scans_current_tree_not_git_history(
+        self, fake_run: FakeSubprocess, project_root: Path
+    ) -> None:
+        # Arrange — release readiness validates the checked-out tag contents.
+        # Historical deleted fixtures are governed by CI's commit-range scan,
+        # not by the release-source tree scan.
+        (project_root / ".gitleaks.toml").write_text("title = 'fake'\n", encoding="utf-8")
+        fake_run.set_response("gitleaks", returncode=0, stdout="[]")
+        fake_run.set_response("tls_pip_audit", returncode=0, stdout="")
+
+        # Act
+        result = verify_security(project_root, profile="release")
+
+        # Assert
+        assert result.score == 100
+        gitleaks_call = next(call for call in fake_run.calls if call[0] == "gitleaks")
+        assert "--no-git" in gitleaks_call
+        assert "--config" in gitleaks_call
+        assert ".gitleaks.toml" in gitleaks_call
+        assert "--report-format" in gitleaks_call
+        assert "json" in gitleaks_call
+        assert "--report-path" in gitleaks_call
+        assert "-" in gitleaks_call
+
     def test_pip_audit_vulnerabilities_are_critical_severity(
         self, fake_run: FakeSubprocess, project_root: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- Run release readiness verification with `profile="release"`.
- Scope release-profile gitleaks to the checked-out release tree via `gitleaks detect --no-git` and the repo `.gitleaks.toml`.
- Add regression coverage for the release profile and release-readiness profile dispatch.

## Why
Recovery run 26086674134 used the fixed CI-parity readiness gates but still returned `NO-GO` in the security dimension. The uploaded `release-readiness.json` showed gitleaks findings from historical deleted docs / old ignore-file history, not from files present in the `v0.7.0` release source tree.

Per current Gitleaks CLI docs, `--no-git` treats the repo as a regular directory scan. Release readiness should validate the checked-out tag contents; historical commit-range scanning remains a CI concern.

The existing `v0.7.0` tag remains unchanged at `2d9322b2`.

## Verification
- `uv run pytest -q tests/unit/test_verify_service.py tests/unit/test_release_readiness.py`
- `uv run ruff format --check src/ai_engineering/verify/service.py src/ai_engineering/release/readiness.py tests/unit/test_verify_service.py tests/unit/test_release_readiness.py`
- `uv run ruff check src/ai_engineering/verify/service.py src/ai_engineering/release/readiness.py tests/unit/test_verify_service.py tests/unit/test_release_readiness.py`
- `uv run ty check --exclude 'src/ai_engineering/templates/**' src/` (existing typer.core warning only; exit 0)
- `gitleaks protect --staged --no-banner`
- Full local release-readiness reproduction against a clean checkout of existing tag `v0.7.0`:
  - `uv run ai-eng --json verify --release 0.7.0 --target /tmp/ai-eng-release-source-v0.7.0-fix528`
  - Result: `verdict: GO`
