### PR TITLE
fix(ai-constitution): make /ai-constitution portable to installed repos

### DIFF
--- a/.agents/skills/ai-constitution/SKILL.md
+++ b/.agents/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/.ai-engineering/observations/meta.json
+++ b/.ai-engineering/observations/meta.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0",
-  "lastExtractedAt": "2026-05-31T18:20:34Z",
+  "lastExtractedAt": "2026-06-02T12:18:30Z",
   "deltaThreshold": 10,
   "lastContextGeneratedAt": null,
   "pendingContextRefresh": false,

--- a/.ai-engineering/observations/observations.yml
+++ b/.ai-engineering/observations/observations.yml
@@ -1,5 +1,5 @@
 schemaVersion: '2.0'
-updatedAt: '2026-05-31T18:21:15Z'
+updatedAt: '2026-06-02T12:19:10Z'
 corrections:
 - pattern: Verify file naming convention (underscore vs hyphen) before asserting files
     are missing

--- a/.ai-engineering/state/specs/spec-158.json
+++ b/.ai-engineering/state/specs/spec-158.json
@@ -1,0 +1,11 @@
+{
+  "branch": "spec-159-installer-parity",
+  "created": "2026-06-02T00:02:12.941487+00:00",
+  "extra": {},
+  "pr": "561",
+  "shipped": "2026-06-02T00:02:13.072057+00:00",
+  "slug": "spec-159",
+  "spec_id": "spec-158",
+  "state": "archived",
+  "title": "Installer source-of-truth parity"
+}

--- a/.claude/skills/ai-constitution/SKILL.md
+++ b/.claude/skills/ai-constitution/SKILL.md
@@ -31,18 +31,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -70,8 +84,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -92,10 +106,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/.codex/skills/ai-constitution/SKILL.md
+++ b/.codex/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/.github/skills/ai-constitution/SKILL.md
+++ b/.github/skills/ai-constitution/SKILL.md
@@ -37,18 +37,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -76,8 +90,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -98,10 +112,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(ai-constitution): `/ai-constitution` step 6 no longer instructs two
+  dev-repo-only operations that break in installed projects. It told the
+  agent to run `python -m skill_lint --check` — absent on a consumer's bare
+  `python3`, and even via the console script the full mirror-parity sweep
+  false-fails on the `.codex`/`.github` mirror surfaces a consuming project
+  legitimately lacks — and to emit a `constitution_updated` audit event,
+  a kind not in `ALLOWED_EVENT_KINDS` (would `ValueError`), with no
+  `ai-eng audit emit` command, into a hash-chained log. Both are now
+  replaced by an inline header self-check, the already-automatic
+  `skill_invoked` audit (UserPromptSubmit hook), and an optional fail-open
+  `framework_operation` marker; the forbidden-header list is inlined so the
+  skill is self-contained off the dev `tools/` tree. Synced to all mirrors
+  and install templates. Fixes the "2 pasos del skill no corren aquí" error
+  observed running `/ai-constitution` in consuming repos.
+
 ## [0.9.1] - 2026-06-01
 
 ### Fixed

--- a/src/ai_engineering/templates/project/.agents/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.agents/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/src/ai_engineering/templates/project/.claude/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-constitution/SKILL.md
@@ -31,18 +31,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -70,8 +84,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -92,10 +106,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/src/ai_engineering/templates/project/.codex/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.codex/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/src/ai_engineering/templates/project/.cursor/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.cursor/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/src/ai_engineering/templates/project/.github/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.github/skills/ai-constitution/SKILL.md
@@ -37,18 +37,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -76,8 +90,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -98,10 +112,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/src/ai_engineering/templates/project/.opencode/skills/ai-constitution/SKILL.md
+++ b/src/ai_engineering/templates/project/.opencode/skills/ai-constitution/SKILL.md
@@ -36,18 +36,32 @@ CANONICAL.md. The two never overlap.
    diff + explicit confirm (R-131-03 mitigation).
 3. **Interview the 10 sections** — see "Interview" below.
 4. **Write** — emit `CONSTITUTION.md` using the 10-section skeleton.
