### PR TITLE
fix(cli): clearer install/update output (+ spec-152 lifecycle sync)

### DIFF
--- a/.ai-engineering/specs/_history.md
+++ b/.ai-engineering/specs/_history.md
@@ -150,6 +150,7 @@ Completed specs. Details in git history.
 | 003 | Governance Enforcement | done | 2026-02-10 | — | — | spec/003-governance-enforcement |
 | 002 | Cross-Reference Hardening + Skill Registration | done | 2026-02-09 | — | — | spec/002-cross-ref-hardening |
 | 001 | AI-Engineering Framework: Rewrite from Scratch | done | 2026-02-08 | — | — | spec/001-rewrite-v2 |
+| github-actions-supply-chain-hardening | GitHub Actions CI/CD Supply-Chain Hardening and Simplification | shipped | 2026-05-22 | 2026-05-22 | 536 | spec-152-github-actions-supply-chain-hardening |
 
 ---
 

--- a/.ai-engineering/state/specs/github-actions-supply-chain-hardening.json
+++ b/.ai-engineering/state/specs/github-actions-supply-chain-hardening.json
@@ -1,11 +1,11 @@
 {
-  "branch": null,
+  "branch": "spec-152-github-actions-supply-chain-hardening",
   "created": "2026-05-22T10:34:28.650616+00:00",
   "extra": {},
-  "pr": null,
-  "shipped": null,
+  "pr": "536",
+  "shipped": "2026-05-22T16:09:26.702167+00:00",
   "slug": "github-actions-supply-chain-hardening",
   "spec_id": "github-actions-supply-chain-hardening",
-  "state": "draft",
+  "state": "shipped",
   "title": "GitHub Actions CI/CD Supply-Chain Hardening and Simplification"
 }

--- a/src/ai_engineering/cli_commands/core.py
+++ b/src/ai_engineering/cli_commands/core.py
@@ -1147,8 +1147,12 @@ def _render_update_result(result: Any, *, root: Path, show_diff: bool) -> None:
     mode = "APPLIED" if not result.dry_run else "PREVIEW"
     print_stdout(f"Update [{mode}]: {root}")
 
-    kv("Available", result.available_count if result.dry_run else 0)
-    kv("Applied", result.applied_count if not result.dry_run else 0)
+    # Show only the count that can be non-zero in this mode; the other is
+    # structurally always zero and would be pure noise.
+    if result.dry_run:
+        kv("Available", result.available_count)
+    else:
+        kv("Applied", result.applied_count)
     kv("Protected", result.protected_count)
     kv("Unchanged", result.unchanged_count)
     kv("Orphan", result.orphan_count)

--- a/src/ai_engineering/cli_ui.py
+++ b/src/ai_engineering/cli_ui.py
@@ -285,7 +285,7 @@ def _tree_parts(path: Path, *, root: Path) -> tuple[str, ...]:
 _STATE_LABELS: dict[str, tuple[str, str]] = {
     "create": ("new", "green"),
     "update": ("updated", "yellow"),
-    "skip-denied": ("protected", "red"),
+    "skip-denied": ("protected", "dim"),
     "overwrite": ("overwrite", "bold red"),
     "skip-unchanged": ("unchanged", "dim"),
     "orphan": ("orphan", "dim magenta"),

--- a/tests/integration/test_cli_command_modules.py
+++ b/tests/integration/test_cli_command_modules.py
@@ -420,6 +420,48 @@ def test_core_update_interactive_preview_then_apply(
     mock_confirm.assert_called_once()
 
 
+def test_core_render_update_omits_zero_applied_row_in_preview(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Preview must not print the structurally-zero 'Applied' count row.
+
+    In preview mode ``Applied`` can only ever be 0, so the row is pure noise.
+    """
+    preview = UpdateResult(
+        dry_run=True,
+        changes=[
+            FileChange(path=Path("f"), action="update", reason_code="template-drift"),
+        ],
+    )
+
+    core._render_update_result(preview, root=tmp_path, show_diff=False)
+    err = capsys.readouterr().err
+
+    assert "Available  1" in err, "Preview must still report the actionable count"
+    assert "Applied" not in err, "Preview must not print the always-zero 'Applied' row"
+
+
+def test_core_render_update_omits_zero_available_row_on_apply(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Apply must not print the structurally-zero 'Available' count row.
+
+    Once applied, ``Available`` can only ever be 0, so the row is pure noise.
+    """
+    applied = UpdateResult(
+        dry_run=False,
+        changes=[
+            FileChange(path=Path("f"), action="update", reason_code="template-drift"),
+        ],
+    )
+
+    core._render_update_result(applied, root=tmp_path, show_diff=False)
+    err = capsys.readouterr().err
+
+    assert "Applied  1" in err, "Apply must report the applied count"
+    assert "Available" not in err, "Apply must not print the always-zero 'Available' row"
+
+
 def test_core_update_interactive_decline_keeps_preview_only(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_cli_ui.py
+++ b/tests/unit/test_cli_ui.py
@@ -531,6 +531,36 @@ class TestUnifiedTreeRenderer:
         assert "3 files unchanged" in err, "Footer should say '3 files unchanged'"
 
 
+class TestStateLabelColorSemantics:
+    """Tree color is keyed to actionability, not to existence.
+
+    Inert states (nothing happens to the file) must recede; only
+    content-changing or destructive states may use an alarm color.
+    """
+
+    def test_protected_label_is_dim_not_alarm(self) -> None:
+        """skip-denied (protected) is an inert no-op and must not use red.
+
+        The updater intentionally leaves protected files alone, so painting
+        them red falsely signals an error and drowns the actionable files in
+        a wall of alarm color. Dim lets them recede.
+        """
+        from ai_engineering.cli_ui import _STATE_LABELS
+
+        label, style = _STATE_LABELS["skip-denied"]
+        assert label == "protected"
+        assert style == "dim", (
+            f"Protected is inert; expected calm 'dim' so it recedes, got '{style}'."
+        )
+
+    def test_actionable_labels_keep_meaningful_colors(self) -> None:
+        """create stays green (additive) and update stays yellow (caution)."""
+        from ai_engineering.cli_ui import _STATE_LABELS
+
+        assert _STATE_LABELS["create"] == ("new", "green")
+        assert _STATE_LABELS["update"] == ("updated", "yellow")
+
+
 class TestHeaderFallback:
     """Tests for header() ImportError fallback."""
 


### PR DESCRIPTION
## Summary

Two small, unrelated working-tree changes bundled per request.

### 1. CLI install/update output polish (`fix`)
- `cli_ui.py`: the `skip-denied` / "protected" label was **red** (reads like an error) — a protected file being left untouched is normal/expected, so it's now **dim** (informational).
- `cli_commands/core.py`: `_render_update_result` printed both `Available` and `Applied` with whichever is irrelevant to the mode forced to `0` (noise). Now shows only the count that can be non-zero — `Available` in dry-run, `Applied` on apply.
- Covered by `tests/unit/test_cli_ui.py` + `tests/integration/test_cli_command_modules.py` (63 tests green locally).

### 2. spec-152 lifecycle sync (`chore`)
`mark_shipped` for [spec-152 / PR #536](https://github.com/arcasilesgroup/ai-engineering/pull/536) ran *after* that PR merged, so the shipped state (`.ai-engineering/state/specs/…json`) + the `_history.md` row land here as a follow-up.

## Notes
The CLI change originated as uncommitted WIP from a concurrent session; verified sound + green and committed verbatim (no behavior added beyond the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)