### PR TITLE
fix(security): sync .pytest_cache allowlist to shipped gitleaks template

### DIFF
--- a/src/ai_engineering/templates/project/.gitleaks.toml
+++ b/src/ai_engineering/templates/project/.gitleaks.toml
@@ -31,5 +31,6 @@ paths = [
   '''node_modules/''',
   '''\.venv/''',
   '''__pycache__/''',
+  '''\.pytest_cache/''',
   '''\.git/''',
 ]


### PR DESCRIPTION
## Summary

Completes [#544](https://github.com/arcasilesgroup/ai-engineering/pull/544). That PR added `.pytest_cache/` to the source-repo `.gitleaks.toml` allowlist but not the template copy shipped under `src/ai_engineering/templates/project/.gitleaks.toml`. `test_dogfood_parity[gitleaks]` (spec-132 D-132-16) requires the two to be byte-equivalent, so the source-only change broke parity — caught by the 0.8.1 release readiness gate (tests dimension).

This adds the identical line to the template.

## Test Plan

- `shasum -a 256` source vs template → **identical**
- `pytest tests/integration/test_dogfood_parity.py` → **2 passed** (gitleaks + semgrep)

## Context

Surfaced by 0.8.1 release readiness — correctly stopped before tag/publish. Lands on main ahead of the v0.8.1 tag, so it ships in 0.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)