### PR TITLE
chore(spec-157): consolidate shipped spec (backfill post-UI-merge)

### DIFF
--- a/.ai-engineering/specs/_history.md
+++ b/.ai-engineering/specs/_history.md
@@ -152,5 +152,6 @@ Completed specs. Details in git history.
 | 001 | AI-Engineering Framework: Rewrite from Scratch | done | 2026-02-08 | — | — | spec/001-rewrite-v2 |
 | spec-152 | GitHub Actions CI/CD Supply-Chain Hardening and Simplification | shipped | 2026-05-22 | 2026-05-22 | 536 | spec-152-github-actions-supply-chain-hardening |
 | spec-153 | Spec/Plan Lifecycle Automation and Client-Facing Capability README | shipped | 2026-05-24 | 2026-05-29 | 539 | spec-153-lifecycle-and-client-readmes |
+| spec-157 | Version Update Notice — Clean Re-land (scope-free) | shipped | 2026-05-30 | 2026-05-31 | 557 | feat/version-update-notice-clean |
 
 ---

--- a/.ai-engineering/specs/archive/spec-157-version-update-notice-clean/plan.md
+++ b/.ai-engineering/specs/archive/spec-157-version-update-notice-clean/plan.md
@@ -1,0 +1,212 @@
+---
+execution_route:
+  version: 1
+  spec: spec-157
+  executor: build
+  automation: assisted
+  concern_count: 1
+  estimated_files: 30
+  reason: "Single concern (re-land version-update-notice scope-free). Mostly mechanical transplant of proven green files + two targeted single-scope rewrites + two rider cherry-picks. One coherent feature, build-routable; not multi-concern, so not autopilot."
+  safe_next_command: "/ai-build"
+status: approved
+spec: spec-157
+title: Version Update Notice — Clean Re-land (scope-free)
+pipeline: standard
+---
+
+# Plan — spec-157 Version Update Notice: Clean Re-land
+
+## Design
+
+Re-land is a TRANSPLANT, not a redesign. The version-notice design is proven and
+green in PR #556. The plan moves proven artifacts onto a fresh main-cut branch,
+rewrites only the two genuinely scope-coupled files back to single-scope, brings
+two CI-green riders, and asserts zero scope residue. Source of truth for the
+"old" artifacts is the `feat/version-update-notice` branch (PR #556); the build
+agent reads files from it via `git show <ref>:<path>` / `git checkout <ref> --
+<path>`.
+
+`OLD = feat/version-update-notice` (PR #556 tip). `BASE = main`.
+
+## Architecture
+
+Pattern: **branch-transplant migration** (ad-hoc). Three rails:
+1. Verbatim copy of scope-clean source + tests from OLD.
+2. Single-scope rewrite of the two coupled files to the BASE shape + KEEP-block
+   graft.
+3. Rider cherry-pick (security/governance, scope-independent).
+
+No new abstractions. local-always-wins is the only model (it is BASE's model).
+
+## Phases
+
+Order: P0 branch+preserve → P1 riders → P2 verbatim transplant → P3 coupled
+rewrites → P4 strip+wire cleanup → P5 gate. RED-before-GREEN does not apply
+(tests are transplanted alongside their proven implementations); the gate phase
+is the verification contract.
+
+---
+
+### Phase 0 — Branch + preserve briefs
+
+- [ ] T-0a — Preserve the two global briefs before switching branches
+  - Agent: build
+  - Files: `.ai-engineering/specs/drafts/global-install-work-plane-brief.md`, `.ai-engineering/specs/drafts/global-hook-surface-resilience-brief.md`
+  - Principles applied: §10.2 YAGNI (keep the validated artifact, drop the over-built code)
+  - Patch (deterministic): none — `git stash push -- .ai-engineering/specs/drafts/global-*-brief.md` OR copy to `/tmp` so they survive the branch cut; restore after T-0b.
+  - Gate: both files readable after T-0b.
+
+- [ ] T-0b — Cut the clean branch from main
+  - Agent: build
+  - Files: (git ref only)
+  - Principles applied: §10.1 KISS (D-157-01 fresh branch, zero residue)
+  - Patch (deterministic): none — `git fetch origin && git switch -c feat/version-update-notice-clean origin/main` (or local `main` if current).
+  - Gate: `git rev-parse --abbrev-ref HEAD` == `feat/version-update-notice-clean`; `git merge-base --is-ancestor main HEAD` true; spec.md + plan.md (spec-157) and both briefs present in the working tree on the new branch.
+
+- [ ] T-0c — Land spec-157 spec.md + plan.md + briefs on the new branch
+  - Agent: build
+  - Files: `.ai-engineering/specs/spec.md`, `.ai-engineering/specs/plan.md`, `.ai-engineering/specs/drafts/global-*-brief.md`
+  - Principles applied: §10.6 SDD (the spec/plan are the contract for this branch)
+  - Patch (deterministic): none — ensure the spec-157 spec.md/plan.md (currently working-tree) and the restored briefs are on the new branch; commit them: `docs(spec-157): clean version-notice re-land spec + plan`.
+  - Gate: `git show HEAD:.ai-engineering/specs/spec.md` frontmatter `spec: spec-157`.
+
+---
+
+### Phase 1 — Riders (cherry-pick, CI-green-required)
+
+- [ ] T-1a — Cherry-pick `.snyk` CVE-2026-8643 accept
+  - Agent: build
+  - Files: `.snyk`
+  - Principles applied: §13.1 Secrets/CVE gate (Hard Rule 1 — branch must pass the same gate as main)
+  - Patch (deterministic): none — `git cherry-pick 5b9b4272`. If it touches more than `.snyk`, instead `git checkout 5b9b4272 -- .snyk` and commit `chore(security): risk-accept CVE-2026-8643 (pip) in Snyk gate`.
+  - Gate: `.snyk` contains the CVE-2026-8643 entry; `pip-audit`/Snyk gate green locally if runnable.
+
+- [ ] T-1b — Cherry-pick decision-store tracking
+  - Agent: build
+  - Files: `.gitignore`, `.ai-engineering/state/decision-store.json`, `CHANGELOG.md`, `docs/persistence-doctrine.md`, `src/ai_engineering/installer/gitignore.py`, `tests/unit/installer/test_project_gitignore.py`
+  - Principles applied: §13.7 SSOT per datum (decision-store becomes a tracked canonical store)
+  - Patch (deterministic): none — `git cherry-pick d6db3dc7`; resolve any CHANGELOG conflict by keeping both entries.
+  - Gate: `git check-ignore .ai-engineering/state/decision-store.json` returns nothing (no longer ignored); `pytest tests/unit/installer/test_project_gitignore.py` green.
+
+---
+
+### Phase 2 — Verbatim transplant (scope-clean source + tests)
+
+- [ ] T-2a — Transplant the `version/` package from OLD
+  - Agent: build
+  - Files: `src/ai_engineering/version/{cache,compare,install_method,pypi,refresh,__init__,checker}.py`
+  - Principles applied: §10.4 DRY (reuse proven green modules; do not rewrite)
+  - Patch (deterministic): none — `git checkout OLD -- src/ai_engineering/version/cache.py src/ai_engineering/version/compare.py src/ai_engineering/version/install_method.py src/ai_engineering/version/pypi.py src/ai_engineering/version/refresh.py src/ai_engineering/version/__init__.py src/ai_engineering/version/checker.py` (OLD = `feat/version-update-notice`).
+  - Gate: `grep -rE "scope|brain_root|global" src/ai_engineering/version/` returns only benign prose (no module refs); `python -c "import ai_engineering.version.refresh, ai_engineering.version.pypi, ai_engineering.version.cache, ai_engineering.version.compare, ai_engineering.version.install_method"` imports clean.
+
+- [ ] T-2b — Transplant `config/manifest.py` VersionCheckConfig
+  - Agent: build
+  - Files: `src/ai_engineering/config/manifest.py`
+  - Principles applied: §10.3 SOLID (config model isolated)
+  - Patch (deterministic): none — if `manifest.py` has no other OLD changes, `git checkout OLD -- src/ai_engineering/config/manifest.py`; else graft only the `VersionCheckConfig` class + `version_check` field (+14 lines). Verify no scope field rode along.
+  - Gate: `pytest tests/unit/config/test_manifest.py` green; no `scope` field in the manifest model.
+
+- [ ] T-2c — Transplant `cli_factory.py` (fully scope-clean)
+  - Agent: build
+  - Files: `src/ai_engineering/cli_factory.py`
+  - Principles applied: §10.4 DRY (proven notice wiring + `version_app` sub-typer)
+  - Patch (deterministic): none — `git checkout OLD -- src/ai_engineering/cli_factory.py` (agent confirmed zero scope imports).
+  - Gate: `grep -E "scope_resolution|installer.*scope|brain_root" src/ai_engineering/cli_factory.py` returns nothing; CLI builds (`python -c "import ai_engineering.cli_factory"`).
+
+- [ ] T-2d — Transplant the 11 version-notice test files
+  - Agent: build
+  - Files: `tests/unit/version/{__init__,test_cache,test_compare,test_install_method,test_pypi,test_refresh}.py`, `tests/unit/test_cli_ui_notice.py`, `tests/unit/test_cli_notice_exempt.py`, `tests/unit/test_version_lifecycle.py`, `tests/unit/cli_commands/test_version_upgrade.py`, `tests/integration/test_version_checker.py`
+  - Principles applied: §10.5 TDD (the proven test contract travels with its implementation)
+  - Patch (deterministic): none — `git checkout OLD -- tests/unit/version/ tests/unit/test_cli_ui_notice.py tests/unit/test_cli_notice_exempt.py tests/unit/test_version_lifecycle.py tests/unit/cli_commands/test_version_upgrade.py tests/integration/test_version_checker.py`.
+  - Gate: files present; `grep -rE "scope|--global|dual_scope" tests/unit/version/` clean. (Tests will fail to collect until P3 lands cli_ui/core/updater — expected; P5 is the green gate.)
+
+---
+
+### Phase 3 — Coupled-file single-scope rewrites
+
+- [ ] T-3a — Transplant `cli_ui.py` notice block, strip `announce_scope`
+  - Agent: build
+  - Files: `src/ai_engineering/cli_ui.py:392-528`, `cli_ui.py:416-433`
+  - Principles applied: §10.7 Clean Code (D-157-03 no dead scope rider)
+  - Patch (deterministic): none (judgment) — start from `git checkout OLD -- src/ai_engineering/cli_ui.py`, then DELETE the `announce_scope` function (`~416-433`) and any `announce_scope` export. Keep `maybe_render_update_notice`, `_render_update_notice`, `_load_version_check_config`.
+  - Gate: `grep -n "announce_scope" src/ai_engineering/cli_ui.py` returns nothing; `python -c "import ai_engineering.cli_ui"` clean.
+
+- [ ] T-3b — Rewrite `updater/service.py` to single-scope
+  - Agent: build
+  - Files: `src/ai_engineering/updater/service.py:122-171,444-446,449-504,507-589,766-790,793-839,842-887,900-912,915-928,931-946,949-965`
+  - Principles applied: §10.1 KISS, §10.4 DRY (collapse dual-scope to the BASE shape)
+  - Patch (deterministic): none (judgment) — base file is BASE's `updater/service.py`; graft ONLY the version-notice/self-upgrade additions from OLD. DROP: `ScopeNotInstalledError`, `_SCOPE_INSTALL_HINT`, `_scope_is_installed`, `update_scopes`, `reconcile_scopes_with_skips`, `_scope_root`, `_update_dests`, `_orphan_path`, `_merge_update_results`, `UpdateResult.skipped_scopes`. REVERT scope params on `update`, `_evaluate_project_files`, `_detect_orphan_files`, `_provider_orphan_changes`, `_provider_file_orphans`, `_provider_tree_orphans` to BASE signatures. Net: file should differ from BASE only by any genuine version-notice hook (likely none — confirm `git diff main -- src/ai_engineering/updater/service.py` is empty or notice-only).
+  - Gate: `grep -nE "scope|brain_root|_update_dests|_orphan_path|ScopeNotInstalled|skipped_scopes" src/ai_engineering/updater/service.py` returns nothing; `pytest tests/unit/updater/ -k "not dual_scope"` green.
+
+- [ ] T-3c — Rewrite `cli_commands/core.py`: keep version block, drop scope
+  - Agent: build
+  - Files: `src/ai_engineering/cli_commands/core.py:31,151-164,181,196,209,215-219,236,263-268,304,330-345,384-414,451-480,568-581,584-599,1135-1142,1144-1148,1153,1155-1160,1163,1172-1196,1243-1254,1257-1298,1301-1314,1697-1846`
+  - Principles applied: §10.3 SOLID, §10.7 Clean Code (one concern per command; no scope contamination)
+  - Patch (deterministic): none (judgment) — base file is BASE's `core.py`; graft the KEEP block (`_cached_latest` 1697-1706, `version_cmd` 1709-1738 incl. `ctx`/sub-command guard, `_MANUAL_UPGRADE_COMMANDS` 1741-1746, `_emit_manual_upgrade_guidance` 1749-1773, `version_upgrade_cmd` 1776-1846) and the notice wiring. DROP: `scope_global`/`scope_local` on `install_cmd` + `update_cmd`, `_explicit_install_scope`, `_resolve_update_scope`, `_merge_update_results`, `announce_scope` import (`31`), `brain_root` routing (`263-268`), scope except-block (`1172-1196`). REVERT `_is_reinstall`, `_resolve_install_configuration`, `_resolve_first_install_configuration`, `_run_update_with_spinner`, `_emit_install_dry_run_plan`, `_run_install_pipeline` to BASE signatures (no `scope` param). KEEP `success` import (`42`).
+  - Gate: `grep -nE "scope_global|scope_local|_explicit_install_scope|_resolve_update_scope|announce_scope|brain_root|ScopeNotInstalled" src/ai_engineering/cli_commands/core.py` returns nothing; `ai-eng version` and `ai-eng version upgrade --help` run; `pytest tests/unit/cli_commands/test_version_upgrade.py` green.
+
+- [ ] T-3d — Drop scope-announce from `config.py`
+  - Agent: build
+  - Files: `src/ai_engineering/cli_commands/config.py:57-62`
+  - Principles applied: §10.7 Clean Code (remove scope rider)
+  - Patch (deterministic): none (judgment) — remove the `announce_scope(resolve_scope(root).announce)` block + the two scope imports; restore `config_cmd` to BASE behavior. Easiest: `git checkout main -- src/ai_engineering/cli_commands/config.py` (config has no version-notice additions).
+  - Gate: `grep -nE "scope_resolution|announce_scope" src/ai_engineering/cli_commands/config.py` returns nothing; `pytest tests/unit -k config` green.
+
+---
+
+### Phase 4 — Residue sweep + manifest consistency
+
+- [ ] T-4a — Assert zero scope residue across src/
+  - Agent: verify
+  - Files: `src/`
+  - Principles applied: §10.7 Clean Code (no orphaned scope surface)
+  - Patch (deterministic): none — run `grep -rnE "scope_resolution|installer\.scope|brain_root|--global|--local|detect_scopes|scope_status|update_scopes|reconcile_scopes" src/` and confirm ZERO hits. Confirm pure-scope files ABSENT: `installer/scope.py`, `installer/scope_resolution.py`, `doctor/runtime/scope_status.py`.
+  - Gate: grep returns nothing; the three pure-scope modules do not exist; `doctor/service.py` has no `scope_status` registration.
+
+- [ ] T-4b — Regenerate hooks-manifest if hook bytes changed
+  - Agent: build
+  - Files: `.ai-engineering/state/hooks-manifest.json`
+  - Principles applied: §13 hook integrity pin
+  - Patch (deterministic): none — hooks should be untouched; if `git diff main -- .ai-engineering/scripts/hooks/` is non-empty, regenerate the manifest per the established procedure; else leave as-is.
+  - Gate: hook integrity check passes; `git diff main -- .ai-engineering/scripts/hooks/` empty (expected).
+
+---
+
+### Phase 5 — Green gate (the verification contract)
+
+- [ ] T-5a — Full test suite green
+  - Agent: verify
+  - Files: `tests/`
+  - Principles applied: §10.5 TDD, §4 Verification Before Done
+  - Patch (deterministic): none — `pytest` (full). Expect the 11 transplanted version tests + BASE suite all green; NO scope tests present.
+  - Gate: full suite green; `pytest tests/unit/version tests/unit/test_cli_ui_notice.py tests/unit/test_cli_notice_exempt.py tests/unit/cli_commands/test_version_upgrade.py tests/unit/test_version_lifecycle.py tests/integration/test_version_checker.py` all pass.
+
+- [ ] T-5b — Behavioral parity + notice purity smoke
+  - Agent: verify
+  - Files: (runtime)
+  - Principles applied: §4 Verification Before Done
+  - Patch (deterministic): none — confirm: `ai-eng install`/`update`/`config`/`doctor` carry no `--global`/`--local` and no scope announce (parity with main); `ai-eng version` shows the notice; `ai-eng version --json`/`gate`/`internal` are notice-free (stdout pure) and do not advance the throttle.
+  - Gate: all acceptance checkboxes in spec-157 satisfiable; ready for `/ai-pr`.
+
+---
+
+## Post-build (operator, not a build task)
+
+- Open the PR for `feat/version-update-notice-clean` via `/ai-pr`.
+- Close PR #556 as superseded with a note: "Scope (global/local) abandoned per
+  spec-157 + global-viability panel; version-update-notice re-landed clean in
+  #NNN. Global briefs preserved under specs/drafts/." (irreversible/outward —
+  operator confirms.)
+
+## Risks
+
+- `git checkout OLD -- <file>` brings a stray scope import → mitigated by the
+  per-file grep gates in P2/P3 and the T-4a sweep.
+- `core.py` / `updater/service.py` graft drifts from BASE → base ON main's file,
+  graft only the version block; gate asserts `git diff main` is notice-only.
+- Rider cherry-pick conflicts (CHANGELOG) → keep both entries.
+- Briefs lost across the branch cut → T-0a preserves before T-0b.
+
+## safe_next_command
+
+`/ai-build`

--- a/.ai-engineering/specs/archive/spec-157-version-update-notice-clean/spec.md
+++ b/.ai-engineering/specs/archive/spec-157-version-update-notice-clean/spec.md
@@ -1,0 +1,210 @@
+---
+spec: spec-157
+title: Version Update Notice — Clean Re-land (scope-free)
+status: approved
+effort: medium
+summary: Re-land only the version-update-notice + version-upgrade feature on a fresh branch cut from main, scope-free. Transplant the proven version modules, rewrite the two scope-coupled files to single-scope, and drop all global/local scope machinery. Supersedes PR #556 (spec-156).
+---
+
+# spec-157 — Version Update Notice: Clean Re-land
+
+## Summary
+
+PR #556 (`feat/version-update-notice`, spec-156) bundled two concerns into one
+branch: (A) a cross-surface PyPI **update-available notice + `ai-eng version
+upgrade`** self-upgrade, and (B) a **global/local scope** install/update system.
+A strategy judge-panel (8 agents) and an atom census found global-as-install is
+an architectural impedance mismatch: ~64% of ai-engineering's atoms (specs,
+decision-store, audit chain, ownership, install-state, hooks-manifest) are
+per-repo singletons that are incoherent shared, and spec-156 writes a global
+brain the runtime resolvers (`paths.py`, `config.py` — untouched) can never read
+back. Concern A is genuinely valuable and ships green (Sonar Quality Gate
+passed, 92.7% coverage on new code). Concern B fights the architecture.
+
+This spec re-lands ONLY Concern A, scope-free, on a fresh branch cut from
+`main`. The design is already proven in code; this is a transplant + targeted
+single-scope rewrite, not a new feature. Concern B is dropped entirely. PR #556
+is closed as superseded; the two global briefs
+(`global-install-work-plane-brief.md`, `global-hook-surface-resilience-brief.md`)
+are preserved for a future, properly-scoped effort.
+
+## Current State (boundary evidence)
+
+Two adversarial `ai-explore` passes mapped the exact cut (`git diff main...HEAD`):
+
+**Scope-clean — transplant verbatim (zero scope refs, confirmed):**
+- `src/ai_engineering/version/cache.py` (net-new, 112), `compare.py` (25),
+  `install_method.py` (93), `pypi.py` (77), `refresh.py` (60),
+  `__init__.py` (+5 re-exports), `checker.py` (+6/-26, uses `compare.is_newer`).
+- `src/ai_engineering/config/manifest.py` (+14, `VersionCheckConfig`).
+- `src/ai_engineering/cli_factory.py` (+81/-4, notice wiring + `version_app`
+  sub-typer) — fully scope-clean (`cli_factory.py`).
+- `src/ai_engineering/cli_ui.py` (+135) version-notice block
+  (`maybe_render_update_notice`, `_render_update_notice`,
+  `_load_version_check_config`) is clean; it ALSO carries `announce_scope`
+  (`cli_ui.py:416-433`) which is scope infra — strip it on re-land (dead
+  otherwise).
+
+**Scope-coupled — rewrite single-scope:**
+- `src/ai_engineering/updater/service.py` — DROP `ScopeNotInstalledError`
+  (`507-512`), `_SCOPE_INSTALL_HINT` (`515-518`), `_scope_is_installed`
+  (`521-524`), `update_scopes` (`527-566`), `reconcile_scopes_with_skips`
+  (`569-589`), `_scope_root` (`444-446`), `_update_dests` (`766-790`),
+  `_orphan_path` (`915-928`), `_merge_update_results`, `skipped_scopes` field
+  (`122-124,171`); REVERT `scope` param on `update` (`449-504`),
+  `_evaluate_project_files` (`793-839`), `_detect_orphan_files` (`842-887`),
+  `_provider_orphan_changes` (`900-912`), `_provider_file_orphans` (`931-946`),
+  `_provider_tree_orphans` (`949-965`) to the `main` shape.
+- `src/ai_engineering/cli_commands/core.py` — KEEP `_cached_latest`
+  (`1697-1706`), `version_cmd` (`1709-1738`), `_MANUAL_UPGRADE_COMMANDS`
+  (`1741-1746`), `_emit_manual_upgrade_guidance` (`1749-1773`),
+  `version_upgrade_cmd` (`1776-1846`); DROP `scope_global`/`scope_local` params
+  on `install_cmd` (`151-164`) + `update_cmd` (`1135-1142`),
+  `_explicit_install_scope` (`568-581`), `_resolve_update_scope` (`1243-1254`),
+  `_merge_update_results` (`1301-1314`), `announce_scope` import (`31`),
+  `brain_root` routing (`263-268`); REVERT `_is_reinstall` (`330-345`),
+  `_resolve_install_configuration` (`384-414`),
+  `_resolve_first_install_configuration` (`451-480`), `_run_update_with_spinner`
+  (`1257-1298`) to the `main` shape.
+- `src/ai_engineering/cli_commands/config.py` — DROP scope-announce block
+  (`57-62`).
+
+**Tests — transplant verbatim (all scope-free, confirmed):**
+`tests/unit/version/{__init__,test_cache,test_compare,test_install_method,test_pypi,test_refresh}.py`,
+`tests/unit/test_cli_ui_notice.py`, `tests/unit/test_cli_notice_exempt.py`,
+`tests/unit/test_version_lifecycle.py` (+62, `TestUpgradeVerbAndNotice`),
+`tests/unit/cli_commands/test_version_upgrade.py`,
+`tests/integration/test_version_checker.py` (+3/-21).
+
+**Riders — cherry-pick (scope-independent, CI-green-required):**
+- `5b9b4272` `.snyk` risk-accept CVE-2026-8643 (pip). Load-bearing: the Snyk
+  gate reds CI without it.
+- `d6db3dc7` decision-store tracking: `decision-store.json`, `.gitignore`,
+  `CHANGELOG.md`, `docs/persistence-doctrine.md`,
+  `src/ai_engineering/installer/gitignore.py`, `test_project_gitignore.py`.
+
+**Leave behind — pure scope (must NOT come to the clean branch):**
+`installer/scope.py`, `installer/scope_resolution.py`,
+`doctor/runtime/scope_status.py`, `installer/wizard.py` scope additions,
+installer phases scope routing (governance/hooks/ide_config/state/scripts),
+`doctor/service.py` scope_status registration, and all scope tests
+(`test_scope_*`, `test_install_scope_flow`, `test_cli_scope_announce`,
+`test_update_dual_scope`, `test_install_guidance`, `test_global_roundtrip`,
+`test_install_global`).
+
+**Import-edge danger (the one real trap):** `cli_commands/core.py` is the only
+KEEP-candidate that directly imports drop modules; its four version functions
+import only `version.install_method` and are clean, but live beside
+scope-contaminated code — surgically extract, never transplant verbatim. No
+version module back-depends on scope; `scope_status.py` imports version modules
+(reverse edge) and is left behind, so the edge vanishes.
+
+## Goals
+
+- A fresh branch `feat/version-update-notice-clean` cut from `main` carries the
+  version-update-notice + `ai-eng version upgrade` feature with ZERO scope code.
+- `install`/`update`/`config`/`doctor` behave exactly as `main` today (no
+  `--global`/`--local`, no scope announce, no dual-scope update).
+- The PyPI update-available notice renders only for interactive human commands
+  (stdout-pure, automation/`--json`/hook hot paths exempt, throttle honored) —
+  the proven behavior from #556.
+- `ai-eng version` and `ai-eng version upgrade` work, wrapped in the CLI error
+  boundary, with JSON envelopes — the proven behavior from #556.
+- The two CI-green riders (`.snyk`, decision-store tracking) are present so the
+  branch is green.
+- The two global briefs survive onto the new branch (or main) — not lost with
+  the dying PR.
+- Full test suite green; `hooks-manifest.json` regenerated if any hook bytes
+  changed (they should not).
+
+## Non-Goals
+
+- ANY global/local scope feature (dropped wholesale — that is the point).
+- Fixing the runtime resolver `$HOME` ceiling or hooks exit-127 (tracked in the
+  two preserved briefs; separate future specs).
+- Re-deriving the version-notice design (it is proven in #556; this is a
+  transplant, not a redesign).
+- Migrating PR #556 commit history (squash-merge makes it moot; #556 is closed).
+- Touching `paths.py` / `config.py` runtime resolution.
+
+## Decisions
+
+- **D-157-01 — Fresh branch from main, not surgical revert.** Cut
+  `feat/version-update-notice-clean` from `main`.
+  **Rationale**: the six installer
+  phases carry interwoven scope-routing (+14..+166 each); a fresh branch leaves
+  them prístine by construction (scope never arrives) — zero residue — whereas
+  reverting them in-place risks leftover scope fragments. Squash-merge yields a
+  single clean main commit either way, so history is not the deciding factor.
+
+- **D-157-02 — Transplant proven modules verbatim; rewrite only the two coupled
+  files.** The 13 scope-clean source files + 11 test files are copied as-is from
+  the #556 branch (they carry zero scope refs). Only `updater/service.py` and
+  `cli_commands/core.py` are rewritten to the single-scope (main) shape, plus the
+  3-line scope-announce drop in `config.py`.
+  **Rationale**: §10.4 DRY / §10.1 KISS —
+  do not rewrite tested, green code; minimize the rewrite surface to the genuine
+  coupling.
+
+- **D-157-03 — Strip `announce_scope` from `cli_ui.py` on transplant.** The
+  notice block is clean but `announce_scope` (`cli_ui.py:416-433`) is scope infra
+  that happened to land there. Remove it during the copy so no dead scope rider
+  ships.
+  **Rationale**: §10.7 Clean Code — no dead code; §13.3 no orphaned scope
+  surface.
+
+- **D-157-04 — Cherry-pick the two riders; they are load-bearing for green CI.**
+  `.snyk` (CVE-2026-8643 accept) and the decision-store tracking change are
+  scope-independent and cherry-pick clean onto main. The `.snyk` accept is NOT
+  optional — the Snyk gate reds CI without it.
+  **Rationale**: Hard Rule 1 (secrets/
+  CVE gate) — the branch must pass the same gate `main` does.
+
+- **D-157-05 — Preserve the two global briefs.** Move
+  `global-install-work-plane-brief.md` and
+  `global-hook-surface-resilience-brief.md` onto the new branch (they are
+  untracked working-tree files).
+  **Rationale**: they are the validated foundation for
+  a future correct global-defaults effort; they must not die with PR #556.
+
+- **D-157-06 — Close PR #556 as superseded.** After the clean branch opens its
+  PR, close #556 with a note linking the successor and the abandoned-scope
+  decision. It has zero human reviews, so nothing is lost.
+  **Rationale**: §10.2
+  YAGNI — abandon the over-built scope concern rather than carry it.
+
+## Risks
+
+- **Transplant brings a stray scope import.** Mitigation: per-file scope grep
+  gate on every transplanted file plus a full `src/` residue sweep; confirmed
+  zero scope references after the rewrite.
+- **The two coupled-file rewrites drift from the `main` shape.** Mitigation:
+  base each on `main`'s version and graft only the version block; assert
+  `git diff main` is version-only.
+- **Rider cherry-picks conflict (CHANGELOG).** Mitigation: keep both entries on
+  conflict; riders are otherwise scope-independent and apply clean.
+- **Fresh-from-main drops sibling non-scope fixes the #556 branch accrued.**
+  Mitigation: diff OLD's full commit list vs `main` and transplant every
+  non-scope fix (spec-lint conformance, spec-116 RED dormancy/evidence,
+  conftest json-mode isolation) — not only the feature code.
+- **spec.md / plan.md fail `spec_lint`.** Mitigation: keep `## Risks`, a
+  `**Rationale**:` line per decision, and the required plan frontmatter fields
+  (`spec`, `title`) so the canonical-spec lint gate stays green.
+
+## Acceptance
+
+- [ ] `feat/version-update-notice-clean` exists, cut from `main`.
+- [ ] `grep -rE "scope_resolution|brain_root|--global|--local|detect_scopes|scope_status|update_scopes" src/` returns ZERO hits on the new branch.
+- [ ] None of the pure-scope files exist on the new branch
+      (`installer/scope.py`, `scope_resolution.py`, `doctor/runtime/scope_status.py`, scope tests).
+- [ ] `ai-eng install`, `update`, `config`, `doctor` have no scope flags and
+      behave as `main` (no scope announce).
+- [ ] `ai-eng version` shows the update notice; `ai-eng version upgrade` works
+      and emits a JSON envelope under `--json`.
+- [ ] Update notice is stdout-pure: absent on `--json`, `internal`, `gate`/hook
+      paths; throttle not burned by automation.
+- [ ] `.snyk` CVE-2026-8643 accept present; Snyk gate green.
+- [ ] decision-store tracking change present (`.gitignore` no longer ignores it).
+- [ ] Both global briefs present under `.ai-engineering/specs/drafts/`.
+- [ ] Full test suite green; `hooks-manifest.json` consistent.
+- [ ] PR #556 closed as superseded with a linking note.

--- a/.ai-engineering/state/specs/spec-157.json
+++ b/.ai-engineering/state/specs/spec-157.json
@@ -1,0 +1,11 @@
+{
+  "branch": "feat/version-update-notice-clean",
+  "created": "2026-05-30T18:00:00+00:00",
+  "extra": {},
+  "pr": "557",
+  "shipped": "2026-05-31T19:30:54.223599+00:00",
+  "slug": "version-update-notice-clean",
+  "spec_id": "spec-157",
+  "state": "shipped",
+  "title": "Version Update Notice \u2014 Clean Re-land (scope-free)"
+}


### PR DESCRIPTION
## Summary
- PR #557 was squash-merged via the GitHub UI, so `/ai-pr` Step 11 spec consolidation never ran. spec-157 was also never registered in the lifecycle ledger on `main` (its sidecar lived on the merged feature branch).
- This backfills consolidation: registers the canonical shipped sidecar + appends the canonical 7-col `_history.md` row via `spec_lifecycle.py mark_shipped`, archives the populated `spec.md`/`plan.md`, and resets the canonical slots to placeholder so the next `/ai-brainstorm` starts clean.

## Changes
- `+ .ai-engineering/state/specs/spec-157.json` — shipped sidecar (pr 557, branch `feat/version-update-notice-clean`)
- `+ .ai-engineering/specs/_history.md` — spec-157 shipped row (canonical, via script)
- `+ archive/spec-157-version-update-notice-clean/{spec,plan}.md` — full snapshots
- `~ spec.md` / `~ plan.md` — reset to `# (no active spec)` placeholder

## Test Plan
- `ai-eng gate run --cache-aware --json --mode=local` → 0 findings.
- `_history.md` row generated by canonical `spec_lifecycle.py mark_shipped` (no hand-formatting).
- Idempotent: re-running `mark_shipped`/`consolidate_shipped` is a no-op on already-SHIPPED records.

## Checklist
- [x] lint/format/secret gates pass
- [x] no direct commit to protected `main`
- [x] full spec/plan preserved in archive before clearing