### PR TITLE
fix(install): ship Article VII suppression allowlist to consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`ai-eng install` now ships the Article VII suppression allowlist, so a
+  consumer's first `git push` is no longer self-blocked.** The installer
+  deploys the vendored `.ai-engineering/scripts/` tree, whose framework
+  scripts legitimately carry suppression markers (optional-dependency import
+  fallbacks, self-bootstrap `E402` imports, `__main__` CLI shims, a
+  validated-SSRF `nosemgrep`). The authorizing `suppression-allowlist.yml`
+  was missing from the shipped template tree, so the pre-push no-suppression
+  gate denied every one of those markers and blocked the first push in every
+  installed project. A standard baseline allowlist — permanent (no TTL), no
+  DEC bindings, scoped strictly to `.ai-engineering/scripts/**` and never to
+  a consumer's own `src/`/`tools/`/`tests/` — now ships at
+  `src/ai_engineering/templates/.ai-engineering/suppression-allowlist.yml`.
+  Two regression guards lock it in: `test_template_tree_completeness.py`
+  asserts the baseline covers every marker the scanner finds in the shipped
+  scripts tree, and `test_install_clean.py` runs the gate against a freshly
+  installed tree and asserts zero denials. Same bug class as the earlier
+  `skill_scripts_lib` ship-gap.
+
 ### Changed
 
 - **README install section now gives explicit per-tool-manager

