### PR TITLE
perf(tests): share install fixtures, parallelize, harden CI fail-loud

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -217,6 +217,7 @@ jobs:
         env:
           SKIP_HOT_PATH_SLO: "1"
         run: |
+          set -o pipefail  # pytest exit must survive the pipe to tee
           uv run pytest tests/unit -v -n auto --dist worksteal --durations=25 \
             --deselect tests/unit/test_orchestrator_wave2.py::test_wave2_wall_clock_ms_is_max_not_sum \
             --deselect tests/unit/test_orchestrator_emit_findings.py::test_emit_findings_atomic_write \
@@ -285,7 +286,7 @@ jobs:
           git config --global user.name "CI"
       - name: Run integration tests
         run: |
-          uv run pytest tests/integration -v -n auto --dist worksteal --durations=25 | tee integration-output.log
+          uv run pytest tests/integration -v -n auto --dist worksteal --durations=25
       - name: Run integration tests with coverage (ubuntu only)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -319,7 +320,7 @@ jobs:
           git config --global user.name "CI"
       - name: Run e2e tests
         run: |
-          uv run pytest tests/e2e -v --durations=10 | tee e2e-output.log
+          uv run pytest tests/e2e -v --durations=10
       - name: Run e2e tests with coverage
         run: |
           uv run pytest tests/e2e -v \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host-preflight/budget-profile names remain reserved.
 - `.ai-engineering/cache/gate/` is documented as an existing bounded cache
   with 24-hour/256-entry limits and existing status/clear commands.
+- Test suite runs faster with no loss of coverage, security, or
+  governance assertions: the doctor and skills integration tests now
+  share a module-scoped read-only install fixture (`installed_project_ro`)
+  instead of re-running the ~2s installer per test, the docs link walker
+  is memoised, and the default `pytest` invocation no longer forces `-v`
+  (CI passes it explicitly). A new top-level `Makefile` exposes parallel
+  `make test` / `test-unit` / `test-integration` / `test-e2e` targets via
+  pytest-xdist, with integration and full runs grouped by `--dist
+  loadscope` so module-scoped fixtures build once per worker.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,13 @@ ty check src/
 
 ## Testing
 
-Run the full test suite with:
+Run the full test suite in parallel (mirrors CI) with:
 
 ```bash
-pytest
+make test
 ```
 
-This automatically runs with verbose output and coverage reporting (configured in `pyproject.toml`).
+Scoped targets: `make test-unit`, `make test-integration`, `make test-e2e`. These run `pytest -n auto --dist worksteal` via `pytest-xdist`. Bare `pytest` still works and runs serially — prefer it for focused, `--pdb`-friendly runs.
 
 **Test conventions**:
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: test test-unit test-integration test-e2e
+
+# Fail loud and honest. pipefail makes a pipeline return the first failing
+# command's status (so `pytest ... | tee` reports pytest's exit, not tee's);
+# -e aborts the recipe on the first error. Without this a piped test command
+# can exit 0 while tests fail. bash is required for pipefail.
+SHELL := bash
+.SHELLFLAGS := -e -o pipefail -c
+
+PYTEST ?= uv run pytest
+# Parallel run via pytest-xdist. Bare `pytest <file>` stays serial for fast
+# focused runs and `--pdb` debugging.
+#   worksteal  — best load balance for many fast tests (unit).
+#   loadscope  — groups a module's tests on one worker so module-scoped
+#                fixtures (e.g. installed_project_ro, ~2s install) build once
+#                per worker instead of rebuilding across workers (integration).
+PAR ?= -n auto --dist worksteal
+PAR_SCOPED ?= -n auto --dist loadscope
+
+test:
+	$(PYTEST) $(PAR_SCOPED)
+
+test-unit:
+	$(PYTEST) tests/unit $(PAR)
+
+test-integration:
+	$(PYTEST) tests/integration $(PAR_SCOPED)
+
+# e2e is serial: only a handful of flows, xdist worker spawn would dominate.
+test-e2e:
+	$(PYTEST) tests/e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ known-first-party = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v -m 'not slow'"
+addopts = "-m 'not slow'"
 # spec-127 M1: expose ``tools/`` so ``skill_domain``, ``skill_app``,
 # ``skill_infra``, and ``skill_lint`` import as top-level packages
 # without a project-root ``tools/__init__.py`` (which would make

