### PR TITLE
fix(release): resumable --wait, lockfile pin sync, env-drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ai-eng release <version> --wait` is now idempotent and resumable.** When the
+  release PR has already merged (the version bump is on the default branch and the
+  CHANGELOG `[Unreleased]` is already promoted) but the tag was never created, a
+  rerun now detects that the current version already equals the target and the tag
+  is absent, skips validate's version/changelog gate plus prepare/PR/wait-for-merge,
+  and proceeds straight to readiness → create-tag → monitor. The pre-merge flow is
+  unchanged when the bump has not landed, and a genuine downgrade still errors.
+- **Release `prepare` now syncs the project's own version pin in `uv.lock`.** The
+  bump updated `pyproject.toml`, `version/registry.json`, and the two `manifest.yml`
+  surfaces but left the `uv.lock` editable-root pin stale, which forced a manual
+  lockfile commit onto the release branch. The pin is now rewritten in place
+  alongside the other bumped files.
+- **Release deployment-environment drift is now guarded.** The 0.8.0 publish
+  nearly failed because `release.yml` became tag-triggered (spec-152) while the
+  `pypi` GitHub environment still allowed only the `main` branch — a setting
+  that lives in repo configuration, not the repository, so nothing in-tree
+  caught the drift. `ai-eng doctor` now runs a `release-env-policy` runtime
+  check that reads each release environment's live deployment policy and warns
+  when the `v*` tag pattern is missing, and a new
+  `tests/unit/workflows/test_release_env_policy_docs.py` fails CI if a publish
+  environment is added to the workflow without a matching policy note. The
+  required `pypi`, `testpypi`, and `github-release` deployment policies and the
+  `tag-protection-v` ruleset coupling are documented in
+  `docs/ci-branch-protection.md`.
+
 ## [0.8.0] - 2026-05-24
 
 ### BREAKING

--- a/docs/ci-branch-protection.md
+++ b/docs/ci-branch-protection.md
@@ -97,3 +97,79 @@ single-required-check model cannot silently regress into a fail-open hole.
 Repo settings → Branches → branch protection rule for `main` → "Require
 status checks to pass before merging" → add **`CI Result`**. This is an
 operator-applied repo-settings change; it is not enforced by code.
+
+## Environment deployment policies (release publishing)
+
+> The 0.8.0 release nearly failed here. Spec-152 made
+> [`release.yml`](../.github/workflows/release.yml) **tag-triggered**
+> (`on: push: tags: ['v*']`), but the `pypi` environment still allowed only
+> the `main` *branch* (correct for the pre-spec-152 branch-triggered
+> workflow). The first tag-triggered publish was rejected with *"Tag v0.8.0
+> is not allowed to deploy to pypi due to environment protection rules."*
+> This section is the operator contract that keeps that from recurring.
+
+The Release workflow runs from a **tag ref** (`refs/tags/vX.Y.Z`) and
+deploys through three GitHub **deployment environments**, each with its own
+protection rules under Settings → Environments:
+
+| Environment | Deploying job | Required deployment policy |
+|-------------|---------------|----------------------------|
+| `pypi` | `publish-pypi` | a **`v*` tag** policy (Selected branches and tags) |
+| `testpypi` | `publish-testpypi` | unrestricted, **or** a `v*` tag policy |
+| `github-release` | `finalize-release-packet` | unrestricted, **or** a `v*` tag policy |
+
+The rule: **any environment that restricts deployments MUST include a *tag*
+policy matching the workflow's `v*` glob.** GitHub's "Deployment branches
+and tags" setting has three modes:
+
+- **No restriction** (`deployment_branch_policy: null`) — every ref,
+  tags included, may deploy. `testpypi` and `github-release` sit here today.
+- **Protected branches only** — *tags can never deploy*; a tag-triggered
+  release is rejected outright. Never select this for a release environment.
+- **Selected branches and tags** (`custom_branch_policies: true`) — only the
+  listed patterns may deploy, so an explicit `v*` rule of type **`tag`** (not
+  `branch`) is mandatory. `pypi` sits here: `main` (branch) + `v*` (tag).
+
+### Coupling to the `tag-protection-v` ruleset
+
+The `v*` pattern is shared by two distinct controls that must stay in
+agreement:
+
+- the **`tag-protection-v`** ruleset (Settings → Rules, target `tag`)
+  governs *who may create* a `v*` release tag;
+- each environment's **`v*` tag deployment policy** governs *whether that
+  tag may deploy* to PyPI / TestPyPI / the GitHub Release.
+
+Both key on `v*`; changing the tag shape in one without the other reopens
+the drift.
+
+### Applying or repairing a policy
+
+To move an environment to "Selected branches and tags" and add the `v*`
+tag rule (repeat per restricted environment — the environment must already
+be in "Selected branches and tags" mode for the POST to take effect):
+
+```bash
+gh api --method POST \
+  repos/arcasilesgroup/ai-engineering/environments/pypi/deployment-branch-policies \
+  -f name='v*' -f type='tag'
+```
+
+### Why this is guarded twice
+
+Like the `CI Result` check above, environment policies live in **GitHub
+settings, not in the repo**, so committed code cannot enforce them. Two
+guards make drift loud instead of silent:
+
+- **`ai-eng doctor`** runs a `release-env-policy` runtime check
+  ([`src/ai_engineering/doctor/runtime/release_env_policy.py`](../src/ai_engineering/doctor/runtime/release_env_policy.py))
+  that reads each environment's *live* deployment policy and WARNs when the
+  `v*` tag pattern is missing. It is operator-run, needs `gh` authenticated
+  with admin scope, and is WARN-only (never blocks a developer's run).
+- **[`tests/unit/workflows/test_release_env_policy_docs.py`](../tests/unit/workflows/test_release_env_policy_docs.py)**
+  fails CI if `release.yml` stays tag-triggered while a deployment
+  environment it uses is left undocumented in this table — so adding a new
+  publish environment forces a matching policy note here. The tag trigger
+  itself is held in place by
+  [`scripts/check_workflow_policy.py`](../scripts/check_workflow_policy.py)
+  (`workflow-sanity` job).

--- a/docs/supply-chain-control-matrix.md
+++ b/docs/supply-chain-control-matrix.md
@@ -23,6 +23,17 @@ This matrix maps every dependency-ingress surface to its **owner**, the
 | 5 | Supply-chain-sensitive file edits | `@arcasilesgroup/maintainers` | `.github/CODEOWNERS` — explicit entries for `/.github/**`, `/.github/actions/**`, `release.yml`, `check_workflow_policy.py`, `pyproject.toml`, `uv.lock` | every PR touching those paths | required maintainer review before merge | PR review record | Request maintainer review; the rule is GitHub-enforced once branch protection requires CODEOWNERS review |
 | 6 | GitHub Action / runtime-tool pinning | `@arcasilesgroup/maintainers` | `scripts/check_workflow_policy.py` (`workflow-sanity` job) — every external `uses:` must be a 40-char SHA; runtime installs must be version-pinned | every run (`workflow-sanity` is `always_required`) | any unpinned action or install → policy fails → `CI Result` fails | policy-check log | Resolve the tag to a SHA via `git ls-remote`; pin the install version |
 
+## Release deployment authorization (egress)
+
+The matrix above guards dependency *ingress*. The complementary *egress*
+control — which refs may publish to PyPI / TestPyPI and cut the GitHub
+Release — is each environment's **deployment policy**. Because
+[`release.yml`](../.github/workflows/release.yml) is tag-triggered, every
+release environment must admit the `v*` tag pattern. That requirement, the
+`tag-protection-v` ruleset coupling, and the `release-env-policy` doctor
+guard are documented in
+[`docs/ci-branch-protection.md`](ci-branch-protection.md#environment-deployment-policies-release-publishing).
+
 ## Dependabot PRs run the same `CI Result`
 
 Dependabot opens PRs against `main` like any contributor, so its PRs run

--- a/src/ai_engineering/doctor/runtime/release_env_policy.py
+++ b/src/ai_engineering/doctor/runtime/release_env_policy.py
@@ -1,0 +1,334 @@
+"""Doctor runtime check: release-env-policy -- guards the tag-triggered
+publish path against GitHub deployment-environment drift.
+
+Why this exists
+---------------
+spec-152 made ``.github/workflows/release.yml`` *tag-triggered*
+(``on: push: tags: ['v*']``). A GitHub **deployment environment** whose
+protection rules restrict deployments to *branches* (e.g. only ``main``)
+will reject a deploy that runs from a tag ref with::
+
+    Tag vX.Y.Z is not allowed to deploy to <env> due to environment
+    protection rules.
+
+That is the regression that nearly broke the 0.8.0 production publish: the
+``pypi`` environment allowed only the ``main`` branch (correct for the
+pre-spec-152 *branch*-triggered workflow), and 0.8.0 was the first
+tag-triggered release to hit the drift. The fix was to add a ``v*`` *tag*
+deployment policy to the environment.
+
+That policy lives in **GitHub repo settings, not in the repository**, so
+nothing in-tree stops it from drifting again. This check closes the gap:
+for every environment the release workflow deploys through, it asks the
+live GitHub API whether a *tag* deployment policy matching the workflow's
+tag glob exists, and WARNs when it does not.
+
+Robustness
+----------
+WARN-never-FAIL, like every doctor runtime check. ``service._run_runtime_modules``
+calls ``check(ctx)`` with no surrounding try/except, so this module catches
+everything internally and downgrades to WARN -- a missing ``gh`` binary,
+absent auth, a network failure, or an under-scoped token must never crash
+``ai-eng doctor``. A repository whose ``release.yml`` is not tag-triggered
+(or has no deployment environments) contributes nothing and pays zero
+network cost -- the release file is read and parsed before any API call.
+
+The companion static guard
+``tests/unit/workflows/test_release_env_policy_docs.py`` keeps the
+documentation (``docs/ci-branch-protection.md``) honest whenever the
+workflow's environment set changes; ``scripts/check_workflow_policy.py``
+keeps the tag trigger itself from being removed.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import yaml
+
+from ai_engineering.doctor.models import CheckResult, CheckStatus, DoctorContext
+
+_CHECK = "release-env-policy"
+_RELEASE_WORKFLOW = Path(".github") / "workflows" / "release.yml"
+_GH_TIMEOUT = 10
+
+
+def check(ctx: DoctorContext) -> list[CheckResult]:
+    """Verify release deployment environments admit the workflow's tag glob."""
+    try:
+        return _check(ctx)
+    except Exception as exc:
+        # service._run_runtime_modules calls check(ctx) unwrapped: a broad
+        # catch here is the contract that keeps doctor from crashing.
+        return [_result(CheckStatus.WARN, f"release env policy check errored: {exc}")]
+
+
+def _check(ctx: DoctorContext) -> list[CheckResult]:
+    workflow_path = ctx.target / _RELEASE_WORKFLOW
+    if not workflow_path.is_file():
+        # No release workflow (typical for consumer installs) -> not applicable.
+        return []
+
+    try:
+        data = yaml.safe_load(workflow_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        # A malformed release.yml is caught by actionlint / check_workflow_policy;
+        # it is not this check's concern.
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    tag_globs = _tag_globs(data)
+    if not tag_globs:
+        # Branch-triggered (or non-tag) release workflows do not hit the
+        # tag-vs-branch environment drift this check guards.
+        return []
+
+    environments = _environment_names(data)
+    if not environments:
+        return []
+
+    # Only now -- once we know the coupling applies -- do we touch the network.
+    slug = _resolve_repo_slug(ctx.target)
+    if slug is None:
+        return [
+            _result(
+                CheckStatus.WARN,
+                "gh CLI unavailable or repository unresolved; cannot verify that "
+                f"release environments {sorted(environments)} admit tag glob "
+                f"{sorted(tag_globs)} (run 'gh auth login' with admin scope)",
+            )
+        ]
+
+    return [_evaluate_env(ctx.target, slug, env, tag_globs) for env in environments]
+
+
+# ---------------------------------------------------------------------------
+# Workflow parsing
+# ---------------------------------------------------------------------------
+
+
+def _tag_globs(data: dict[Any, Any]) -> list[str]:
+    """Return the workflow's ``on: push: tags`` globs.
+
+    Handles PyYAML parsing the bare ``on:`` key as the boolean ``True`` (YAML
+    1.1), so the parsed document is keyed by ``str | bool`` -- hence ``dict[Any,
+    Any]`` rather than ``dict[str, Any]``.
+    """
+    triggers = data.get("on", data.get(True))
+    if not isinstance(triggers, dict):
+        return []
+    push = triggers.get("push")
+    if not isinstance(push, dict):
+        return []
+    tags = push.get("tags")
+    if isinstance(tags, str):
+        return [tags]
+    if isinstance(tags, list):
+        return [str(item) for item in tags]
+    return []
+
+
+def _environment_names(data: dict[str, Any]) -> list[str]:
+    """Collect the unique deployment-environment names across all jobs.
+
+    A job's ``environment`` may be a plain string or a mapping with a
+    ``name`` key. Order is preserved (first-seen) for stable output.
+    """
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    names: list[str] = []
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        environment = job.get("environment")
+        name: str | None = None
+        if isinstance(environment, str):
+            name = environment
+        elif isinstance(environment, dict):
+            raw = environment.get("name")
+            if isinstance(raw, str):
+                name = raw
+        # Skip environment names that interpolate workflow expressions --
+        # we cannot resolve "${{ ... }}" to a real environment here.
+        if name and "${{" not in name and name not in names:
+            names.append(name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+
+def _resolve_repo_slug(target: Path) -> str | None:
+    """Return ``owner/repo`` via gh, or None when gh/auth/remote is unavailable.
+
+    Doubles as the gh availability + authentication preflight so the
+    per-environment calls below can assume a resolvable repository.
+    """
+    proc = _gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], target)
+    if proc is None or proc.returncode != 0:
+        return None
+    slug = (proc.stdout or "").strip()
+    return slug or None
+
+
+def _evaluate_env(target: Path, slug: str, env: str, tag_globs: list[str]) -> CheckResult:
+    """Evaluate one environment's live deployment policy against the tag globs."""
+    name = f"release-env-{env}"
+    env_path = f"repos/{slug}/environments/{quote(env, safe='')}"
+    proc = _gh(["api", env_path], target)
+    if proc is None or proc.returncode != 0:
+        return _result(
+            CheckStatus.WARN,
+            f"could not read environment {env!r} deployment policy via gh api: "
+            f"{_first_error_line(proc)}; ensure gh is authenticated with admin scope",
+            name=name,
+        )
+
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return _result(
+            CheckStatus.WARN,
+            f"environment {env!r} API response was not valid JSON",
+            name=name,
+        )
+
+    policy = payload.get("deployment_branch_policy")
+    if policy is None:
+        return _result(
+            CheckStatus.OK,
+            f"environment {env!r} allows all refs; tag-triggered deploys are permitted",
+            name=name,
+        )
+
+    if isinstance(policy, dict) and policy.get("custom_branch_policies"):
+        return _evaluate_custom_policies(target, slug, env, tag_globs, name)
+
+    if isinstance(policy, dict) and policy.get("protected_branches"):
+        return _result(
+            CheckStatus.WARN,
+            f"environment {env!r} restricts deployments to protected branches; the "
+            f"tag-triggered release ({sorted(tag_globs)}) will be REJECTED. Set "
+            "'Deployment branches and tags' to 'Selected branches and tags' and add a "
+            f"tag rule. Fix: {_fix_command(slug, env)}",
+            name=name,
+        )
+
+    return _result(
+        CheckStatus.WARN,
+        f"environment {env!r} has an unrecognized deployment policy {policy!r}; "
+        f"verify it admits the release tag glob {sorted(tag_globs)}",
+        name=name,
+    )
+
+
+def _evaluate_custom_policies(
+    target: Path, slug: str, env: str, tag_globs: list[str], name: str
+) -> CheckResult:
+    """Inspect an environment's custom deployment-branch-policies list."""
+    policies_path = f"repos/{slug}/environments/{quote(env, safe='')}/deployment-branch-policies"
+    proc = _gh(["api", policies_path], target)
+    if proc is None or proc.returncode != 0:
+        return _result(
+            CheckStatus.WARN,
+            f"could not list environment {env!r} deployment-branch-policies via gh api: "
+            f"{_first_error_line(proc)}",
+            name=name,
+        )
+
+    try:
+        items = json.loads(proc.stdout or "{}").get("branch_policies", [])
+    except json.JSONDecodeError:
+        return _result(
+            CheckStatus.WARN,
+            f"environment {env!r} deployment-branch-policies response was not valid JSON",
+            name=name,
+        )
+
+    if _admits_all_tag_globs(items, tag_globs):
+        return _result(
+            CheckStatus.OK,
+            f"environment {env!r} has a tag deployment policy admitting {sorted(tag_globs)}",
+            name=name,
+        )
+
+    return _result(
+        CheckStatus.WARN,
+        f"environment {env!r} has custom deployment policies but none admit the release "
+        f"tag glob {sorted(tag_globs)}; tag-triggered publish will be REJECTED. "
+        f"Fix: {_fix_command(slug, env)}",
+        name=name,
+    )
+
+
+def _admits_all_tag_globs(items: list[Any], tag_globs: list[str]) -> bool:
+    """True when every workflow tag glob is admitted by some tag policy.
+
+    A custom deployment policy entry is ``{"name": <glob>, "type": <"branch"|"tag">}``.
+    Each policy name is itself a glob, so we test whether it admits a
+    representative tag the workflow's glob would produce (``v*`` -> ``v0``):
+    if the policy ``v*`` admits ``v0`` it admits every real ``vX.Y.Z`` tag.
+    Entries without ``type == "tag"`` (older API responses default to branch)
+    cannot admit a tag and are ignored.
+    """
+    tag_policy_names = [
+        item["name"]
+        for item in items
+        if isinstance(item, dict)
+        and item.get("type") == "tag"
+        and isinstance(item.get("name"), str)
+    ]
+    if not tag_policy_names:
+        return False
+    for glob in tag_globs:
+        representative = glob.replace("*", "0").replace("?", "0")
+        if not any(fnmatch.fnmatch(representative, policy) for policy in tag_policy_names):
+            return False
+    return True
+
+
+def _fix_command(slug: str, env: str) -> str:
+    """Return the copy-pasteable gh command that adds the v* tag policy."""
+    return (
+        f"gh api --method POST repos/{slug}/environments/{env}/deployment-branch-policies "
+        "-f name='v*' -f type='tag'"
+    )
+
+
+def _gh(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str] | None:
+    """Run a gh command, returning None when gh itself is unavailable."""
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=_GH_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _first_error_line(proc: subprocess.CompletedProcess[str] | None) -> str:
+    """Return the first non-empty stderr/stdout line for a WARN message."""
+    if proc is None:
+        return "gh CLI not found or timed out"
+    for stream in (proc.stderr, proc.stdout):
+        for line in (stream or "").splitlines():
+            if line.strip():
+                return line.strip()
+    return f"gh exited {proc.returncode}"
+
+
+def _result(status: CheckStatus, message: str, *, name: str = _CHECK) -> CheckResult:
+    return CheckResult(name=name, status=status, message=message)

--- a/src/ai_engineering/doctor/service.py
+++ b/src/ai_engineering/doctor/service.py
@@ -33,6 +33,7 @@ from ai_engineering.doctor.runtime import (
     branch_policy,
     feeds,
     opa_health,
+    release_env_policy,
     secrets_gate,
     vcs_auth,
     version,
@@ -78,6 +79,7 @@ _RUNTIME_CHECK_MODULES = {
     "version": version,
     "opa_health": opa_health,
     "secrets_gate": secrets_gate,
+    "release_env_policy": release_env_policy,
 }
 
 _RUNTIME_MODULES: tuple[str, ...] = (
@@ -87,6 +89,7 @@ _RUNTIME_MODULES: tuple[str, ...] = (
     "version",
     "opa_health",
     "secrets_gate",
+    "release_env_policy",
 )
 
 

--- a/src/ai_engineering/release/orchestrator.py
+++ b/src/ai_engineering/release/orchestrator.py
@@ -34,6 +34,12 @@ from ai_engineering.verify.service import verify_release
 _RELEASE_PACKET_NAME = "release-packet.json"
 _RELEASE_READINESS_NAME = "release-readiness.json"
 _CHANGELOG_REL = Path("CHANGELOG.md")
+_LOCKFILE_NAME = "uv.lock"
+# Editable-root pin in uv.lock: only the project's own `source = { editable = "." }`
+# package block is rewritten; dependency pins are left untouched.
+_LOCK_EDITABLE_ROOT_RE = re.compile(
+    r'(\[\[package\]\]\nname = "[^"]+"\nversion = ")([^"]+)("\nsource = \{ editable = "\." \})'
+)
 
 
 class Clock(Protocol):
@@ -234,93 +240,74 @@ def execute_release(
         _attach_release_packet(result)
         return result
 
-    if not config.skip_bump:
-        prepare = _prepare_branch(config, clock)
-        phases.append(prepare)
-        if not prepare.success:
-            result.errors.append(prepare.output)
+    if compare_versions(state.current_version, config.version) == 0:
+        # Resume path: the bump already merged to the default branch but the tag
+        # was never created (e.g. `--wait` was interrupted, or the PR merged out
+        # of band). Skip prepare/PR/wait-for-merge and go straight to completion.
+        base_branch = _default_branch(config.project_root)
+        phases.append(
+            PhaseResult(
+                phase="prepare",
+                success=True,
+                skipped=True,
+                output=f"Version {config.version} already on {base_branch}",
+            )
+        )
+        phases.append(
+            PhaseResult(phase="pr", success=True, skipped=True, output="Release PR already merged")
+        )
+        phases.append(
+            PhaseResult(
+                phase="wait-for-merge",
+                success=True,
+                skipped=True,
+                output="Release PR already merged",
+            )
+        )
+        if not _complete_release(config, provider, clock, result, phases):
             return result
-        if prepare.output:
-            result.bump_files.extend(prepare.output.split("\n"))
     else:
-        phases.append(
-            PhaseResult(phase="prepare", success=True, skipped=True, output="--skip-bump")
-        )
+        if not config.skip_bump:
+            prepare = _prepare_branch(config, clock)
+            phases.append(prepare)
+            if not prepare.success:
+                result.errors.append(prepare.output)
+                return result
+            if prepare.output:
+                result.bump_files.extend(prepare.output.split("\n"))
+        else:
+            phases.append(
+                PhaseResult(phase="prepare", success=True, skipped=True, output="--skip-bump")
+            )
 
-    pr_phase = _create_release_pr(config, provider, runner)
-    phases.append(pr_phase)
-    if not pr_phase.success:
-        result.errors.append(pr_phase.output)
-        return result
-    if pr_phase.output.startswith("http"):
-        result.pr_url = pr_phase.output.splitlines()[0].strip()
-
-    if config.wait:
-        wait_phase = _wait_for_merge(config, provider, config.wait_timeout, runner)
-        phases.append(wait_phase)
-        if not wait_phase.success:
-            result.errors.append(wait_phase.output)
+        pr_phase = _create_release_pr(config, provider, runner)
+        phases.append(pr_phase)
+        if not pr_phase.success:
+            result.errors.append(pr_phase.output)
             return result
+        if pr_phase.output.startswith("http"):
+            result.pr_url = pr_phase.output.splitlines()[0].strip()
 
-        readiness_phase = _run_release_readiness(config)
-        phases.append(readiness_phase)
-        result.readiness = _readiness_payload(readiness_phase)
-        if not readiness_phase.success:
-            result.errors.append(readiness_phase.output)
-            return result
-
-        tag_phase = _create_tag(config, provider)
-        phases.append(tag_phase)
-        if not tag_phase.success:
-            result.errors.append(tag_phase.output)
-            return result
-
-        result.release_url = _release_url_for_tag(config)
-        _attach_release_packet(result)
-        manifest_phase = _update_manifest(config, clock)
-        phases.append(manifest_phase)
-        if not manifest_phase.success:
-            result.errors.append(manifest_phase.output)
-            return result
-
-        emit_deploy_event(
-            config.project_root,
-            environment="production",
-            strategy="tag",
-            version=config.version,
-            result=f"tag={tag_name}",
-            release_packet_url=result.release_packet_url,
-            release_packet_ref=result.release_packet_ref,
-        )
-
-        monitor_phase = _monitor_pipeline(config, provider, config.wait_timeout)
-        phases.append(monitor_phase)
-        if not monitor_phase.success:
-            result.errors.append(monitor_phase.output)
-            return result
-        result.pipeline_status = monitor_phase.output
-        if monitor_phase.output.startswith("http"):
-            result.release_url = _release_url_from_monitor(config, monitor_phase.output)
-            _attach_release_packet(result)
-        emit_deploy_event(
-            config.project_root,
-            environment="production",
-            strategy="pipeline",
-            version=config.version,
-            result=monitor_phase.output,
-            release_packet_url=result.release_packet_url,
-            release_packet_ref=result.release_packet_ref,
-        )
-    else:
-        skip_msg = "Tag deferred -- run `ai-eng release <version> --wait` after merge"
-        phases.append(
-            PhaseResult(phase="wait-for-merge", success=True, skipped=True, output="--wait off")
-        )
-        phases.append(PhaseResult(phase="tag", success=True, skipped=True, output=skip_msg))
-        phases.append(
-            PhaseResult(phase="manifest", success=True, skipped=True, output="--wait off")
-        )
-        phases.append(PhaseResult(phase="monitor", success=True, skipped=True, output="--wait off"))
+        if config.wait:
+            wait_phase = _wait_for_merge(config, provider, config.wait_timeout, runner)
+            phases.append(wait_phase)
+            if not wait_phase.success:
+                result.errors.append(wait_phase.output)
+                return result
+            if not _complete_release(config, provider, clock, result, phases):
+                return result
+        else:
+            skip_msg = "Tag deferred -- run `ai-eng release <version> --wait` after merge"
+            phases.append(
+                PhaseResult(phase="wait-for-merge", success=True, skipped=True, output="--wait off")
+            )
+            phases.append(PhaseResult(phase="tag", success=True, skipped=True, output=skip_msg))
+            phases.append(
+                PhaseResult(phase="manifest", success=True, skipped=True, output="--wait off")
+            )
+            phases.append(
+                PhaseResult(phase="monitor", success=True, skipped=True, output="--wait off")
+            )
 
     result.success = True
     if not result.release_url:
@@ -328,6 +315,73 @@ def execute_release(
         if slug:
             result.release_url = f"https://github.com/{slug}/releases/tag/{tag_name}"
     return result
+
+
+def _complete_release(
+    config: ReleaseConfig,
+    provider: VcsProvider,
+    clock: Clock,
+    result: ReleaseResult,
+    phases: list[PhaseResult],
+) -> bool:
+    """Run the post-merge completion sequence: readiness -> tag -> manifest -> monitor.
+
+    Shared by the pre-merge ``--wait`` flow and the post-merge resume flow. Appends
+    each phase to *phases*, mutates *result*, and returns ``False`` on the first
+    failing phase (the caller returns the partially populated result).
+    """
+    tag_name = f"v{config.version}"
+
+    readiness_phase = _run_release_readiness(config)
+    phases.append(readiness_phase)
+    result.readiness = _readiness_payload(readiness_phase)
+    if not readiness_phase.success:
+        result.errors.append(readiness_phase.output)
+        return False
+
+    tag_phase = _create_tag(config, provider)
+    phases.append(tag_phase)
+    if not tag_phase.success:
+        result.errors.append(tag_phase.output)
+        return False
+
+    result.release_url = _release_url_for_tag(config)
+    _attach_release_packet(result)
+    manifest_phase = _update_manifest(config, clock)
+    phases.append(manifest_phase)
+    if not manifest_phase.success:
+        result.errors.append(manifest_phase.output)
+        return False
+
+    emit_deploy_event(
+        config.project_root,
+        environment="production",
+        strategy="tag",
+        version=config.version,
+        result=f"tag={tag_name}",
+        release_packet_url=result.release_packet_url,
+        release_packet_ref=result.release_packet_ref,
+    )
+
+    monitor_phase = _monitor_pipeline(config, provider, config.wait_timeout)
+    phases.append(monitor_phase)
+    if not monitor_phase.success:
+        result.errors.append(monitor_phase.output)
+        return False
+    result.pipeline_status = monitor_phase.output
+    if monitor_phase.output.startswith("http"):
+        result.release_url = _release_url_from_monitor(config, monitor_phase.output)
+        _attach_release_packet(result)
+    emit_deploy_event(
+        config.project_root,
+        environment="production",
+        strategy="pipeline",
+        version=config.version,
+        result=monitor_phase.output,
+        release_packet_url=result.release_packet_url,
+        release_packet_ref=result.release_packet_ref,
+    )
+    return True
 
 
 def _build_dry_run_plan(config: ReleaseConfig, state: ReleaseState) -> ReleaseDryRunPlan:
@@ -362,6 +416,8 @@ def _governed_changed_files(project_root: Path) -> list[str]:
         files.append(registry.as_posix())
     if (project_root / _TEMPLATE_MANIFEST_REL).is_file():
         files.extend([_ROOT_MANIFEST_REL.as_posix(), _TEMPLATE_MANIFEST_REL.as_posix()])
+    if (project_root / _LOCKFILE_NAME).is_file():
+        files.append(_LOCKFILE_NAME)
     return files
 
 
@@ -452,9 +508,18 @@ def _validate(config: ReleaseConfig, provider: VcsProvider) -> list[str]:
     elif output.strip():
         errors.append("Working tree must be clean")
 
+    resume = False
     try:
         current = detect_current_version(config.project_root)
-        if compare_versions(current, config.version) >= 0:
+        comparison = compare_versions(current, config.version)
+        if comparison == 0:
+            # Bump already landed on the default branch (release PR merged): the
+            # version pin already matches and the changelog is already promoted.
+            # This is a resume-to-tag run, not a downgrade -- skip the
+            # greater-than and changelog gates and let state detection drive the
+            # resume flow in execute_release.
+            resume = True
+        elif comparison > 0:
             errors.append(
                 f"New version ({config.version}) must be greater than current ({current})"
             )
@@ -468,11 +533,12 @@ def _validate(config: ReleaseConfig, provider: VcsProvider) -> list[str]:
         if not auth.success:
             errors.append(f"VCS auth check failed: {auth.output}")
 
-    changelog_path = config.project_root / _CHANGELOG_REL
-    if not changelog_path.exists():
-        errors.append(f"{_CHANGELOG_REL.as_posix()} not found")
-    else:
-        errors.extend(validate_changelog(changelog_path, config.version))
+    if not resume:
+        changelog_path = config.project_root / _CHANGELOG_REL
+        if not changelog_path.exists():
+            errors.append(f"{_CHANGELOG_REL.as_posix()} not found")
+        else:
+            errors.extend(validate_changelog(changelog_path, config.version))
 
     return errors
 
@@ -518,8 +584,13 @@ def _prepare_branch(config: ReleaseConfig, clock: Clock) -> PhaseResult:
 
     try:
         bump = bump_python_version(config.project_root, config.version)
+        lock_path = _update_lockfile_version(config.project_root, config.version)
     except (ValueError, FileNotFoundError) as exc:
         return PhaseResult(phase="prepare", success=False, output=str(exc))
+
+    files_modified = list(bump.files_modified)
+    if lock_path is not None:
+        files_modified.append(lock_path)
 
     today = clock.utcnow().strftime("%Y-%m-%d")
     changelog_path = config.project_root / _CHANGELOG_REL
@@ -530,7 +601,7 @@ def _prepare_branch(config: ReleaseConfig, clock: Clock) -> PhaseResult:
             output=f"Failed to promote [Unreleased] in {_CHANGELOG_REL.as_posix()}",
         )
 
-    files_to_add = [str(p.relative_to(config.project_root)) for p in bump.files_modified]
+    files_to_add = [str(p.relative_to(config.project_root)) for p in files_modified]
     files_to_add.append(_CHANGELOG_REL.as_posix())
     add_ok, add_out = run_git(["add", *files_to_add], config.project_root)
     if not add_ok:
@@ -545,8 +616,33 @@ def _prepare_branch(config: ReleaseConfig, clock: Clock) -> PhaseResult:
             phase="prepare", success=False, output=f"git commit failed: {commit_out}"
         )
 
-    files = [str(path.relative_to(config.project_root)) for path in bump.files_modified]
+    files = [str(path.relative_to(config.project_root)) for path in files_modified]
     return PhaseResult(phase="prepare", success=True, output="\n".join(files))
+
+
+def _update_lockfile_version(project_root: Path, new_version: str) -> Path | None:
+    """Sync the project's own version pin in ``uv.lock`` with the bump.
+
+    Only the editable root package (``source = { editable = "." }``) is rewritten,
+    so dependency pins are untouched and the result is byte-identical to what
+    ``uv lock`` would emit for a version-only bump. Returns the lockfile path when
+    updated, or ``None`` when no ``uv.lock`` is present (e.g. installed consumer
+    projects). Raises ``ValueError`` when the lockfile exists but the editable
+    root pin cannot be located, so the release fails loud rather than committing a
+    desynced lockfile.
+    """
+    lock_path = project_root / _LOCKFILE_NAME
+    if not lock_path.is_file():
+        return None
+
+    text = lock_path.read_text(encoding="utf-8")
+    updated, count = _LOCK_EDITABLE_ROOT_RE.subn(rf"\g<1>{new_version}\g<3>", text, count=1)
+    if count != 1:
+        msg = f"Unable to update project version in {_LOCKFILE_NAME}"
+        raise ValueError(msg)
+
+    lock_path.write_text(updated, encoding="utf-8")
+    return lock_path
 
 
 def _create_release_pr(

--- a/tests/unit/doctor/test_release_env_policy.py
+++ b/tests/unit/doctor/test_release_env_policy.py
@@ -1,0 +1,342 @@
+"""Unit tests for ``ai-eng doctor`` release-env-policy runtime probe.
+
+Guards the tag-triggered publish path against GitHub deployment-environment
+drift (the 0.8.0 near-miss). Every probe runs hermetically: ``subprocess.run``
+is patched so the suite never touches the network or requires ``gh``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from ai_engineering.doctor.models import CheckStatus, DoctorContext
+from ai_engineering.doctor.runtime import release_env_policy
+
+_RUN = "ai_engineering.doctor.runtime.release_env_policy.subprocess.run"
+
+# Tag-triggered release workflow with one environment (dict form).
+_RELEASE_TAG_TRIGGERED_PYPI = """\
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  publish-pypi:
+    environment:
+      name: pypi
+    steps: []
+"""
+
+# Tag-triggered with two environments (dict + bare-string form).
+_RELEASE_TAG_TRIGGERED_TWO = """\
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  publish-pypi:
+    environment:
+      name: pypi
+    steps: []
+  finalize:
+    environment: github-release
+    steps: []
+"""
+
+_RELEASE_BRANCH_TRIGGERED = """\
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish-pypi:
+    environment:
+      name: pypi
+    steps: []
+"""
+
+_RELEASE_TAG_NO_ENV = """\
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  build:
+    steps: []
+"""
+
+
+def _ctx(target: Path) -> DoctorContext:
+    return DoctorContext(target=target)
+
+
+def _cp(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_release(target: Path, body: str) -> None:
+    workflow = target / ".github" / "workflows" / "release.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(body, encoding="utf-8")
+
+
+def _slug_ok() -> subprocess.CompletedProcess:
+    return _cp(0, stdout="owner/repo\n")
+
+
+# ---------------------------------------------------------------------------
+# Not-applicable paths (zero network)
+# ---------------------------------------------------------------------------
+
+
+def test_no_release_workflow_returns_empty(tmp_path: Path) -> None:
+    with patch(_RUN) as run:
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert results == []
+    run.assert_not_called()
+
+
+def test_branch_triggered_returns_empty(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_BRANCH_TRIGGERED)
+    with patch(_RUN) as run:
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert results == []
+    run.assert_not_called()
+
+
+def test_tag_triggered_without_environments_returns_empty(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_NO_ENV)
+    with patch(_RUN) as run:
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert results == []
+    run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# gh / auth preflight failures -> single WARN, network short-circuited
+# ---------------------------------------------------------------------------
+
+
+def test_gh_missing_warns_once(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(_RUN, side_effect=FileNotFoundError("gh not found")):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].name == "release-env-policy"
+    assert results[0].status == CheckStatus.WARN
+    assert "gh" in results[0].message.lower()
+
+
+def test_repo_unresolved_warns_once(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(_RUN, return_value=_cp(1, stderr="not logged in")):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.WARN
+    assert "pypi" in results[0].message
+
+
+# ---------------------------------------------------------------------------
+# Per-environment policy evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_null_policy_is_ok(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"name":"pypi","deployment_branch_policy":null}'),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].name == "release-env-pypi"
+    assert results[0].status == CheckStatus.OK
+
+
+def test_protected_branches_only_warns(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(
+                0,
+                stdout=(
+                    '{"deployment_branch_policy":'
+                    '{"protected_branches":true,"custom_branch_policies":false}}'
+                ),
+            ),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.WARN
+    assert "REJECTED" in results[0].message
+    assert "deployment-branch-policies" in results[0].message
+    assert "type='tag'" in results[0].message
+
+
+def test_custom_policy_with_v_star_tag_is_ok(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(
+                0,
+                stdout=(
+                    '{"deployment_branch_policy":'
+                    '{"protected_branches":false,"custom_branch_policies":true}}'
+                ),
+            ),
+            _cp(
+                0,
+                stdout=(
+                    '{"branch_policies":'
+                    '[{"name":"main","type":"branch"},{"name":"v*","type":"tag"}]}'
+                ),
+            ),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.OK
+    assert "pypi" in results[0].message
+
+
+def test_custom_policy_without_tag_warns(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"deployment_branch_policy":{"custom_branch_policies":true}}'),
+            _cp(0, stdout='{"branch_policies":[{"name":"main","type":"branch"}]}'),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.WARN
+    assert "REJECTED" in results[0].message
+    assert "v*" in results[0].message
+
+
+def test_branch_named_v_star_does_not_satisfy_tag_requirement(tmp_path: Path) -> None:
+    """A ``v*`` policy of type ``branch`` must NOT be mistaken for a tag policy."""
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"deployment_branch_policy":{"custom_branch_policies":true}}'),
+            _cp(0, stdout='{"branch_policies":[{"name":"v*","type":"branch"}]}'),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert results[0].status == CheckStatus.WARN
+
+
+def test_env_api_error_warns_for_that_env(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(1, stderr="gh: Not Found (HTTP 404)"),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.WARN
+    assert "404" in results[0].message
+
+
+def test_custom_policy_list_error_warns(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"deployment_branch_policy":{"custom_branch_policies":true}}'),
+            _cp(1, stderr="gh: Forbidden (HTTP 403)"),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.WARN
+    assert "403" in results[0].message
+
+
+def test_multiple_environments_one_result_each(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_TWO)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"name":"pypi","deployment_branch_policy":null}'),
+            _cp(0, stdout='{"name":"github-release","deployment_branch_policy":null}'),
+        ],
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    names = {r.name for r in results}
+    assert names == {"release-env-pypi", "release-env-github-release"}
+    assert all(r.status == CheckStatus.OK for r in results)
+
+
+def test_gh_calls_use_target_as_cwd(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        _RUN,
+        side_effect=[
+            _slug_ok(),
+            _cp(0, stdout='{"deployment_branch_policy":null}'),
+        ],
+    ) as run:
+        release_env_policy.check(_ctx(tmp_path))
+    assert run.call_count >= 1
+    for call in run.call_args_list:
+        assert call.kwargs["cwd"] == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Catch-all: a runtime check must never crash diagnose()
+# ---------------------------------------------------------------------------
+
+
+def test_unexpected_error_downgrades_to_warn(tmp_path: Path) -> None:
+    _write_release(tmp_path, _RELEASE_TAG_TRIGGERED_PYPI)
+    with patch(
+        "ai_engineering.doctor.runtime.release_env_policy._resolve_repo_slug",
+        side_effect=RuntimeError("boom"),
+    ):
+        results = release_env_policy.check(_ctx(tmp_path))
+    assert len(results) == 1
+    assert results[0].name == "release-env-policy"
+    assert results[0].status == CheckStatus.WARN
+    assert "errored" in results[0].message
+
+
+# ---------------------------------------------------------------------------
+# Signature contract
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports_check() -> None:
+    assert hasattr(release_env_policy, "check")
+    assert callable(release_env_policy.check)
+    result = release_env_policy.check(_ctx(Path("/nonexistent-target-xyz")))
+    assert isinstance(result, list)
+
+
+def test_check_is_registered_in_service() -> None:
+    """The module must be wired into the doctor runtime registry."""
+    from ai_engineering.doctor import service
+
+    assert "release_env_policy" in service._RUNTIME_CHECK_MODULES
+    assert "release_env_policy" in service._RUNTIME_MODULES
+    assert service._RUNTIME_CHECK_MODULES["release_env_policy"] is release_env_policy

--- a/tests/unit/test_release_orchestrator.py
+++ b/tests/unit/test_release_orchestrator.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from ai_engineering.release.orchestrator import (
     PhaseResult,
     ReleaseConfig,
@@ -23,6 +25,7 @@ from ai_engineering.release.orchestrator import (
     _prepare_branch,
     _repo_slug,
     _run_release_readiness,
+    _update_lockfile_version,
     _update_manifest,
     _validate,
     _version_from_git_ref,
@@ -1154,3 +1157,294 @@ def test_parse_runs_and_helpers_extra_branches(tmp_path: Path) -> None:
 
     with patch("ai_engineering.release.orchestrator.run_git", return_value=(True, "[1]")):
         assert _find_existing_pr_url(tmp_path, "release/v0.2.0", _FakeProvider(), _Runner()) == ""
+
+
+# --- Idempotent resume: bump already merged, tag still missing ------------------
+
+
+def _write_post_promotion_changelog(tmp_path: Path, version: str) -> None:
+    """Write a CHANGELOG in the post-promotion state: empty [Unreleased], [version] present."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        f"# Changelog\n\n## [Unreleased]\n\n## [{version}] - 2026-01-01\n\n### Added\n- thing\n",
+        encoding="utf-8",
+    )
+
+
+def test_validate_resume_skips_version_and_changelog_gate(tmp_path: Path) -> None:
+    """current == target (bump merged) must skip the greater-than gate AND the
+    changelog gate so a post-merge rerun can resume to tag instead of failing."""
+    # Arrange — CHANGELOG already promoted (empty [Unreleased], [0.2.0] present)
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    _write_post_promotion_changelog(tmp_path, "0.2.0")
+
+    # Act — tag absent (so no early return), branch main, clean tree, version equal
+    with (
+        patch(
+            "ai_engineering.release.orchestrator.run_git",
+            side_effect=[(False, ""), (True, "")],
+        ),
+        patch("ai_engineering.release.orchestrator.current_branch", return_value="main"),
+        patch("ai_engineering.release.orchestrator.detect_current_version", return_value="0.2.0"),
+    ):
+        errors = _validate(cfg, _FakeProvider())
+
+    # Assert — no errors despite empty [Unreleased] and existing [0.2.0] section
+    assert errors == []
+
+
+def test_validate_still_blocks_downgrade(tmp_path: Path) -> None:
+    """current > target is a genuine downgrade and must still error."""
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- x\n", encoding="utf-8"
+    )
+
+    # Act
+    with (
+        patch(
+            "ai_engineering.release.orchestrator.run_git",
+            side_effect=[(False, ""), (True, "")],
+        ),
+        patch("ai_engineering.release.orchestrator.current_branch", return_value="main"),
+        patch("ai_engineering.release.orchestrator.detect_current_version", return_value="0.3.0"),
+    ):
+        errors = _validate(cfg, _FakeProvider())
+
+    # Assert
+    assert any("must be greater than current" in e for e in errors)
+
+
+def test_execute_release_resume_creates_tag_when_bump_already_merged(tmp_path: Path) -> None:
+    """When the bump is already on main and the tag is missing, skip
+    prepare/PR/wait-for-merge and proceed straight to readiness -> tag -> monitor."""
+    # Arrange — current_version equals target, tag absent
+    config = ReleaseConfig(version="0.2.0", project_root=tmp_path, wait=True)
+    provider = _FakeProvider()
+    state = ReleaseState("release/v0.2.0", False, False, tag_exists=False, current_version="0.2.0")
+
+    # Act
+    with (
+        patch("ai_engineering.release.orchestrator._validate", return_value=[]),
+        patch("ai_engineering.release.orchestrator._detect_state", return_value=state),
+        patch("ai_engineering.release.orchestrator._prepare_branch") as prepare,
+        patch("ai_engineering.release.orchestrator._create_release_pr") as create_pr,
+        patch("ai_engineering.release.orchestrator._wait_for_merge") as wait,
+        patch(
+            "ai_engineering.release.orchestrator._run_release_readiness",
+            return_value=_readiness_phase(),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._create_tag",
+            return_value=PhaseResult("tag", True, "v0.2.0 created"),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._update_manifest",
+            return_value=PhaseResult("manifest", True, "ok"),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._monitor_pipeline",
+            return_value=PhaseResult("monitor", True, "https://example/release/v0.2.0"),
+        ),
+        patch("ai_engineering.release.orchestrator.emit_deploy_event"),
+    ):
+        result = execute_release(config, provider, clock=_FixedClock())
+
+    # Assert — pre-merge phases skipped (not invoked), completion phases ran
+    assert result.success is True
+    prepare.assert_not_called()
+    create_pr.assert_not_called()
+    wait.assert_not_called()
+    assert [phase.phase for phase in result.phases] == [
+        "validate",
+        "prepare",
+        "pr",
+        "wait-for-merge",
+        "readiness",
+        "tag",
+        "manifest",
+        "monitor",
+    ]
+    by_phase = {phase.phase: phase for phase in result.phases}
+    assert by_phase["prepare"].skipped is True
+    assert by_phase["pr"].skipped is True
+    assert by_phase["wait-for-merge"].skipped is True
+    assert by_phase["tag"].skipped is False
+    assert by_phase["tag"].success is True
+
+
+def test_execute_release_resume_completes_even_without_wait_flag(tmp_path: Path) -> None:
+    """Resume finishes (tag + monitor) even without --wait: there is no merge to
+    wait for once the bump has landed, so the deferred-tag path must not apply."""
+    # Arrange
+    config = ReleaseConfig(version="0.2.0", project_root=tmp_path, wait=False)
+    provider = _FakeProvider()
+    state = ReleaseState("release/v0.2.0", False, False, tag_exists=False, current_version="0.2.0")
+
+    # Act — _prepare_branch/_create_release_pr must not be called
+    with (
+        patch("ai_engineering.release.orchestrator._validate", return_value=[]),
+        patch("ai_engineering.release.orchestrator._detect_state", return_value=state),
+        patch("ai_engineering.release.orchestrator._prepare_branch") as prepare,
+        patch("ai_engineering.release.orchestrator._create_release_pr") as create_pr,
+        patch(
+            "ai_engineering.release.orchestrator._run_release_readiness",
+            return_value=_readiness_phase(),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._create_tag",
+            return_value=PhaseResult("tag", True, "v0.2.0 created"),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._update_manifest",
+            return_value=PhaseResult("manifest", True, "ok"),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._monitor_pipeline",
+            return_value=PhaseResult("monitor", True, "https://example/release/v0.2.0"),
+        ),
+        patch("ai_engineering.release.orchestrator.emit_deploy_event"),
+    ):
+        result = execute_release(config, provider, clock=_FixedClock())
+
+    # Assert — tag actually created (not deferred)
+    assert result.success is True
+    prepare.assert_not_called()
+    create_pr.assert_not_called()
+    tag_phases = [phase for phase in result.phases if phase.phase == "tag"]
+    assert len(tag_phases) == 1
+    assert tag_phases[0].skipped is False
+    assert "deferred" not in tag_phases[0].output.lower()
+
+
+def test_execute_release_resume_blocks_on_readiness_no_go(tmp_path: Path) -> None:
+    """Resume path still honors the readiness gate: NO-GO stops before tagging."""
+    # Arrange
+    config = ReleaseConfig(version="0.2.0", project_root=tmp_path, wait=True)
+    provider = _FakeProvider()
+    state = ReleaseState("release/v0.2.0", False, False, tag_exists=False, current_version="0.2.0")
+
+    # Act
+    with (
+        patch("ai_engineering.release.orchestrator._validate", return_value=[]),
+        patch("ai_engineering.release.orchestrator._detect_state", return_value=state),
+        patch("ai_engineering.release.orchestrator._prepare_branch"),
+        patch("ai_engineering.release.orchestrator._create_release_pr"),
+        patch(
+            "ai_engineering.release.orchestrator._run_release_readiness",
+            return_value=_readiness_phase("NO-GO", success=False),
+        ),
+        patch("ai_engineering.release.orchestrator._create_tag") as tag,
+    ):
+        result = execute_release(config, provider, clock=_FixedClock())
+
+    # Assert
+    assert result.success is False
+    assert result.errors == ["NO-GO"]
+    assert result.phases[-1].phase == "readiness"
+    tag.assert_not_called()
+
+
+# --- Secondary: uv.lock project pin stays consistent with the bump --------------
+
+
+_LOCK_FIXTURE = (
+    (
+        "version = 1\n"
+        "revision = 3\n\n"
+        "[[package]]\n"
+        'name = "ai-engineering"\n'
+        'version = "0.1.0"\n'
+        'source = {{ editable = "." }}\n'
+        "dependencies = [\n"
+        '    {{ name = "click" }},\n'
+        "]\n\n"
+        "[[package]]\n"
+        'name = "click"\n'
+        'version = "8.3.3"\n'
+    )
+    .replace("{{", "{")
+    .replace("}}", "}")
+)
+
+
+def test_update_lockfile_version_updates_editable_root_pin(tmp_path: Path) -> None:
+    # Arrange
+    lock = tmp_path / "uv.lock"
+    lock.write_text(_LOCK_FIXTURE, encoding="utf-8")
+
+    # Act
+    result = _update_lockfile_version(tmp_path, "0.2.0")
+
+    # Assert — only the editable-root pin moved
+    text = lock.read_text(encoding="utf-8")
+    assert result == lock
+    assert 'version = "0.2.0"\nsource = { editable = "." }' in text
+    # lockfile-format `version = 1` line and dependency pins untouched
+    assert text.startswith("version = 1\n")
+    assert 'name = "click"\nversion = "8.3.3"' in text
+
+
+def test_update_lockfile_version_missing_file_returns_none(tmp_path: Path) -> None:
+    assert _update_lockfile_version(tmp_path, "0.2.0") is None
+
+
+def test_update_lockfile_version_without_editable_root_raises(tmp_path: Path) -> None:
+    # Arrange — a lockfile with no editable root pin
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        'version = 1\n\n[[package]]\nname = "click"\nversion = "8.3.3"\n', encoding="utf-8"
+    )
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"uv\.lock"):
+        _update_lockfile_version(tmp_path, "0.2.0")
+
+
+def test_prepare_branch_updates_uv_lock_and_lists_it(tmp_path: Path) -> None:
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    bump = type("Bump", (), {})()
+    bump.old_version = "0.1.0"
+    bump.new_version = "0.2.0"
+    bump.files_modified = [tmp_path / "pyproject.toml"]
+    # show-ref (absent), checkout -b, add, commit
+    seq = [(False, ""), (True, ""), (True, ""), (True, "")]
+
+    # Act
+    with (
+        patch("ai_engineering.release.orchestrator.run_git", side_effect=seq),
+        patch("ai_engineering.release.orchestrator.bump_python_version", return_value=bump),
+        patch("ai_engineering.release.orchestrator.promote_unreleased", return_value=True),
+        patch(
+            "ai_engineering.release.orchestrator._update_lockfile_version",
+            return_value=tmp_path / "uv.lock",
+        ),
+    ):
+        phase = _prepare_branch(cfg, _FixedClock())
+
+    # Assert — uv.lock listed among the bumped files
+    assert phase.success is True
+    assert "uv.lock" in phase.output
+
+
+def test_prepare_branch_propagates_lockfile_error(tmp_path: Path) -> None:
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    bump = type("Bump", (), {})()
+    bump.files_modified = [tmp_path / "pyproject.toml"]
+
+    # Act — lock update fails after a successful bump
+    with (
+        patch("ai_engineering.release.orchestrator.run_git", side_effect=[(False, ""), (True, "")]),
+        patch("ai_engineering.release.orchestrator.bump_python_version", return_value=bump),
+        patch(
+            "ai_engineering.release.orchestrator._update_lockfile_version",
+            side_effect=ValueError("Unable to update project version in uv.lock"),
+        ),
+    ):
+        phase = _prepare_branch(cfg, _FixedClock())
+
+    # Assert
+    assert phase.success is False
+    assert "uv.lock" in phase.output

--- a/tests/unit/workflows/test_release_env_policy_docs.py
+++ b/tests/unit/workflows/test_release_env_policy_docs.py
@@ -1,0 +1,100 @@
+"""Coupling guard: the tag-triggered release workflow's deployment
+environments MUST be documented with their ``v*`` policy requirement.
+
+spec-152 made ``release.yml`` tag-triggered; a deployment environment that
+restricts deploys to branches then rejects the tag-triggered publish (the
+0.8.0 near-miss). The environment policy lives in GitHub settings, so it
+cannot be enforced by committed code — but its *documentation* can be.
+
+This gate fails CI when ``release.yml`` stays tag-triggered while any
+environment it deploys through is left undocumented in
+``docs/ci-branch-protection.md``. Adding a new publish environment to the
+workflow therefore forces a matching policy note. The live setting itself
+is checked by the ``release-env-policy`` doctor probe; the tag trigger is
+held in place by ``scripts/check_workflow_policy.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+BRANCH_PROTECTION_DOC = REPO_ROOT / "docs" / "ci-branch-protection.md"
+
+
+def _load_release() -> dict[str, Any]:
+    data = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "release.yml did not parse to a mapping"
+    return data
+
+
+def _tag_globs(data: dict[str, Any]) -> list[str]:
+    # PyYAML parses the bare ``on:`` key as the boolean True.
+    triggers = data.get("on", data.get(True))
+    assert isinstance(triggers, dict), "release.yml has no trigger mapping"
+    push = triggers.get("push")
+    if not isinstance(push, dict):
+        return []
+    tags = push.get("tags")
+    if isinstance(tags, str):
+        return [tags]
+    if isinstance(tags, list):
+        return [str(item) for item in tags]
+    return []
+
+
+def _environment_names(data: dict[str, Any]) -> set[str]:
+    jobs = data.get("jobs", {})
+    assert isinstance(jobs, dict)
+    names: set[str] = set()
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        environment = job.get("environment")
+        if isinstance(environment, str) and "${{" not in environment:
+            names.add(environment)
+        elif isinstance(environment, dict):
+            name = environment.get("name")
+            if isinstance(name, str) and "${{" not in name:
+                names.add(name)
+    return names
+
+
+def test_release_workflow_is_tag_triggered() -> None:
+    """Premise of the coupling: the publish path fires on ``v*`` tags."""
+    assert "v*" in _tag_globs(_load_release()), (
+        "release.yml must trigger on push tags ['v*']; if this changed, the "
+        "environment deployment-policy coupling below must be revisited"
+    )
+
+
+def test_release_workflow_uses_expected_environments() -> None:
+    """Lock the documented environment set so a silent addition is caught."""
+    assert _environment_names(_load_release()) == {"pypi", "testpypi", "github-release"}
+
+
+def test_every_release_environment_is_documented() -> None:
+    doc = BRANCH_PROTECTION_DOC.read_text(encoding="utf-8")
+    for env in _environment_names(_load_release()):
+        assert f"`{env}`" in doc, (
+            f"deployment environment {env!r} is used by release.yml but is not "
+            f"documented in {BRANCH_PROTECTION_DOC.relative_to(REPO_ROOT)}"
+        )
+
+
+def test_doc_records_v_star_tag_policy_and_remediation() -> None:
+    doc = BRANCH_PROTECTION_DOC.read_text(encoding="utf-8")
+    assert "v*" in doc, "branch-protection doc must record the v* tag pattern"
+    assert "deployment-branch-policies" in doc, (
+        "branch-protection doc must include the gh deployment-branch-policies remediation command"
+    )
+    assert "release-env-policy" in doc, (
+        "branch-protection doc must reference the release-env-policy doctor guard"
+    )
+    assert "tag-protection-v" in doc, (
+        "branch-protection doc must document the tag-protection-v ruleset coupling"
+    )


### PR DESCRIPTION
## Summary

Three release-pipeline hardening fixes, all surfaced while cutting 0.8.0:

- **`ai-eng release <version> --wait` is now idempotent/resumable.** When the bump already merged but the tag was never created, a rerun detects the current version equals the target and the tag is absent, skips `prepare`/`pr`/`wait-for-merge`, and proceeds straight to readiness → create-tag → monitor. A genuine downgrade still errors; the pre-merge flow is unchanged.
- **`release prepare` now syncs the project's own editable-root version pin in `uv.lock`** alongside `pyproject.toml`/`version/registry.json`/`manifest.yml`, removing the manual lockfile commit previously needed on the release branch.
- **New `ai-eng doctor` runtime check `release-env-policy`** reads each release deployment environment's live policy and WARNs when the `v*` tag pattern is missing — the tag-vs-branch drift that nearly broke the 0.8.0 publish. A companion static guard (`tests/unit/workflows/test_release_env_policy_docs.py`) fails CI if a publish env is added to `release.yml` without a matching documented policy note.

**Why:** `release.yml` became tag-triggered (spec-152) but the `pypi` GitHub environment still only admitted `main`; that drift lives in repo settings, not in-tree, so nothing caught it. These fixes make the publish path self-checking and the release command safe to rerun.

## Test Plan

- `uv run pytest tests/unit/test_release_orchestrator.py tests/unit/doctor/test_release_env_policy.py tests/unit/workflows/test_release_env_policy_docs.py` → **70 passed**
- `ty check` on changed source (`orchestrator.py`, `release_env_policy.py`, `service.py`) → **All checks passed**
- `gitleaks protect --staged` → no leaks
- `ai-eng validate` → exit 0
- This fix is validated end-to-end by the **0.8.1 release**: the release forks from this merged commit and runs the hardened orchestrator.

## Work Items

None — off-spec release-pipeline hardening (the active `spec-153` is unrelated lifecycle work and is untouched here).

## Checklist

- [x] Lint/format (ruff)
- [x] Secrets scan (gitleaks)
- [x] Tests (70 passed)
- [x] Types (ty)
- [x] CHANGELOG updated (`[Unreleased]`)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