--- a/src/ai_engineering/templates/.ai-engineering/suppression-allowlist.yml
+++ b/src/ai_engineering/templates/.ai-engineering/suppression-allowlist.yml
@@ -1,0 +1,230 @@
+# Suppression allowlist — ai-engineering shipped baseline (CONSTITUTION.md Article VII).
+#
+# This file is deployed by `ai-eng install` alongside the framework's
+# vendored scripts under `.ai-engineering/scripts/`. Those scripts carry
+# a small, fixed set of suppression markers that are INTRINSIC to the
+# tooling (optional-dependency import fallbacks, self-bootstrapping
+# `E402` imports, `__main__` CLI shims, validated-SSRF egress). Each
+# entry below authorizes exactly one such marker family on exactly one
+# shipped script so the Article VII pre-push gate passes out of the box.
+#
+# Contract:
+#   * These are PERMANENT framework authorizations, NOT time-boxed risk
+#     acceptances — `expires_at` and `dec_id` are intentionally empty.
+#   * Scope is limited to `.ai-engineering/scripts/**` (framework-vendored
+#     code). It never pre-authorizes a consumer's own `src/`, `tools/`,
+#     `tests/`, workflows, or `pyproject.toml` — those remain fully
+#     governed by the consumer's gate.
+#   * `tests/architecture/test_template_tree_completeness.py` asserts this
+#     file covers every suppression the scanner finds in the shipped
+#     `scripts/` tree, so the baseline can never drift out of sync.
+#
+# Entry keys: path (glob, consumer-relative) · rule (engine rule or "*")
+#   · pattern (scanner rule_id family) · justification · spec_ref
+#   · expires_at ("" = permanent) · dec_id ("" = no DEC binding)
+#   · severity.
+
+entries:
+  # --- branch_slug.py: optional PyYAML import fallback -------------------
+  - path: ".ai-engineering/scripts/branch_slug.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Optional-dependency import fallback: PyYAML is imported defensively
+      and rebound to None when absent. The type-checker cannot model the
+      conditional rebind, so the import and the None assignment carry
+      `type: ignore`.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+  - path: ".ai-engineering/scripts/branch_slug.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      Defensive `except ImportError` fallback branch — not exercised when
+      the optional dependency is present, so it is excluded from coverage.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- commit_compose.py: optional skill_scripts_lib import fallback -----
+  - path: ".ai-engineering/scripts/commit_compose.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Optional-dependency import fallback for skill_scripts_lib: the
+      symbols are rebound to None / Exception when the lib is unavailable.
+      The type-checker cannot model the rebind.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+  - path: ".ai-engineering/scripts/commit_compose.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      Defensive `except ImportError` fallback branch — not exercised when
+      skill_scripts_lib is present.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- pr_body_compose.py: self-bootstrap import ordering ----------------
+  - path: ".ai-engineering/scripts/pr_body_compose.py"
+    rule: "*"
+    pattern: "noqa"
+    justification: >-
+      `E402` module-level import after a runtime `sys.path` bootstrap. A
+      deployed standalone script must extend its own import path before
+      importing skill_scripts_lib, so import-at-top is not possible.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- session_bootstrap.py: optional import + self-bootstrap ordering ---
+  - path: ".ai-engineering/scripts/session_bootstrap.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Optional-dependency import fallback: PyYAML is imported defensively
+      and rebound to None when absent.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+  - path: ".ai-engineering/scripts/session_bootstrap.py"
+    rule: "*"
+    pattern: "noqa"
+    justification: >-
+      `E402` module-level imports after a runtime `sys.path` bootstrap, so
+      the script can resolve skill_scripts_lib once its path is extended.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/_lib/hook-common.py: defensive guard ------------------------
+  - path: ".ai-engineering/scripts/hooks/_lib/hook-common.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      Defensive `except Exception` guard in shared hook plumbing — the
+      failure branch is intentionally uncovered.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/_lib/hook_http.py: validated SSRF egress --------------------
+  - path: ".ai-engineering/scripts/hooks/_lib/hook_http.py"
+    rule: "ssrf-urllib-request"
+    pattern: "nosemgrep_hash"
+    justification: >-
+      The sink URL is operator-supplied via AIENG_HOOK_HTTP_SINK_URL
+      (opt-in) and its scheme + netloc are validated with
+      urllib.parse.urlsplit before reaching urlopen, so only http/https
+      endpoints are ever requested.
+    spec_ref: "spec-141"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/_lib/instincts.py: defensive import fallback ----------------
+  - path: ".ai-engineering/scripts/hooks/_lib/instincts.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      Defensive `except ImportError` fallback branch — uncovered when the
+      optional import succeeds.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/_lib/locked_append.py: type-checker boundary ----------------
+  - path: ".ai-engineering/scripts/hooks/_lib/locked_append.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Type-checker limitation at the platform file-locking boundary
+      (`arg-type`); the handle type cannot be expressed across the
+      conditional posix/Windows locking backends.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/mcp-health.py: Windows import fallback ----------------------
+  - path: ".ai-engineering/scripts/hooks/mcp-health.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      Defensive `except ImportError` Windows fallback branch — uncovered
+      on the primary posix path.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- hooks/runtime-guard.py: optional _lib import fallback -------------
+  - path: ".ai-engineering/scripts/hooks/runtime-guard.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Optional-dependency import fallback for the `_lib` risk accumulator
+      (`import-not-found`); resolved at runtime when the hook lib is on
+      path.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- skills/skill_scripts/cleanup_run.py: CLI entrypoint shim ----------
+  - path: ".ai-engineering/scripts/skills/skill_scripts/cleanup_run.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      `if __name__ == "__main__"` CLI entrypoint shim — exercised via
+      subprocess invocation, not unit coverage.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- skills/skill_scripts/resolve_classify.py: CLI entrypoint shim -----
+  - path: ".ai-engineering/scripts/skills/skill_scripts/resolve_classify.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      `if __name__ == "__main__"` CLI entrypoint shim — exercised via
+      subprocess invocation, not unit coverage.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+
+  # --- skills/skill_scripts/standup_render.py: dynamic typing + CLI shim -
+  - path: ".ai-engineering/scripts/skills/skill_scripts/standup_render.py"
+    rule: "*"
+    pattern: "type_ignore"
+    justification: >-
+      Type-checker limitation at a dynamically-typed mapping access
+      (`index`) on a heterogeneous record.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"
+  - path: ".ai-engineering/scripts/skills/skill_scripts/standup_render.py"
+    rule: "*"
+    pattern: "pragma_no_cover"
+    justification: >-
+      `if __name__ == "__main__"` CLI entrypoint shim — exercised via
+      subprocess invocation, not unit coverage.
+    spec_ref: "spec-133"
+    expires_at: ""
+    dec_id: ""
+    severity: "low"