--- a/tests/docs/test_links.py
+++ b/tests/docs/test_links.py
@@ -20,6 +20,7 @@ to that test and does not re-implement.
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 from pathlib import Path
@@ -86,14 +87,15 @@ PII_PATTERNS = [
 ]
 
 
-def _walk_md_files() -> list[Path]:
+@functools.cache
+def _walk_md_files() -> tuple[Path, ...]:
     files: list[Path] = []
     for p in REPO_ROOT.rglob("*.md"):
         s = str(p)
         if any(frag in s for frag in EXCLUDED_PATH_FRAGMENTS):
             continue
         files.append(p)
-    return sorted(files)
+    return tuple(sorted(files))
 
 
 def _slugify(heading: str) -> str:

--- a/tests/integration/test_doctor_integration.py
+++ b/tests/integration/test_doctor_integration.py
@@ -39,6 +39,20 @@ def installed_git_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(scope="module")
+def installed_project_ro(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Module-scoped install shared by diagnose-only (read-only) tests.
+
+    install() costs ~2s; sharing one tree across the read-only tests
+    avoids re-paying it per test. Tests that mutate the tree (drift
+    simulation, --fix, state edits) MUST use the function-scoped
+    ``installed_project`` to preserve isolation.
+    """
+    project = tmp_path_factory.mktemp("installed_ro")
+    install(project)
+    return project
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -110,8 +124,8 @@ def _force_venv_mode(project: Path) -> None:
 class TestGovernancePhaseCheck:
     """Tests for governance phase validation (framework layout + manifest)."""
 
-    def test_passes_on_valid_layout(self, installed_project: Path) -> None:
-        report = diagnose(installed_project)
+    def test_passes_on_valid_layout(self, installed_project_ro: Path) -> None:
+        report = diagnose(installed_project_ro)
         governance = _find_phase(report, "governance")
         governance_dirs = next((c for c in governance.checks if c.name == "governance-dirs"), None)
         assert governance_dirs is not None
@@ -142,8 +156,8 @@ class TestGovernancePhaseCheck:
 class TestStatePhaseChecks:
     """Tests for state file integrity validation."""
 
-    def test_all_state_files_valid(self, installed_project: Path) -> None:
-        report = diagnose(installed_project)
+    def test_all_state_files_valid(self, installed_project_ro: Path) -> None:
+        report = diagnose(installed_project_ro)
         state_phase = _find_phase(report, "state")
         parseable = next((c for c in state_phase.checks if c.name == "state-files-parseable"), None)
         assert parseable is not None
@@ -193,9 +207,9 @@ class TestStatePhaseChecks:
 class TestHookChecks:
     """Tests for git hook verification."""
 
-    def test_ok_when_installed_with_git(self, installed_project: Path) -> None:
+    def test_ok_when_installed_with_git(self, installed_project_ro: Path) -> None:
         # Since spec-072, install() auto-initializes git and installs hooks
-        report = diagnose(installed_project)
+        report = diagnose(installed_project_ro)
         hooks_phase = _find_phase(report, "hooks")
         hook_check = next((c for c in hooks_phase.checks if c.name == "hooks-integrity"), None)
         assert hook_check is not None
@@ -367,9 +381,9 @@ class TestVenvHealthCheck:
 class TestToolChecks:
     """Tests for tool availability checks."""
 
-    def test_tool_checks_produce_results(self, installed_project: Path) -> None:
+    def test_tool_checks_produce_results(self, installed_project_ro: Path) -> None:
         """Tools phase should produce check results for required tools."""
-        report = diagnose(installed_project)
+        report = diagnose(installed_project_ro)
         tools_phase = _find_phase(report, "tools")
         assert len(tools_phase.checks) > 0
 
@@ -382,12 +396,12 @@ class TestToolChecks:
 class TestVersionLifecycleCheck:
     """Tests for version lifecycle diagnostic check."""
 
-    def test_version_check_appears_in_report(self, installed_project: Path) -> None:
-        report = diagnose(installed_project)
+    def test_version_check_appears_in_report(self, installed_project_ro: Path) -> None:
+        report = diagnose(installed_project_ro)
         check = _find_check_in_runtime(report, "version")
         assert check.status in (CheckStatus.OK, CheckStatus.WARN)
 
-    def test_version_check_ok_when_current(self, installed_project: Path) -> None:
+    def test_version_check_ok_when_current(self, installed_project_ro: Path) -> None:
         from unittest.mock import patch
 
         from ai_engineering.version.checker import VersionCheckResult
@@ -404,11 +418,11 @@ class TestVersionLifecycleCheck:
             message="0.1.0 (current)",
         )
         with patch("ai_engineering.doctor.runtime.version.check_version", return_value=mock_result):
-            report = diagnose(installed_project)
+            report = diagnose(installed_project_ro)
         check = _find_check_in_runtime(report, "version")
         assert check.status == CheckStatus.OK
 
-    def test_version_check_fail_when_deprecated(self, installed_project: Path) -> None:
+    def test_version_check_fail_when_deprecated(self, installed_project_ro: Path) -> None:
         from unittest.mock import patch
 
         from ai_engineering.version.checker import VersionCheckResult
@@ -425,7 +439,7 @@ class TestVersionLifecycleCheck:
             message="0.0.1 is deprecated",
         )
         with patch("ai_engineering.doctor.runtime.version.check_version", return_value=mock_result):
-            report = diagnose(installed_project)
+            report = diagnose(installed_project_ro)
         check = _find_check_in_runtime(report, "version")
         assert check.status == CheckStatus.FAIL
 
@@ -499,8 +513,8 @@ class TestDoctorReport:
         serialized = json.dumps(data)
         assert '"test"' in serialized
 
-    def test_full_report_on_installed_project(self, installed_project: Path) -> None:
-        report = diagnose(installed_project)
+    def test_full_report_on_installed_project(self, installed_project_ro: Path) -> None:
+        report = diagnose(installed_project_ro)
         assert len(report.phases) > 0
         data = report.to_dict()
         assert "passed" in data

--- a/tests/integration/test_skills_integration.py
+++ b/tests/integration/test_skills_integration.py
@@ -35,6 +35,19 @@ def installed_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(scope="module")
+def installed_project_ro(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Module-scoped install shared by read-only report tests.
+
+    install() costs ~2s; tests that only call generate_report() (no
+    writes) share one tree. Tests that mutate the tree (write files,
+    create_maintenance_pr) keep the function-scoped ``installed_project``.
+    """
+    project = tmp_path_factory.mktemp("installed_ro")
+    install(project, stacks=["python"])
+    return project
+
+
 # ---------------------------------------------------------------------------
 # Maintenance — Report generation
 # ---------------------------------------------------------------------------
@@ -45,9 +58,9 @@ class TestGenerateReport:
 
     def test_report_on_installed_project(
         self,
-        installed_project: Path,
+        installed_project_ro: Path,
     ) -> None:
-        report = generate_report(installed_project)
+        report = generate_report(installed_project_ro)
         assert report.total_governance_files >= 0
         assert report.total_state_files >= 1
         assert report.install_manifest_version != ""
@@ -59,9 +72,9 @@ class TestGenerateReport:
 
     def test_report_counts_framework_events(
         self,
-        installed_project: Path,
+        installed_project_ro: Path,
     ) -> None:
-        report = generate_report(installed_project)
+        report = generate_report(installed_project_ro)
         # Install creates at least one framework event
         assert report.recent_framework_events >= 1
 
@@ -69,8 +82,8 @@ class TestGenerateReport:
 class TestStalenessDetection:
     """Tests for stale file detection."""
 
-    def test_fresh_files_not_stale(self, installed_project: Path) -> None:
-        report = generate_report(installed_project, staleness_days=90)
+    def test_fresh_files_not_stale(self, installed_project_ro: Path) -> None:
+        report = generate_report(installed_project_ro, staleness_days=90)
         assert len(report.stale_files) == 0
 
     def test_old_files_detected_as_stale(
@@ -94,11 +107,11 @@ class TestStalenessDetection:
 
     def test_custom_staleness_threshold(
         self,
-        installed_project: Path,
+        installed_project_ro: Path,
     ) -> None:
         # With threshold of 0 days everything is stale (if governance
         # files exist); with a very large threshold nothing is stale
-        report = generate_report(installed_project, staleness_days=999_999)
+        report = generate_report(installed_project_ro, staleness_days=999_999)
         assert len(report.stale_files) == 0
 
 

--- a/tests/unit/workflows/test_ci_pytest_fails_loud.py
+++ b/tests/unit/workflows/test_ci_pytest_fails_loud.py
@@ -1,0 +1,69 @@
+"""CI test invocations must fail loud — a piped pytest must not mask its exit.
+
+A pipeline like ``pytest ... | tee log`` returns the LAST command's exit
+status (``tee`` = 0), so a failing test suite can report success. GitHub's
+default bash shell enables ``pipefail`` implicitly, but relying on that is
+fragile: a shell change or a copy-pasted step elsewhere silently reintroduces
+the footgun. This gate makes the guarantee explicit and durable — any workflow
+step that pipes pytest output MUST set ``pipefail`` in the same run block (or
+not pipe at all).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _run_blocks() -> list[tuple[str, str, str]]:
+    """Return (workflow_file, job_name, run_text) for every step with a run."""
+    blocks: list[tuple[str, str, str]] = []
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
+        for job_name, job in (data.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if isinstance(step, dict) and isinstance(step.get("run"), str):
+                    blocks.append((wf.name, job_name, step["run"]))
+    return blocks
+
+
+def _pipes_pytest(run_text: str) -> bool:
+    """True if a pytest invocation is piped into a downstream command."""
+    # Join shell line-continuations so a multi-line pytest call reads as one.
+    joined = run_text.replace("\\\n", " ")
+    for line in joined.splitlines():
+        if "pytest" in line and "|" in line.split("pytest", 1)[1]:
+            return True
+    return False
+
+
+_RUN_BLOCKS = _run_blocks()
+_PIPED_PYTEST = [b for b in _RUN_BLOCKS if _pipes_pytest(b[2])]
+
+
+def test_workflow_run_blocks_discovered() -> None:
+    """Guard against the scanner silently finding nothing (path/parse drift)."""
+    assert _RUN_BLOCKS, f"no workflow run steps discovered under {WORKFLOWS_DIR}"
+
+
+@pytest.mark.parametrize(
+    "wf,job,run_text",
+    _PIPED_PYTEST,
+    ids=[f"{wf}:{job}" for wf, job, _ in _PIPED_PYTEST],
+)
+def test_piped_pytest_sets_pipefail(wf: str, job: str, run_text: str) -> None:
+    assert "pipefail" in run_text, (
+        f"{wf} job {job!r}: pytest output is piped without `set -o pipefail`. "
+        "The pipeline returns the downstream command's exit code (e.g. tee=0), "
+        "masking test failures. Add `set -o pipefail` to the run block or drop "
+        "the pipe."
+    )


### PR DESCRIPTION
## Summary
- Doctor + skills integration tests share a module-scoped read-only install fixture (`installed_project_ro`) instead of re-running the ~2s installer per test. Only read-only consumers are repointed; tests that mutate the installed tree keep the isolated function-scoped fixture. Default `pytest` no longer forces `-v` (CI passes it explicitly); the docs link walker is memoised.
- New top-level `Makefile` exposes parallel `make test` / `test-unit` / `test-integration` / `test-e2e` via pytest-xdist. Integration and full runs use `--dist loadscope` so module-scoped fixtures build once per worker instead of rebuilding under worksteal.
- CI test results made honest: a piped `pytest ... | tee` returns tee's exit (0), masking failures. The unit step now sets `set -o pipefail`; the dead integration/e2e `tee` logs (never uploaded) are removed; and a new governance gate (`test_ci_pytest_fails_loud`) fails CI if any workflow pipes pytest without pipefail. The `Makefile` sets `.SHELLFLAGS := -e -o pipefail -c` for the same guarantee locally.

## Test Plan
- [x] Full suite green via `make test` (loadscope), reliable no-pipe exit capture (`PYTEST_EXIT=0`)
- [x] Modified integration files pass serial AND parallel `--dist worksteal` (40 passed, no flake)
- [x] 34 workflow tests pass, including the new fail-loud gate (detects the one piped step, confirms its pipefail)
- [x] `ruff check` + `ruff format --check` clean on changed Python
- [x] `make` targets parse and dry-run to correct commands

## Checklist
- [x] Lint/format clean
- [x] Secret scan clean (gate: 0 findings)
- [x] Tests pass (full suite)
- [x] CHANGELOG updated
- [x] No breaking changes — behaviour, coverage, security, and governance assertions unchanged

_No linked work items: off-spec DX/CI improvement (active spec-146 is unrelated)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)