### PR TITLE
fix(release): bound GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,21 @@ jobs:
           mkdir -p packet
           : > packet/github-attestation-verify.log
           for artifact in dist/*; do
-            gh attestation verify "${artifact}" --repo "${REPO}" | tee -a packet/github-attestation-verify.log
+            echo "## gh attestation verify $(basename "${artifact}")" | tee -a packet/github-attestation-verify.log
+            if output="$(gh attestation verify "${artifact}" --repo "${REPO}" 2>&1)"; then
+              if [ -n "${output}" ]; then
+                printf '%s\n' "${output}" | tee -a packet/github-attestation-verify.log
+              fi
+              echo "Result: PASS (exit 0)" | tee -a packet/github-attestation-verify.log
+            else
+              status=$?
+              if [ -n "${output}" ]; then
+                printf '%s\n' "${output}" | tee -a packet/github-attestation-verify.log
+              fi
+              echo "Result: FAIL (exit ${status})" | tee -a packet/github-attestation-verify.log
+              exit "${status}"
+            fi
+            echo | tee -a packet/github-attestation-verify.log
           done
 
       - name: Upload attestation verification evidence
@@ -554,14 +568,72 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
+          TAG_NAME: ${{ needs.resolve-version.outputs.tag-name }}
         run: |
           set -euo pipefail
           awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{flag=0} flag" \
-            CHANGELOG.md > packet/release-notes.md
-          if [ ! -s packet/release-notes.md ]; then
+            CHANGELOG.md > packet/release-notes-full.md
+          if [ ! -s packet/release-notes-full.md ]; then
             echo "::error::CHANGELOG.md is missing non-empty release notes for ${VERSION}"
             exit 1
           fi
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          GITHUB_RELEASE_BODY_LIMIT = 125_000
+          RELEASE_BODY_HEADROOM = 4_096
+          MAX_RELEASE_BODY_BYTES = GITHUB_RELEASE_BODY_LIMIT - RELEASE_BODY_HEADROOM
+
+          packet_dir = Path("packet")
+          full_notes_path = packet_dir / "release-notes-full.md"
+          release_notes_path = packet_dir / "release-notes.md"
+          version = os.environ["VERSION"]
+          tag = os.environ["TAG_NAME"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          full_notes = full_notes_path.read_text(encoding="utf-8")
+          full_notes_bytes = len(full_notes.encode("utf-8"))
+
+          if full_notes_bytes <= MAX_RELEASE_BODY_BYTES:
+              release_notes_path.write_text(full_notes, encoding="utf-8")
+              raise SystemExit(0)
+
+          def truncate_utf8(text: str, max_bytes: int) -> str:
+              encoded = text.encode("utf-8")
+              if len(encoded) <= max_bytes:
+                  return text
+              return encoded[:max_bytes].decode("utf-8", errors="ignore").rstrip()
+
+          changelog_url = f"https://github.com/{repo}/blob/{tag}/CHANGELOG.md"
+          prefix = f"""# ai-engineering {tag}
+
+          The full CHANGELOG section for `{version}` is {full_notes_bytes} bytes, which
+          exceeds GitHub's {GITHUB_RELEASE_BODY_LIMIT}-byte release body limit. This
+          GitHub Release body is therefore capped deliberately; the complete notes are
+          attached as `release-notes-full.md` and remain canonical in CHANGELOG.md.
+
+          Full changelog at tag: {changelog_url}
+
+          ---
+
+          """
+          suffix = """
+
+          ---
+
+          _Release notes truncated for GitHub's release body limit. Download
+          `release-notes-full.md` from this release packet, or read the full
+          CHANGELOG.md section at the tag link above._
+          """
+          remaining = MAX_RELEASE_BODY_BYTES - len(prefix.encode("utf-8")) - len(
+              suffix.encode("utf-8")
+          )
+          if remaining <= 0:
+              release_notes = prefix + suffix
+          else:
+              release_notes = prefix + truncate_utf8(full_notes, remaining) + suffix
+          release_notes_path.write_text(release_notes, encoding="utf-8")
+          PY
 
       - name: Write release-packet.json manifest
         env:
@@ -607,6 +679,7 @@ jobs:
               },
               "changelog_source": "CHANGELOG.md",
               "release_notes": "release-notes.md",
+              "release_notes_full": "release-notes-full.md",
               "recovery": {
                   "used": os.environ.get("RECOVERY") == "true",
                   "reason": os.environ.get("RECOVERY_REASON", ""),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release finalization now caps GitHub Release body notes below GitHub's
+  125,000-character limit, uploads the full changelog section as
+  `release-notes-full.md`, and writes non-empty attestation verification
+  proof logs so release packet asset uploads do not fail on zero-byte files.
+
 ## [0.7.0] - 2026-05-18
 
 ### BREAKING

--- a/scripts/check_workflow_policy.py
+++ b/scripts/check_workflow_policy.py
@@ -248,6 +248,7 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
                     "subject-path: dist/*",
                     "gh attestation verify",
                     "github-attestation-verify.log",
+                    "Result: PASS (exit 0)",
                 ),
                 f"{workflow}: attest-and-verify",
             )
@@ -325,6 +326,8 @@ def check_release_workflow_policy(workflow: Path, data: dict[str, Any]) -> list[
                     "--clobber",
                     "release-packet.json",
                     "release-notes.md",
+                    "release-notes-full.md",
+                    "GITHUB_RELEASE_BODY_LIMIT",
                     "release-readiness.json",
                     "github-attestation-verify.log",
                     "testpypi-proof.txt",

--- a/tests/unit/test_check_workflow_policy.py
+++ b/tests/unit/test_check_workflow_policy.py
@@ -167,7 +167,12 @@ def _minimal_release_workflow() -> dict:
                         "uses": "actions/attest-build-provenance@v1",
                         "with": {"subject-path": "dist/*"},
                     },
-                    {"run": "gh attestation verify dist/a.whl > github-attestation-verify.log"},
+                    {
+                        "run": (
+                            "gh attestation verify dist/a.whl > github-attestation-verify.log\n"
+                            "echo 'Result: PASS (exit 0)' >> github-attestation-verify.log"
+                        )
+                    },
                 ],
             },
             "publish-testpypi": {
@@ -246,6 +251,7 @@ def _minimal_release_workflow() -> dict:
                             'gh release edit "$TAG" --notes-file release-notes.md\n'
                             'gh release upload "$TAG" dist/* --clobber\n'
                             "release-packet.json release-readiness.json "
+                            "release-notes-full.md GITHUB_RELEASE_BODY_LIMIT "
                             "github-attestation-verify.log testpypi-proof.txt "
                             "testpypi-install-proof.txt pypi-proof.txt ci_run_url recovery"
                         )

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -43,6 +43,8 @@ PACKET_EVIDENCE = {
     "pypi-proof.txt",
     "release-readiness.json",
     "release-notes.md",
+    "release-notes-full.md",
+    "GITHUB_RELEASE_BODY_LIMIT",
     "ci_run_url",
     "recovery",
 }
@@ -224,6 +226,7 @@ def test_github_artifact_attestation(workflow: dict) -> None:
     assert "subject-path: dist/*" in text
     assert "gh attestation verify" in text
     assert "github-attestation-verify.log" in text
+    assert "Result: PASS (exit 0)" in text
 
 
 def test_testpypi_publish_and_install_gate(workflow: dict) -> None:
@@ -273,11 +276,27 @@ def test_github_release_packet_finalization(workflow: dict) -> None:
         "--clobber",
         "release-packet.json",
         "release-notes.md",
+        "release-notes-full.md",
+        "GITHUB_RELEASE_BODY_LIMIT",
         "CHANGELOG.md",
         "ci_run_url",
     ]
     missing = [needle for needle in required if needle not in text]
     assert not missing, f"finalize-release-packet missing command(s): {missing}\n{text}"
+
+
+def test_github_release_body_is_bounded(workflow: dict) -> None:
+    """T-22 regression — large CHANGELOG sections must not break finalization."""
+    text = _step_text(workflow, "finalize-release-packet")
+    required = [
+        "GITHUB_RELEASE_BODY_LIMIT = 125_000",
+        "MAX_RELEASE_BODY_BYTES",
+        "release-notes-full.md",
+        "Full changelog at tag",
+        "truncate_utf8",
+    ]
+    missing = [needle for needle in required if needle not in text]
+    assert not missing, f"release body limit guard missing: {missing}\n{text}"
 
 
 def test_release_workflow_runs_readiness_before_publish(workflow: dict) -> None:


### PR DESCRIPTION
## Summary

- Cap generated GitHub Release body notes below GitHub's API limit and attach the complete changelog section as `release-notes-full.md` in the release packet.
- Make GitHub attestation verification proof logs non-empty even when `gh attestation verify` emits no stdout, avoiding zero-byte release asset upload failures.
- Extend workflow policy gates and regression tests for the release body limit guard and non-empty attestation proof contract.

## Test Plan

- `uv run pytest tests/unit/workflows/test_release_workflow_policy.py tests/unit/test_check_workflow_policy.py -q`
- `uv run python scripts/check_workflow_policy.py`
- `uvx --from actionlint-py actionlint .github/workflows/release.yml`
- `uv run ai-eng gate run --cache-aware --json --mode=local`
- Local replay of the `Extract release notes from CHANGELOG.md` workflow step against `0.7.0` produced `release-notes.md` at 120,904 bytes and `release-notes-full.md` at 141,434 bytes.

## Release Recovery Context

This follows the successful manual finalization of [`v0.7.0`](https://github.com/arcasilesgroup/ai-engineering/releases/tag/v0.7.0), after run 26089734293 published to TestPyPI/PyPI but failed only because the full CHANGELOG section exceeded GitHub's release body limit.
