### PR TITLE
fix(release): exempt ### Fixed from release-path BREAKING gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The release changelog gate no longer false-trips on non-breaking
+  release-path *fixes*. `validate_changelog` now exempts the `### Fixed`
+  subgroup from the "release-path semantic changes must be documented under
+  `### BREAKING`" requirement, since Keep-a-Changelog `### Fixed` entries are
+  non-breaking by definition. A release-path fix mentioning tokens like
+  "release packet" under `### Fixed` no longer blocks `ai-eng release`;
+  genuine semantic changes under `### Added`/`### Changed`/`### Removed` still
+  require a `### BREAKING` entry. Guarded by
+  `tests/unit/test_changelog_parser.py`.
 - `ai-eng install` now writes a managed `.ai-engineering/.gitignore` so the
   transient, per-install, and derived artifacts it generates — the audit and
   observation NDJSON streams, per-install state SoTs, the compiled & signed

--- a/src/ai_engineering/release/changelog.py
+++ b/src/ai_engineering/release/changelog.py
@@ -65,7 +65,12 @@ def validate_changelog(changelog_path: Path, version: str) -> list[str]:
                 "subgroup (### Added, Changed, Deprecated, Removed, Fixed, Security, "
                 "or BREAKING)"
             )
-        if _release_path_semantics_changed(unreleased_body):
+        # Keep-a-Changelog ``### Fixed`` entries are non-breaking bug fixes by
+        # definition, so a release-path *fix* must not trip the BREAKING-subgroup
+        # requirement that exists for release-path *semantic changes*. Scan every
+        # subgroup except Fixed for the requirement trigger.
+        semantic_body = _body_excluding_subsection(unreleased_body, "Fixed")
+        if _release_path_semantics_changed(semantic_body):
             breaking_body = _subsection_body(unreleased_body, "BREAKING")
             if breaking_body is None or not _release_path_semantics_changed(breaking_body):
                 errors.append(
@@ -145,6 +150,23 @@ def _subsection_body(section_body: str, heading: str) -> str | None:
             end = index
             break
     return "\n".join(lines[start:end]).strip()
+
+
+def _body_excluding_subsection(section_body: str, heading: str) -> str:
+    """Return the section body with the named ``### heading`` subgroup removed."""
+    lines = section_body.splitlines()
+    kept: list[str] = []
+    in_target = False
+    for line in lines:
+        name = _changelog_subgroup_name(line)
+        if name is not None:
+            in_target = name == heading
+            if in_target:
+                continue
+        if in_target:
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
 
 
 def _validate_target_section_date(text: str, version: str) -> str | None:

--- a/tests/unit/test_changelog_parser.py
+++ b/tests/unit/test_changelog_parser.py
@@ -173,6 +173,60 @@ def test_validate_changelog_accepts_release_path_semantics_under_breaking(
     assert not any("### BREAKING" in err for err in errors)
 
 
+def test_validate_changelog_allows_release_path_fix_under_fixed(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a non-breaking release-path *fix* belongs under ### Fixed and
+    # must not be forced into a ### BREAKING subgroup (Keep-a-Changelog).
+    changelog = tmp_path / "CHANGELOG.md"
+    _write_changelog(
+        changelog,
+        "\n".join(
+            [
+                "### Fixed",
+                "- Release finalization now writes non-empty proof logs so "
+                "release packet asset uploads do not fail on zero-byte files.",
+                "",
+            ]
+        ),
+    )
+
+    # Act
+    errors = validate_changelog(changelog, "0.2.0")
+
+    # Assert
+    assert not any("### BREAKING" in err for err in errors)
+
+
+def test_validate_changelog_still_requires_breaking_when_fixed_subsection_present(
+    tmp_path: Path,
+) -> None:
+    # Arrange — the Fixed exemption is scoped: a release-path *semantic change*
+    # under ### Changed still requires a ### BREAKING entry even when a ### Fixed
+    # subsection coexists.
+    changelog = tmp_path / "CHANGELOG.md"
+    _write_changelog(
+        changelog,
+        "\n".join(
+            [
+                "### Changed",
+                "- semantic-release and manual CI commit-back are removed; "
+                "ai-eng release is sole authority.",
+                "",
+                "### Fixed",
+                "- unrelated typo fix.",
+                "",
+            ]
+        ),
+    )
+
+    # Act
+    errors = validate_changelog(changelog, "0.2.0")
+
+    # Assert
+    assert any("### BREAKING" in err for err in errors)
+
+
 def test_promote_unreleased_moves_content_and_leaves_empty_section(tmp_path: Path) -> None:
     # Arrange
     changelog = tmp_path / "CHANGELOG.md"


### PR DESCRIPTION
## Why

`ai-eng release 0.8.0` was blocked at the `validate` phase by the changelog gate:

> Release-path semantic changes in CHANGELOG [Unreleased] must be documented under a ### BREAKING subgroup

Root cause: `_release_path_semantics_changed` scanned the **entire** `[Unreleased]` body for release-path tokens (`release packet`, `testpypi`, `trusted publishing`, `sole authority`, …) and required a matching `### BREAKING` entry. A **non-breaking release-path fix** — `1b28b602 fix(release): bound GitHub release notes` (#529), filed correctly under `### Fixed` and mentioning "release packet" — false-tripped the gate. A `### Fixed` entry cannot be breaking by Keep-a-Changelog definition.

## What

- `validate_changelog` now scans `[Unreleased]` **excluding the `### Fixed` subgroup** for the BREAKING-requirement trigger (new `_body_excluding_subsection` helper).
- Genuine semantic changes under `### Added` / `### Changed` / `### Removed` still require a `### BREAKING` entry. The v0.7.0 precedent (publishing-spine change documented under BREAKING) is preserved.
- Two new guard tests: release-path fix under `### Fixed` passes; semantic change under `### Changed` still requires BREAKING even when a `### Fixed` subsection coexists.

## Context

Prep fix to unblock the **0.8.0** release. Autonomous bug fix (CLAUDE.md §9) — self-contained, test-guarded, documented in CHANGELOG `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)