--- a/tests/architecture/test_template_tree_completeness.py
+++ b/tests/architecture/test_template_tree_completeness.py
@@ -111,3 +111,53 @@ def test_every_in_tree_import_target_is_shipped() -> None:
     assert not unresolved, "In-tree imports without shipped target:\n" + "\n".join(
         f"  {src}: from {pkg} import …" for src, pkg in unresolved
     )
+
+
+# ---------------------------------------------------------------------------
+# Article VII allowlist parity (shipped baseline).
+#
+# Same bug class as the skill_scripts_lib gap above: the installer deploys
+# `.ai-engineering/scripts/**` — which carry suppression markers (optional
+# import fallbacks, self-bootstrap E402, __main__ CLI shims, validated SSRF) —
+# but used to omit the `suppression-allowlist.yml` that authorizes them, so a
+# consumer's first `git push` was blocked by `ai-eng gate pre-push`. These
+# assertions keep the shipped baseline both PRESENT and COMPLETE.
+# ---------------------------------------------------------------------------
+
+_TEMPLATES_ROOT = _REPO_ROOT / "src" / "ai_engineering" / "templates"
+_TEMPLATE_ALLOWLIST = _TEMPLATES_ROOT / ".ai-engineering" / "suppression-allowlist.yml"
+
+
+def test_template_ships_suppression_allowlist() -> None:
+    """The installer template tree must ship the Article VII allowlist."""
+    assert _TEMPLATE_ALLOWLIST.is_file(), (
+        f"Template tree missing suppression-allowlist.yml at {_TEMPLATE_ALLOWLIST}. "
+        "Without it, a consumer's first `git push` fails the no-suppression gate "
+        "on the vendored `.ai-engineering/scripts/` tree."
+    )
+
+
+def test_template_script_suppressions_are_allowlisted() -> None:
+    """Every suppression in the shipped `scripts/` tree is covered by the
+    shipped allowlist, so the baseline can never drift out of sync."""
+    from no_suppression.allowlist import evaluate, load_allowlist
+    from no_suppression.scanner import scan_paths
+
+    findings = scan_paths(
+        _TEMPLATES_ROOT,
+        include_globs=(".ai-engineering/scripts/**/*.py",),
+        exclude_globs=(),
+    )
+    entries = load_allowlist(_TEMPLATE_ALLOWLIST)
+    # The baseline carries no DEC bindings, so state.db is never consulted.
+    decisions = evaluate(findings, entries, state_db=Path("/nonexistent-state.db"))
+    denied = [d for d in decisions if d.status != "allowed"]
+    assert not denied, (
+        "Shipped suppression-allowlist.yml does not cover every marker in the "
+        "template `scripts/` tree (add/adjust entries):\n"
+        + "\n".join(
+            f"  {d.finding.path.as_posix()}:{d.finding.line} "
+            f"[{d.finding.rule_id}/{d.finding.rule_target or '*'}] {d.status}: {d.reason}"
+            for d in denied
+        )
+    )

--- a/tests/e2e/test_install_clean.py
+++ b/tests/e2e/test_install_clean.py
@@ -248,3 +248,36 @@ class TestInstallClean:
         result = install(tmp_path, stacks=["python"])
         assert (tmp_path / ".git").is_dir()
         assert len(result.hooks.installed) == 3
