### PR TITLE
fix(release): harden release pipeline for 0.8.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,10 +432,32 @@ jobs:
           set -euo pipefail
           python3 -m venv /tmp/testpypi-smoke
           /tmp/testpypi-smoke/bin/python -m pip install --upgrade pip
-          /tmp/testpypi-smoke/bin/python -m pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple/ \
-            "ai-engineering==${VERSION}"
+          # TestPyPI's index can lag seconds-to-minutes behind a successful
+          # upload before "pkg==version" resolves (the publish itself already
+          # succeeded upstream), so poll with backoff instead of failing on the
+          # first miss. 20 attempts x 15s caps polling at ~5 min, well inside
+          # this job's 10-minute timeout.
+          ATTEMPTS=20
+          SLEEP_SECONDS=15
+          installed=false
+          for attempt in $(seq 1 "${ATTEMPTS}"); do
+            if /tmp/testpypi-smoke/bin/python -m pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              "ai-engineering==${VERSION}"; then
+              installed=true
+              echo "Installed ai-engineering==${VERSION} from TestPyPI (attempt ${attempt}/${ATTEMPTS})"
+              break
+            fi
+            if [ "${attempt}" -lt "${ATTEMPTS}" ]; then
+              echo "::warning::ai-engineering==${VERSION} not resolvable on TestPyPI yet (attempt ${attempt}/${ATTEMPTS}); retrying in ${SLEEP_SECONDS}s — TestPyPI index propagation lag"
+              sleep "${SLEEP_SECONDS}"
+            fi
+          done
+          if [ "${installed}" != "true" ]; then
+            echo "::error::ai-engineering==${VERSION} did not become installable from TestPyPI after ${ATTEMPTS} attempts (~$((ATTEMPTS * SLEEP_SECONDS / 60)) min of polling)"
+            exit 1
+          fi
           /tmp/testpypi-smoke/bin/ai-eng version
           cat > testpypi-install-proof.txt <<EOF
           TestPyPI install proof completed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release pipeline's TestPyPI install verification now tolerates index
+  propagation lag.** The `verify-testpypi-install` job ran `pip install
+  ai-engineering==<version>` seconds after the TestPyPI publish succeeded, but
+  TestPyPI's index takes seconds-to-minutes to make a freshly uploaded version
+  resolvable via `pkg==version` — so every release failed the verify job on the
+  first miss and needed a manual `gh run rerun --failed`. The install step now
+  polls with backoff (20 attempts x 15s, ~5 min, inside the job's 10-minute
+  timeout) and fails only after the cap. The production-PyPI publish job has no
+  analogous index-install step, so it needed no change.
+- **`ai-eng release <version> --wait` no longer fails its `monitor` phase with
+  "Unable to read tag SHA".** `GitHubProvider.create_tag` creates the tag ref
+  remote-only via the GitHub API (`gh api .../git/refs`, bypassing the local
+  pre-push hook), so the tag never lands in the local repository. The monitor
+  phase then re-derived the head SHA with a local `git rev-parse v<version>`,
+  which failed (`fatal: ambiguous argument 'v<version>'`) even though readiness
+  was GO, the tag was created, and the publish workflow ran fine. `_create_tag`
+  now exposes the commit SHA it already computed (from `git rev-parse HEAD` on
+  the merged default branch) via `PhaseResult.details["tagged_sha"]`,
+  `_complete_release` threads it into `_monitor_pipeline`, and monitor uses it
+  directly — no local tag lookup, no network round-trip. The local lookup
+  remains a fallback for the resume flow (where the tag already exists locally)
+  and now resolves it through the safe `git rev-parse --verify --quiet
+  refs/tags/v<version>` form used by the validate and create-tag phases, rather
+  than a bare `rev-parse v<version>` that can match a branch or a partial SHA.
+  This only affected the orchestrator's own progress monitoring; the published
+  artifact was never at risk, since the tag is pushed and the tag-triggered
+  `release.yml` publishes regardless.
+
 ## [0.8.1] - 2026-05-24
 
 ### Fixed

