### PR TITLE
fix(security): exclude .pytest_cache from gitleaks release scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,5 +31,6 @@ paths = [
   '''node_modules/''',
   '''\.venv/''',
   '''__pycache__/''',
+  '''\.pytest_cache/''',
   '''\.git/''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required `pypi`, `testpypi`, and `github-release` deployment policies and the
   `tag-protection-v` ruleset coupling are documented in
   `docs/ci-branch-protection.md`.
+- **Release readiness no longer false-positives on the pytest cache.** The
+  `ai-eng verify --release` gitleaks scan runs with `--no-git`, so it walked the
+  gitignored `.pytest_cache/` and flagged a synthetic GitHub App token baked into
+  a `test_redactor` parametrize node ID — turning a clean tree into a spurious
+  NO-GO. `.pytest_cache/` now sits in the `.gitleaks.toml` allowlist alongside the
+  other regenerable caches (`__pycache__/`, `.venv/`, `node_modules/`); the staged
+  pre-commit scan is unaffected (the cache is never staged).
+
 ## [0.8.0] - 2026-05-24
 
 ### BREAKING


### PR DESCRIPTION
## Summary

The `ai-eng verify --release` security lens runs gitleaks with `--no-git` ([verify/service.py:381](src/ai_engineering/verify/service.py)), scanning the working tree rather than only tracked content. It walked the gitignored `.pytest_cache/` and flagged the **synthetic** GitHub App token in a `tests/unit/security/test_redactor.py` parametrize node ID (`ghs_1234...`) as a real secret — producing a spurious release-readiness **NO-GO** on an otherwise clean tree while cutting 0.8.1.

`.pytest_cache/` is a regenerable local cache, never staged or committed — the same category as the `__pycache__/`, `.venv/`, and `node_modules/` entries already in the `.gitleaks.toml` allowlist. This adds it there.

## Test Plan

- `gitleaks detect --source . --no-git --config .gitleaks.toml` (the exact `--release` scan) → **0 findings** (was 1: the false positive)
- `gitleaks protect --staged` → no leaks (staged scan unaffected; cache never staged)
- Real-secret detection unchanged — only a regenerable cache dir is excluded, consistent with existing allowlist convention.

## Context

Surfaced by the 0.8.1 release: the resume-path readiness gate correctly stopped **before** tag/publish. This fix unblocks the v0.8.1 tag (it lands on main ahead of the tag, so it ships in 0.8.1).

## Checklist

- [x] Secrets scan (release + staged) clean
- [x] CHANGELOG updated ([0.8.1] Fixed)
- [x] No real detection weakened
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)