+
+    def test_install_ships_allowlist_and_suppression_gate_passes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A clean install must leave the Article VII gate green.
+
+        Regression: the installer deploys the vendored ``.ai-engineering/
+        scripts/`` tree (which carries suppression markers) but used to omit
+        the authorizing ``suppression-allowlist.yml``, so a consumer's first
+        ``git push`` was blocked by ``ai-eng gate pre-push``. This asserts the
+        allowlist ships AND that scanning the installed tree denies nothing.
+        """
+        from no_suppression.cli import run_check
+
+        install(tmp_path, stacks=["python"])
+
+        allowlist = tmp_path / ".ai-engineering" / "suppression-allowlist.yml"
+        assert allowlist.is_file(), "Install did not ship suppression-allowlist.yml"
+
+        decisions = run_check(
+            root=tmp_path,
+            allowlist_path=None,
+            state_db_path=None,
+            include=None,
+            exclude=None,
+        )
+        denied = [d for d in decisions if d.status != "allowed"]
+        assert not denied, "Post-install no-suppression gate would block first push:\n" + "\n".join(
+            f"  {d.finding.path.as_posix()}:{d.finding.line} "
+            f"[{d.finding.rule_id}] {d.status}: {d.reason}"
+            for d in denied
+        )

--- a/tests/integration/installer/fixtures/install-dir-schema.txt
+++ b/tests/integration/installer/fixtures/install-dir-schema.txt
@@ -20,3 +20,4 @@
 .ai-engineering/state/locks/framework-events.lock
 .ai-engineering/state/observation-events.ndjson
 .ai-engineering/state/ownership-map.json
+.ai-engineering/suppression-allowlist.yml


### PR DESCRIPTION
## Problem

`ai-eng install` deploys the vendored `.ai-engineering/scripts/` tree, whose framework scripts legitimately carry suppression markers (optional-dependency import fallbacks, self-bootstrap `E402` imports, `__main__` CLI shims, a validated-SSRF `nosemgrep`). The authorizing `suppression-allowlist.yml` was **missing from the shipped template tree**, so the Article VII no-suppression pre-push gate denied every one of those markers and **blocked the first `git push` in every installed project**.

Same bug class as the earlier `skill_scripts_lib` ship-gap (a file the source had but the template tree did not ship).

## Fix

Ship a **standard baseline** allowlist at `src/ai_engineering/templates/.ai-engineering/suppression-allowlist.yml`:

- **17 entries**, covering exactly the 22 markers across 13 files the installer deploys.
- **Permanent** — `expires_at: ""` and `dec_id: ""` on every entry (framework authorizations, not time-boxed risk acceptances).
- **Scoped strictly** to `.ai-engineering/scripts/**`; never pre-authorizes a consumer's own `src/` / `tools/` / `tests/`.
- No dogfooding content migrated (no transitional-debt framing, no PII/machine paths).

`GovernancePhase` already copies template-root files, so **no installer code change** is needed.

## Regression guards

- `tests/architecture/test_template_tree_completeness.py` — asserts the baseline ships **and** covers every marker the scanner finds in the template `scripts/` tree (drift guard).
- `tests/e2e/test_install_clean.py` — clean install, then runs the gate over the installed tree and asserts **zero denials** (the consumer first-push path).

## Verification

- 250 targeted tests green (architecture + e2e + no_suppression + parity + installer); ruff clean.
- Scan of the shipped scripts tree: 22 findings / 17 entries / **0 denied**.
- Independent 4-lens adversarial review: **GO** — confirmed leak-free and complete.

## Out-of-scope follow-up (tracked separately, NOT in this PR)

This repo's *own* `.ai-engineering/suppression-allowlist.yml` has a comment promising a 60-day TTL (expiry `2026-07-10`) on its `spec-128 sub-d` entries, but their `expires_at` is empty — so the TTL is not enforced. Pre-existing; reconcile before 2026-07-10 (set real dates, convert to DECs, or amend the comment).