-   Refuse to write any header from
-   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`
-   (those are AI-behaviour headers; CONSTITUTION owns project identity
-   only).
+   Refuse to write any AI-behaviour / engineering-principle header —
+   those belong to CANONICAL.md; CONSTITUTION owns project identity
+   only: Think Before Coding, Simplicity First, Surgical Changes,
+   Goal-Driven Execution, Plan-Mode Default, Subagent Strategy,
+   Self-Improvement Loop, Demand Elegance, Autonomous Bug Fixing,
+   KISS, YAGNI, SOLID, DRY, TDD, SDD, Clean Code, Hexagonal
+   Architecture. (Framework dev repo: the canonical list lives at
+   `tools/skill_lint/checks/md_mirror.py:FORBIDDEN_CONSTITUTION_HEADERS`.)
 5. **Rotate** — when `update` or `amend` replaces operator-authored
    content, copy the pre-write body to
    `.ai-engineering/specs/_history-constitution-<YYYY-MM-DD>.md` so
    the prior identity is recoverable.
-6. **Verify + record** — run `python -m skill_lint --check` after the
-   write to confirm CONSTITUTION.md passes the md_mirror sweep. Emit a
-   `constitution_updated` audit event to
-   `.ai-engineering/state/framework-events.ndjson`.
+6. **Verify + record** — confirm inline that the file you just wrote
+   carries only the 10 project-identity sections and none of the
+   AI-behaviour headers from Step 4 (re-read `CONSTITUTION.md`; do NOT
+   shell out to `skill_lint` — that is a framework-dev mirror-parity
+   gate whose module is absent on a consumer's bare `python3` and which
+   false-fails on the `.codex`/`.github` mirror surfaces a consuming
+   project legitimately lacks). The `/ai-constitution` run is already
+   audited automatically as a `skill_invoked` event by the
+   UserPromptSubmit hook — no manual emit is required. If a distinct
+   marker is wanted, emit a `framework_event` `kind=framework_operation`
+   (`operation=constitution_update`, `component: ai-constitution`,
+   `detail: {version, sections_changed, mode}`); it chains into the
+   standard audit pipeline. **Fail-open**: never block the
+   `CONSTITUTION.md` write on a verification or audit failure.
 
 ## Interview
 
@@ -75,8 +89,8 @@ User: "set up the constitution for this project"
 ```
 
 Interviews the 10 sections, seeds defaults from `manifest.yml`, writes
-`CONSTITUTION.md` v1.0.0 with the ratified date stamped. Emits one
-`constitution_updated` audit event.
+`CONSTITUTION.md` v1.0.0 with the ratified date stamped. The run is
+audited automatically as a `skill_invoked` event.
 
 ### Example 2 — formal amendment with version bump
 
@@ -97,10 +111,11 @@ body into `_history-constitution-<date>.md`.
 Called by: `ai-eng install` (governance phase), `/ai-start` (cold-load
 identity context). Reads: `manifest.yml`, package files, existing
 `CONSTITUTION.md`, `decision-store.json`. Writes: `CONSTITUTION.md`,