--- a/src/ai_engineering/release/orchestrator.py
+++ b/src/ai_engineering/release/orchestrator.py
@@ -344,6 +344,8 @@ def _complete_release(
     if not tag_phase.success:
         result.errors.append(tag_phase.output)
         return False
+    raw_sha = tag_phase.details.get("tagged_sha")
+    tagged_sha = raw_sha if isinstance(raw_sha, str) else None
 
     result.release_url = _release_url_for_tag(config)
     _attach_release_packet(result)
@@ -363,7 +365,7 @@ def _complete_release(
         release_packet_ref=result.release_packet_ref,
     )
 
-    monitor_phase = _monitor_pipeline(config, provider, config.wait_timeout)
+    monitor_phase = _monitor_pipeline(config, provider, config.wait_timeout, tagged_sha=tagged_sha)
     phases.append(monitor_phase)
     if not monitor_phase.success:
         result.errors.append(monitor_phase.output)
@@ -768,13 +770,22 @@ def _create_tag(config: ReleaseConfig, provider: VcsProvider) -> PhaseResult:
         lowered = tag_result.output.lower()
         if "already exists" in lowered or "reference already exists" in lowered:
             return PhaseResult(
-                phase="tag", success=True, skipped=True, output=f"Tag exists: {tag_name}"
+                phase="tag",
+                success=True,
+                skipped=True,
+                output=f"Tag exists: {tag_name}",
+                details={"tagged_sha": sha},
             )
         return PhaseResult(
             phase="tag", success=False, output=f"Tag creation failed: {tag_result.output}"
         )
 
-    return PhaseResult(phase="tag", success=True, output=f"{tag_name} created ({sha[:7]})")
+    return PhaseResult(
+        phase="tag",
+        success=True,
+        output=f"{tag_name} created ({sha[:7]})",
+        details={"tagged_sha": sha},
+    )
 
 
 def _update_manifest(config: ReleaseConfig, clock: Clock) -> PhaseResult:
@@ -795,20 +806,35 @@ def _update_manifest(config: ReleaseConfig, clock: Clock) -> PhaseResult:
     return PhaseResult(phase="manifest", success=True, output="install-state.json updated")
 
 
-def _monitor_pipeline(config: ReleaseConfig, provider: VcsProvider, timeout: int) -> PhaseResult:
-    sha_ok, sha_out = run_git(["rev-parse", f"v{config.version}"], config.project_root)
-    if not sha_ok:
-        return PhaseResult(
-            phase="monitor", success=False, output=f"Unable to read tag SHA: {sha_out}"
+def _monitor_pipeline(
+    config: ReleaseConfig,
+    provider: VcsProvider,
+    timeout: int,
+    tagged_sha: str | None = None,
+) -> PhaseResult:
+    # The tag ref is created remote-only via the GitHub API (see
+    # GitHubProvider.create_tag), so a local ``git rev-parse v<version>`` fails.
+    # Prefer the SHA threaded from _create_tag; fall back to a local lookup only
+    # for the resume flow, where the tag already exists locally.
+    if tagged_sha:
+        resolved_sha = tagged_sha
+    else:
+        sha_ok, sha_out = run_git(
+            ["rev-parse", "--verify", "--quiet", f"refs/tags/v{config.version}"],
+            config.project_root,
         )
-    tagged_sha = sha_out.splitlines()[0].strip()
+        if not sha_ok:
+            return PhaseResult(
+                phase="monitor", success=False, output=f"Unable to read tag SHA: {sha_out}"
+            )
+        resolved_sha = sha_out.splitlines()[0].strip()
 
     deadline = time.time() + timeout
     while time.time() < deadline:
         status = provider.get_pipeline_status(
             PipelineStatusContext(
                 project_root=config.project_root,
-                head_sha=tagged_sha,
+                head_sha=resolved_sha,
                 workflow_name="Release",
             )
         )

--- a/tests/unit/test_release_orchestrator.py
+++ b/tests/unit/test_release_orchestrator.py
@@ -12,9 +12,11 @@ import pytest
 from ai_engineering.release.orchestrator import (
     PhaseResult,
     ReleaseConfig,
+    ReleaseResult,
     ReleaseState,
     SubprocessRunner,
     SystemClock,
+    _complete_release,
     _create_release_pr,
     _create_tag,
     _default_branch,
@@ -47,6 +49,7 @@ class _FakeProvider:
         self.tag_success = True
         self.pipeline_success = True
         self.pipeline_output = "[]"
+        self.last_head_sha: str | None = None
 
     def create_pr(self, ctx: VcsContext) -> VcsResult:
         del ctx
@@ -89,7 +92,7 @@ class _FakeProvider:
         return VcsResult(success=self.tag_success, output="ok" if self.tag_success else "bad")
 
     def get_pipeline_status(self, ctx: PipelineStatusContext) -> VcsResult:
-        del ctx
+        self.last_head_sha = ctx.head_sha
         return VcsResult(success=self.pipeline_success, output=self.pipeline_output)
 
 
@@ -439,6 +442,116 @@ def test_monitor_pipeline_success_and_failure(tmp_path: Path) -> None:
     ):
         phase_ok = _monitor_pipeline(cfg, provider, 5)
     assert phase_ok.success is True
+
+
+def test_monitor_pipeline_uses_threaded_sha_when_tag_is_remote_only(tmp_path: Path) -> None:
+    """Regression (v0.8.1): the tag ref is created remote-only via the GitHub API, so a
+    local ``git rev-parse v<version>`` fails. Monitor must use the SHA threaded from
+    _create_tag instead of re-deriving it locally.
+    """
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    provider = _FakeProvider()
+    provider.pipeline_output = (
+        '[{"status":"completed","conclusion":"success","url":"https://x/run"}]'
+    )
+    local_rev_parse_fails = (
+        False,
+        "fatal: ambiguous argument 'v0.2.0': unknown revision or path not in the working tree.",
+    )
+
+    # Act / Assert — without the threaded SHA, the local lookup fails (the v0.8.1 symptom)
+    with patch("ai_engineering.release.orchestrator.run_git", return_value=local_rev_parse_fails):
+        broken = _monitor_pipeline(cfg, provider, 1)
+    assert broken.success is False
+    assert "Unable to read tag SHA" in broken.output
+
+    # Act / Assert — with the threaded SHA, monitor never touches the local tag
+    with (
+        patch("ai_engineering.release.orchestrator.run_git", return_value=local_rev_parse_fails),
+        patch("ai_engineering.release.orchestrator.time.time", side_effect=[0, 1]),
+    ):
+        fixed = _monitor_pipeline(cfg, provider, 5, tagged_sha="deadbeefcafe")
+    assert fixed.success is True
+    assert fixed.output == "https://x/run"
+    assert provider.last_head_sha == "deadbeefcafe"
+
+
+def test_monitor_pipeline_fallback_resolves_tag_via_refs_namespace(tmp_path: Path) -> None:
+    """The resume-flow fallback must resolve the local tag through the
+    ``refs/tags/`` namespace with ``--verify --quiet`` — the same safe form used
+    by _validate/_create_tag — not a bare ``rev-parse v<version>`` that can match
+    a branch or a partial SHA (0.8.2 release-robustness fix).
+    """
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    provider = _FakeProvider()
+    captured: list[list[str]] = []
+
+    def capture_run_git(args: list[str], _root: Path) -> tuple[bool, str]:
+        captured.append(args)
+        return (False, "")
+
+    with patch("ai_engineering.release.orchestrator.run_git", side_effect=capture_run_git):
+        _monitor_pipeline(cfg, provider, 1)
+
+    assert captured == [["rev-parse", "--verify", "--quiet", "refs/tags/v0.2.0"]]
+
+
+def test_create_tag_exposes_tagged_sha_in_details(tmp_path: Path) -> None:
+    """_create_tag threads the freshly tagged commit SHA via PhaseResult.details so
+    _monitor_pipeline can avoid a (failing) local tag lookup."""
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    provider = _FakeProvider()
+
+    # Act — fresh-tag success path (mirrors test_create_tag_failure_and_success_paths)
+    seq_success = [(False, ""), (True, ""), (True, ""), (True, ""), (True, "abc123\n")]
+    with patch("ai_engineering.release.orchestrator.run_git", side_effect=seq_success):
+        phase = _create_tag(cfg, provider)
+
+    # Assert
+    assert phase.success is True
+    assert phase.details.get("tagged_sha") == "abc123"
+
+
+def test_complete_release_threads_tag_sha_into_monitor(tmp_path: Path) -> None:
+    """_complete_release passes the SHA from _create_tag straight into _monitor_pipeline
+    rather than letting monitor re-derive it from a local tag that does not exist."""
+    # Arrange
+    cfg = ReleaseConfig(version="0.2.0", project_root=tmp_path)
+    provider = _FakeProvider()
+    result = ReleaseResult(success=True, phases=[], version="0.2.0", tag_name="v0.2.0")
+    captured: dict[str, object] = {}
+
+    def fake_monitor(_cfg, _provider, _timeout, tagged_sha=None):
+        captured["tagged_sha"] = tagged_sha
+        return PhaseResult("monitor", True, "https://example/release/v0.2.0")
+
+    # Act
+    with (
+        patch(
+            "ai_engineering.release.orchestrator._run_release_readiness",
+            return_value=_readiness_phase(),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._create_tag",
+            return_value=PhaseResult(
+                "tag", True, "v0.2.0 created (abc123)", details={"tagged_sha": "abc123def456"}
+            ),
+        ),
+        patch(
+            "ai_engineering.release.orchestrator._update_manifest",
+            return_value=PhaseResult("manifest", True, "ok"),
+        ),
+        patch("ai_engineering.release.orchestrator._release_url_for_tag", return_value=""),
+        patch("ai_engineering.release.orchestrator._monitor_pipeline", side_effect=fake_monitor),
+        patch("ai_engineering.release.orchestrator.emit_deploy_event"),
+    ):
+        ok = _complete_release(cfg, provider, _FixedClock(), result, [])
+
+    # Assert
+    assert ok is True
+    assert captured["tagged_sha"] == "abc123def456"
 
 
 def test_parse_runs_handles_valid_and_embedded_json() -> None:

--- a/tests/unit/workflows/test_release_workflow_policy.py
+++ b/tests/unit/workflows/test_release_workflow_policy.py
@@ -67,14 +67,18 @@ def _job(workflow: dict, name: str) -> dict:
     return job
 
 
+# width=4096 disables PyYAML's default 80-col line folding, which would
+# otherwise split long shell lines (e.g. a `pip install --extra-index-url
+# https://pypi.org/simple/ ...` continuation) mid-token and break the exact
+# substring assertions these helpers feed.
 def _job_text(workflow: dict, name: str) -> str:
-    return yaml.safe_dump(_job(workflow, name), sort_keys=False)
+    return yaml.safe_dump(_job(workflow, name), sort_keys=False, width=4096)
 
 
 def _step_text(workflow: dict, name: str) -> str:
     steps = _job(workflow, name).get("steps") or []
     assert isinstance(steps, list), f"job {name!r} steps must be a list"
-    return yaml.safe_dump(steps, sort_keys=False)
+    return yaml.safe_dump(steps, sort_keys=False, width=4096)
 
 
 def _needs(workflow: dict, name: str) -> set[str]:
@@ -244,6 +248,10 @@ def test_testpypi_publish_and_install_gate(workflow: dict) -> None:
     assert "--extra-index-url https://pypi.org/simple/" in install_text
     assert "ai-engineering==${VERSION}" in install_text
     assert "testpypi-install-proof.txt" in install_text
+    # 0.8.2 release-robustness: the install must poll with backoff to ride out
+    # TestPyPI index propagation lag rather than failing on the first miss.
+    assert "for attempt in" in install_text
+    assert "sleep" in install_text
 
 
 def test_production_pypi_publish_gate(workflow: dict) -> None:


### PR DESCRIPTION
## Summary

Two release-pipeline robustness fixes targeting **0.8.2**, both surfaced cutting recent releases.

### 1. TestPyPI install verification tolerates index propagation lag
`release.yml` → `verify-testpypi-install` ran `pip install ai-engineering==<version>` ~5s after the TestPyPI publish succeeded. TestPyPI's index takes seconds-to-minutes to make a freshly uploaded version resolvable via `pkg==version`, so the job failed on the first miss and **every release needed a manual `gh run rerun --failed`**.

The install step now polls with backoff: **20 attempts × 15s (~5 min)**, inside the job's existing 10-minute timeout, failing only after the cap. SHA-pinned actions and the timeout/concurrency policy are untouched (passes `scripts/check_workflow_policy.py` + the workflow-sanity job). The production-PyPI publish job has **no analogous index-install step**, so it needed no change.

### 2. Orchestrator monitor resolves the release tag safely
`release/orchestrator.py::_monitor_pipeline` prefers the SHA threaded from `_create_tag` (the tag is created remote-only via the GitHub API, so a local lookup fails with "Unable to read tag SHA"). Its resume-flow fallback now uses the safe `git rev-parse --verify --quiet refs/tags/v<version>` form — matching the validate and create-tag phases — instead of a bare `rev-parse v<version>` that can match a branch or a partial SHA.

## Tests
- `test_release_workflow_policy.py`: assert the install step polls with backoff (`for attempt in`, `sleep`); the helper now dumps with `width=4096` so 80-col folding can't split substring assertions mid-token.
- `test_release_orchestrator.py`: assert the monitor fallback resolves via `refs/tags/` with `--verify --quiet`.

## Verification
- `ruff check` ✅ · `scripts/check_workflow_policy.py` ✅ · 68 targeted tests ✅

## Changelog
`[Unreleased]` → two `### Fixed` bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