-`_history-constitution-<date>.md` (when rotating). Audited by:
-`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` (any
-AI-behaviour header rejects the write). Consumed by: every skill at
-Step 0. See also: `/ai-governance` (compliance against the
+`_history-constitution-<date>.md` (when rotating). CI-guarded
+(framework dev repo only) by
+`tools/skill_lint/checks/md_mirror.py:check_constitution_clean` — any
+AI-behaviour header fails that gate; consumer projects rely on the
+inline Step 6 self-check. Consumed by: every skill at Step 0. See also: `/ai-governance` (compliance against the
 constitution), CANONICAL.md (AI-behaviour layer — never written by
 this skill).
 

--- a/tests/docs/test_links.py
+++ b/tests/docs/test_links.py
@@ -412,17 +412,25 @@ def test_sub005_plan_has_north_star_preamble() -> None:
 
 
 def test_spec_canonical_slot_carries_spec_marker() -> None:
-    """The canonical slot must always carry a `spec: spec-NNN` marker.
+    """The canonical slot carries an active spec OR the idle placeholder.
 
     spec-136 D-136-01 succeeded spec-132 in the slot. The contract is
-    "any active spec lives here", not "spec-132 specifically".
+    "any active spec lives here", not "spec-132 specifically". After spec
+    consolidation (`spec_lifecycle.py mark_shipped` / `spec_reset.py`) the
+    slot is legitimately cleared to the framework-recognized idle marker
+    `# No active spec` — the same empty-slot state the validator
+    (`manifest_coherence`) and `verify/service` already treat as valid.
+    Both states are accepted here; only an unrecognized slot fails.
     """
     p = REPO_ROOT / ".ai-engineering" / "specs" / "spec.md"
     body = p.read_text()
     import re
 
-    assert re.search(r"^spec: spec-\d+", body, re.MULTILINE), (
-        "canonical slot must declare an active spec via `spec: spec-NNN`"
+    has_active_spec = re.search(r"^spec: spec-\d+", body, re.MULTILINE)
+    is_idle_slot = body.lstrip().startswith("# No active spec")
+    assert has_active_spec or is_idle_slot, (
+        "canonical slot must declare an active spec via `spec: spec-NNN` "
+        "or carry the idle `# No active spec` placeholder"
     )
     # spec-153 W3: archive normalized to the uniform per-spec directory
     # layout (D-153-06): archive/spec-NNN-<slug>/{spec.md,plan.md}.

--- a/tools/spec_lint/cli.py
+++ b/tools/spec_lint/cli.py
@@ -31,6 +31,15 @@ from spec_lint.checks.sections import check_sections
 
 _DEFAULT_SPEC_PATH = Path(".ai-engineering/specs/spec.md")
 
+# Idle-slot marker (spec-136 idle-placeholder contract). After a spec ships,
+# consolidation (``spec_lifecycle.py mark_shipped`` / ``spec_reset.py``) clears
+# the canonical slot to this framework-recognized placeholder. An idle slot has
+# no spec to schema-check, so lint passes clean rather than emitting a wall of
+# ``section_missing`` BLOCKERS — mirroring the idle-slot handling already in
+# ``validator/manifest_coherence`` and ``verify/service``. Inlined (not imported
+# from ``ai_engineering``) so ``spec_lint`` stays a decoupled top-level package.
+_IDLE_SLOT_PREFIX = "# No active spec"
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -88,6 +97,21 @@ def main(argv: list[str] | None = None) -> int:
     if not spec_path.is_file():
         sys.stderr.write(f"spec_lint: file not found: {spec_path}\n")
         return 2
+
+    # Idle slot: nothing to validate. Pass clean before running any check so a
+    # post-consolidation canonical slot (the normal between-specs state) never
+    # fails the gate.
+    if (
+        spec_path.read_text(encoding="utf-8", errors="replace")
+        .lstrip()
+        .startswith(_IDLE_SLOT_PREFIX)
+    ):
+        if args.check and not args.quiet:
+            sys.stdout.write(
+                "spec_lint: idle slot "
+                f"(BLOCKERS=0 ADVISORIES=0, file={spec_path}, idle-placeholder)\n"
+            )
+        return 0
 
     started = time.perf_counter()
 


### PR DESCRIPTION
## Summary

`/ai-constitution` step 6 shipped two **dev-repo-only** operations into every consumer install that fail outside the framework dev repo — producing the "2 pasos del skill no corren aquí" error when the skill runs in a consuming project (observed in `lifeos`):

- **`python -m skill_lint --check`** — the `skill_lint` module is absent on a consumer's bare `python3`; even via the console script, `--check` runs the full 7-family mirror-parity sweep and **false-fails** on the `.codex`/`.github` mirror surfaces a consuming project legitimately lacks. Only `check_constitution_clean` is project-meaningful, and there is no flag to run it alone.
- **emit a `constitution_updated` audit event** — that kind is **not in `ALLOWED_EVENT_KINDS`** (would `ValueError`), there is **no `ai-eng audit emit` command**, and `framework-events.ndjson` is hash-chained (unsafe to hand-append). The `skill_invoked` event is already auto-recorded by the UserPromptSubmit hook, so the manual emit was also redundant.

Both are replaced with an **inline header self-check**, the **automatic `skill_invoked` audit**, and an optional **fail-open `framework_operation`** marker — matching the resilient pattern already used by `ai-spec-draft` / `ai-issue` / `ai-advise`. The forbidden-header list is **inlined** so the skill is self-contained off the dev `tools/` tree. Synced to all mirrors + install templates.

## Test Plan

- `ai-eng dev sync --check` → mirrors in sync
- `skill_lint --check` → exit 0, `md_mirror=OK`, no Grade-D regression
- managed mirror bodies (`.codex` / `.agents` / `.github`) byte-identical to canonical
- local commit gate + native pre-push gate → 0 findings

## Changes

- `.claude/skills/ai-constitution/SKILL.md` (canonical) + 3 top-level mirrors + 6 install templates
- `CHANGELOG.md` — `[Unreleased]` Fixed entry
- `.ai-engineering/state/specs/spec-158.json` — commits the spec-159 lifecycle sidecar left untracked by #564 (siblings are tracked)
- session-watch observations timestamp bump

## Known follow-up (separate, non-blocking)

Top-level `.opencode/skills/` carries `edit_policy: generated-do-not-edit` but is **not** a `dev sync` target — all top-level `.opencode` skills are frozen/stale and still carry the old phantom text. Consumers use the template tree (fixed here), so this is non-blocking; worth a separate spec to wire `.opencode` into sync or delete it.

## Checklist

- [x] Lint / format (ruff)
- [x] Secret scan (gitleaks)
- [x] Native commit + pre-push gates green
- [x] CHANGELOG updated
- [x] No breaking changes (docs / prompt only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Additional Changes — CI unblock (pre-existing main breakage)

`409ba1e1` `fix(tests)`: `test_spec_canonical_slot_carries_spec_marker` demanded the canonical slot always carry `spec: spec-NNN`, but PR #564 ("clear slots post-ship") cleared it to the framework-recognized idle placeholder `# No active spec` — turning this stale spec-136-era test **red on `main`** and blocking every subsequent PR's docs gate (Docs Floor + Docs both run `pytest tests/docs`). The test now accepts either an active `spec: spec-NNN` marker **or** the idle placeholder, matching what `manifest_coherence` + `verify/service` already treat as valid. Not part of the ai-constitution fix; bundled here because it blocks this PR's merge and unbreaks `main`.

`75e008b8` `fix(spec_lint)`: standalone `spec_lint --check` lacked the idle-slot awareness that `ai-eng spec verify` + the validator already have, so it emitted 7 BLOCKERS against the `# No active spec` slot — failing `test_spec_lint_e2e::test_spec_lint_self_validates_canonical_spec` on the **Integration** lane (also a pre-existing #564 breakage). Now short-circuits to clean when the slot is the idle placeholder. Same root cause as the docs fix above.
