### PR TITLE
fix(version): single-source latest + version notice on all human surfaces

### DIFF
--- a/.ai-engineering/scripts/session_bootstrap.py
+++ b/.ai-engineering/scripts/session_bootstrap.py
@@ -892,6 +892,32 @@ def _board_summary(root: Path, manifest: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _version_status() -> dict | None:
+    """Update-available status for the dashboard, or None when unknowable.
+
+    Reuses the CLI's single-source resolver (``resolve_latest_known`` — the
+    newer of the bundled registry and the PyPI cache) so the dashboard agrees
+    with ``ai-eng version`` and the inline notice. Fail-open: any import/IO
+    error (e.g. ai_engineering not importable in a bare checkout) yields None so
+    the dashboard renders without a version line rather than breaking.
+    """
+    try:
+        from ai_engineering import __version__
+        from ai_engineering.version import resolve_latest_known
+        from ai_engineering.version.compare import is_newer
+
+        latest = resolve_latest_known()
+        if not isinstance(latest, str) or not latest:
+            return None
+        return {
+            "installed": __version__,
+            "latest": latest,
+            "update_available": bool(is_newer(latest, __version__)),
+        }
+    except Exception:
+        return None
+
+
 def _render_markdown(d: dict) -> str:
     lines: list[str] = []
     name = d.get("project_name") or "(unnamed)"
@@ -943,6 +969,16 @@ def _render_markdown(d: dict) -> str:
     else:
         state.append(f"hooks: {hh}")
     lines.append("> " + " · ".join(state))
+    vs = d.get("version_status") or {}
+    installed = vs.get("installed")
+    if installed:
+        if vs.get("update_available"):
+            lines.append(
+                f"> ◈ ai-engineering {installed} → {vs.get('latest')}"
+                " · run `ai-eng version upgrade`"
+            )
+        else:
+            lines.append(f"> ◈ ai-engineering {installed} · up to date")
     lines.append("")
     lines.append("---")
     lines.append("")
@@ -1098,6 +1134,7 @@ def build_dashboard(repo_root: Path | None = None) -> dict:
         "mission": _constitution_mission(root / "CONSTITUTION.md"),
         "manifest_summary": _manifest_summary(manifest),
         "compat_warnings": _compat_warnings(manifest),
+        "version_status": _version_status(),
     }
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0

--- a/.ai-engineering/scripts/session_bootstrap.py
+++ b/.ai-engineering/scripts/session_bootstrap.py
@@ -1146,6 +1146,14 @@ def build_dashboard(repo_root: Path | None = None) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # The dashboard markdown is inherently UTF-8 (◈ brand mark, box-drawing,
+    # em-dashes, →). Force a UTF-8 stdout so a legacy cp1252 console (Windows)
+    # never crashes with UnicodeEncodeError. Fail-open if reconfigure is absent.
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        with contextlib.suppress(ValueError, OSError):
+            reconfigure(encoding="utf-8")
+
     parser = argparse.ArgumentParser(
         prog="session_bootstrap",
         description="Emit /ai-start dashboard (deterministic, <3s incl. board).",

--- a/.ai-engineering/state/hooks-manifest.json
+++ b/.ai-engineering/state/hooks-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T18:11:44Z",
+  "generatedAt": "2026-06-02T16:08:02Z",
   "hookCount": 75,
   "hooks": {
     ".ai-engineering/scripts/hooks/_lib/audit.py": "fdb45c8915600885edc9bc8d0a82ec0b8a4fa6d7f31200bf184c36433b93fa9d",
@@ -86,6 +86,6 @@
   ],
   "trustedScripts": {
     ".ai-engineering/scripts/hooks/no-verify-guard.py": "38cf04d30f394d74e95904a9a7b532fa1e02a1038869ed98c5e1274264d3c00f",
-    ".ai-engineering/scripts/session_bootstrap.py": "90f4a27ca9c569d4e0588ea3a6fb8fea31a19ac2d79cf11e823243efc9e934f8"
+    ".ai-engineering/scripts/session_bootstrap.py": "280c956978b1defb7786091adc78c584dec6d975a69ca06f5662fb398fc063cd"
   }
 }

--- a/.ai-engineering/state/hooks-manifest.json
+++ b/.ai-engineering/state/hooks-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-02T16:08:02Z",
+  "generatedAt": "2026-06-02T16:20:06Z",
   "hookCount": 75,
   "hooks": {
     ".ai-engineering/scripts/hooks/_lib/audit.py": "fdb45c8915600885edc9bc8d0a82ec0b8a4fa6d7f31200bf184c36433b93fa9d",
@@ -86,6 +86,6 @@
   ],
   "trustedScripts": {
     ".ai-engineering/scripts/hooks/no-verify-guard.py": "38cf04d30f394d74e95904a9a7b532fa1e02a1038869ed98c5e1274264d3c00f",
-    ".ai-engineering/scripts/session_bootstrap.py": "280c956978b1defb7786091adc78c584dec6d975a69ca06f5662fb398fc063cd"
+    ".ai-engineering/scripts/session_bootstrap.py": "fca66dd77a050da4a88a6faba02b824b7f5dcce7bc4b002bc249a828bb1b21b7"
   }
 }

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -67,7 +67,9 @@ jobs:
           . .smoke-venv/bin/activate || . .smoke-venv/Scripts/activate
           VERSION_OUTPUT="$(ai-eng version)"
           echo "$VERSION_OUTPUT"
-          echo "$VERSION_OUTPUT" | grep -qE '^ai-engineering [0-9]+\.[0-9]+\.[0-9]+'
+          # The status line leads with the ◈ brand mark ("◈ ai-engineering X · up
+          # to date"), so match the name+semver anywhere on the line, not anchored.
+          echo "$VERSION_OUTPUT" | grep -qE 'ai-engineering [0-9]+\.[0-9]+\.[0-9]+'
       - name: Configure git defaults
         run: |
           git config --global init.defaultBranch main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(version): the update-available notice and `ai-eng version` now read a
+  single source of truth for "latest". A new `version.resolve_latest_known()`
+  reconciles the two prior signals — the bundled `registry.json` high-water
+  mark and the live PyPI poll cache — by returning whichever is newer (PEP
+  440). Before, `ai-eng version` rendered one figure from each and could
+  print contradictory lines (`outdated — latest is 0.9.2` beside `latest known
+  release: 0.9.1`), and the inline notice consulted only the cache, so it
+  stayed silent whenever the cache lagged the registry. `ai-eng version` now
+  renders one coherent `◈` status block (`up to date` / `update available →
+  X`) and its `--json` envelope adds `latest`, `update_available`, and
+  `status`.
+
+### Added
+
+- feat(version): the update notice now also surfaces on bare `ai-eng` (the
+  no-subcommand help screen) and in the `/ai-start` session dashboard
+  (`session_bootstrap.py`), in addition to the existing post-command surfaces
+  (`install`/`update`/`status`/…). The dashboard shows the installed version
+  on EVERY start (`◈ ai-engineering X · up to date`), upgrading to
+  `◈ ai-engineering X → Y · run ai-eng version upgrade` when behind — so the
+  version is always visible, not only when outdated. All surfaces share the
+  SSOT resolver and stay silent for automation/`--json`/hook hot paths.
+  `/ai-brainstorm` was deliberately left out — a version nag
+  mid-design-interrogation breaks focus.
+
 ## [0.9.2] - 2026-06-02
 
 ### Fixed

--- a/src/ai_engineering/cli_commands/core.py
+++ b/src/ai_engineering/cli_commands/core.py
@@ -1511,48 +1511,49 @@ def _prompt_for_doctor_fix(approve_all: bool) -> bool:
     return response.lower() == "all"
 
 
-def _cached_latest() -> str | None:
-    """Return the latest known release from the version cache, if any.
-
-    Read-only and fail-open: a missing or malformed cache yields ``None`` so
-    ``ai-eng version`` still renders the installed version + lifecycle message.
-    """
-    from ai_engineering.version import cache
-
-    latest = cache.read().get("latest")
-    return latest if isinstance(latest, str) and latest else None
-
-
 def version_cmd(ctx: typer.Context) -> None:
     """Show the installed ai-engineering version and lifecycle status.
 
     Serves as the ``version`` Typer sub-group callback: when a subcommand
     (e.g. ``upgrade``) is invoked, this returns early so the subcommand owns
     the output and there is no double render.
+
+    The latest-version figure comes from the single SSOT resolver
+    (``resolve_latest_known``) — the newer of the bundled registry and the PyPI
+    cache — so this surface can never contradict the inline update notice (the
+    old dual ``message`` + ``latest known release`` lines could disagree).
     """
     if ctx.invoked_subcommand is not None:
         return
 
-    from ai_engineering.version.checker import check_version, load_registry
+    from ai_engineering.cli_ui import get_console, render_version_status
+    from ai_engineering.version import resolve_latest_known
+    from ai_engineering.version.checker import check_version
+    from ai_engineering.version.compare import is_newer
 
-    registry = load_registry()
-    result = check_version(__version__, registry)
-    latest = _cached_latest()
+    result = check_version(__version__)
+    latest = resolve_latest_known()
+    update_available = bool(latest) and is_newer(latest, __version__)
 
     if is_json_mode():
         emit_success(
             "ai-eng version",
             {
                 "version": __version__,
-                "message": result.message,
                 "latest": latest,
+                "update_available": update_available,
+                "status": result.status.value if result.status else None,
+                "message": result.message,
             },
         )
-    else:
-        show_logo()
-        print_stdout(f"ai-engineering {result.message}")
-        if latest:
-            print_stdout(f"latest known release: {latest}")
+        return
+
+    show_logo()
+    render_version_status(__version__, latest)
+    # Deprecated / EOL are security-relevant lifecycle states — surface the
+    # registry message beyond the one-line version status.
+    if result.is_deprecated or result.is_eol:
+        get_console().print(f"  [warning]{result.message}[/warning]")
 
 
 _MANUAL_UPGRADE_COMMANDS: tuple[str, ...] = (

--- a/src/ai_engineering/cli_factory.py
+++ b/src/ai_engineering/cli_factory.py
@@ -145,13 +145,23 @@ def _maybe_render_post_command_notice() -> None:
     re-loaded it — halving the per-command manifest parse on the CLI hot
     path. Fail-open: any error is swallowed by the notice renderer itself.
     """
+    if _invoked_command is None or _invoked_command in _NOTICE_EXEMPT:
+        return
+    _render_update_notice_gated()
+
+
+def _render_update_notice_gated() -> None:
+    """Shared notice gate: JSON / env opt-out / manifest flag → cli_ui renderer.
+
+    Extracted so both the post-command path and the bare ``ai-eng`` invocation
+    (which exits in the app callback, never reaching the error boundary) render
+    the notice through one set of gates. Fail-open: the renderer swallows errors.
+    """
     import os
 
     from ai_engineering.cli_output import is_json_mode
 
     if is_json_mode():
-        return
-    if _invoked_command is None or _invoked_command in _NOTICE_EXEMPT:
         return
     if os.environ.get("AIENG_NO_UPDATE_CHECK", "").strip().lower() in {"1", "true", "yes", "on"}:
         return
@@ -220,6 +230,9 @@ def _app_callback(
 
             show_logo()
             typer.echo(ctx.get_help())
+            # Bare `ai-eng` exits here, never reaching the error boundary, so
+            # render the update notice inline before exiting.
+            _render_update_notice_gated()
             raise typer.Exit(code=0)
 
     if not json_output and ctx.invoked_subcommand not in {"version", "internal"}:

--- a/src/ai_engineering/cli_ui.py
+++ b/src/ai_engineering/cli_ui.py
@@ -438,7 +438,7 @@ def maybe_render_update_notice(config: object | None = None) -> None:
 
 def _render_update_notice(config: object | None = None) -> None:
     from ai_engineering.cli_output import is_json_mode
-    from ai_engineering.version import cache
+    from ai_engineering.version import cache, resolve_latest_known
     from ai_engineering.version.compare import is_newer
 
     if is_json_mode():
@@ -458,12 +458,15 @@ def _render_update_notice(config: object | None = None) -> None:
 
         refresh.spawn_background()
 
-    data = cache.read()
-    latest = data.get("latest")
+    # SSOT: the newer of the bundled registry and the PyPI cache. Reading the
+    # cache alone left the notice silent whenever the cache lagged the registry.
+    latest = resolve_latest_known()
     if not isinstance(latest, str) or not latest:
         return
     if not is_newer(latest, __version__):
         return
+
+    data = cache.read()
 
     # Throttle: suppress if shown within the TTL window.
     last_shown = data.get("last_shown_at")
@@ -489,6 +492,42 @@ def _render_update_notice(config: object | None = None) -> None:
         sys.stderr.write(message + "\n")
 
     cache.mark_shown()
+
+
+def render_version_status(installed: str, latest: str | None) -> None:
+    """Render the ``ai-eng version`` status block — coherent, single-source.
+
+    Outdated → two lines (installed version + update CTA). Up-to-date or unknown
+    → one line. Uses the same ``◈`` brand mark and dim ink as the inline update
+    notice so both surfaces read as one design system, and takes its ``latest``
+    from the SSOT resolver so it can never contradict the notice.
+    """
+    from ai_engineering.version.compare import is_newer
+
+    con = get_console()
+    outdated = bool(latest) and is_newer(latest, installed)
+    styled = con.is_terminal and not _is_no_color()
+
+    if outdated:
+        if styled:
+            con.print(f"[brand]◈ ai-engineering[/brand] [bold]{installed}[/bold]")
+            con.print(
+                f"  [brand.dim]update available → {latest}[/brand.dim] "
+                "[muted]· run [brand.dim]`ai-eng version upgrade`[/brand.dim][/muted]"
+            )
+        else:
+            sys.stdout.write(
+                f"◈ ai-engineering {installed}\n"
+                f"  update available → {latest} · run `ai-eng version upgrade`\n"
+            )
+        return
+
+    if styled:
+        con.print(
+            f"[brand]◈ ai-engineering[/brand] [bold]{installed}[/bold] [muted]· up to date[/muted]"
+        )
+    else:
+        sys.stdout.write(f"◈ ai-engineering {installed} · up to date\n")
 
 
 def _truthy_env(name: str) -> bool:

--- a/src/ai_engineering/cli_ui.py
+++ b/src/ai_engineering/cli_ui.py
@@ -478,7 +478,10 @@ def _render_update_notice(config: object | None = None) -> None:
         return
 
     con = get_console()
-    message = f"◈ ai-engineering {__version__} → {latest} · run `ai-eng version upgrade`"
+    # Pure-ASCII variant for raw stderr writes (pipes / CI / legacy cp1252
+    # consoles), so a non-UTF-8 stream never hits UnicodeEncodeError. The
+    # styled terminal path keeps the ◈/→ marks via Rich, which encodes safely.
+    plain_message = f"ai-engineering {__version__} -> {latest} (run: ai-eng version upgrade)"
     if con.is_terminal and not _is_no_color():
         markup = (
             f"[brand.dim]◈ ai-engineering {__version__} → {latest}[/brand.dim] "
@@ -487,9 +490,9 @@ def _render_update_notice(config: object | None = None) -> None:
         try:
             con.print(markup)
         except (ImportError, ModuleNotFoundError):
-            sys.stderr.write(message + "\n")
+            sys.stderr.write(plain_message + "\n")
     else:
-        sys.stderr.write(message + "\n")
+        sys.stderr.write(plain_message + "\n")
 
     cache.mark_shown()
 
@@ -508,6 +511,9 @@ def render_version_status(installed: str, latest: str | None) -> None:
     outdated = bool(latest) and is_newer(latest, installed)
     styled = con.is_terminal and not _is_no_color()
 
+    # The styled path keeps the ◈/→ marks (Rich encodes them safely for the
+    # terminal). The plain path is for pipes/CI/legacy consoles (e.g. Windows
+    # cp1252) and stays pure ASCII so a raw write never hits UnicodeEncodeError.
     if outdated:
         if styled:
             con.print(f"[brand]◈ ai-engineering[/brand] [bold]{installed}[/bold]")
@@ -517,8 +523,7 @@ def render_version_status(installed: str, latest: str | None) -> None:
             )
         else:
             sys.stdout.write(
-                f"◈ ai-engineering {installed}\n"
-                f"  update available → {latest} · run `ai-eng version upgrade`\n"
+                f"ai-engineering {installed} -> {latest} (run: ai-eng version upgrade)\n"
             )
         return
 
@@ -527,7 +532,7 @@ def render_version_status(installed: str, latest: str | None) -> None:
             f"[brand]◈ ai-engineering[/brand] [bold]{installed}[/bold] [muted]· up to date[/muted]"
         )
     else:
-        sys.stdout.write(f"◈ ai-engineering {installed} · up to date\n")
+        sys.stdout.write(f"ai-engineering {installed} (up to date)\n")
 
 
 def _truthy_env(name: str) -> bool:

--- a/src/ai_engineering/templates/.ai-engineering/scripts/session_bootstrap.py
+++ b/src/ai_engineering/templates/.ai-engineering/scripts/session_bootstrap.py
@@ -892,6 +892,32 @@ def _board_summary(root: Path, manifest: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _version_status() -> dict | None:
+    """Update-available status for the dashboard, or None when unknowable.
+
+    Reuses the CLI's single-source resolver (``resolve_latest_known`` — the
+    newer of the bundled registry and the PyPI cache) so the dashboard agrees
+    with ``ai-eng version`` and the inline notice. Fail-open: any import/IO
+    error (e.g. ai_engineering not importable in a bare checkout) yields None so
+    the dashboard renders without a version line rather than breaking.
+    """
+    try:
+        from ai_engineering import __version__
+        from ai_engineering.version import resolve_latest_known
+        from ai_engineering.version.compare import is_newer
+
+        latest = resolve_latest_known()
+        if not isinstance(latest, str) or not latest:
+            return None
+        return {
+            "installed": __version__,
+            "latest": latest,
+            "update_available": bool(is_newer(latest, __version__)),
+        }
+    except Exception:
+        return None
+
+
 def _render_markdown(d: dict) -> str:
     lines: list[str] = []
     name = d.get("project_name") or "(unnamed)"
@@ -943,6 +969,16 @@ def _render_markdown(d: dict) -> str:
     else:
         state.append(f"hooks: {hh}")
     lines.append("> " + " · ".join(state))
+    vs = d.get("version_status") or {}
+    installed = vs.get("installed")
+    if installed:
+        if vs.get("update_available"):
+            lines.append(
+                f"> ◈ ai-engineering {installed} → {vs.get('latest')}"
+                " · run `ai-eng version upgrade`"
+            )
+        else:
+            lines.append(f"> ◈ ai-engineering {installed} · up to date")
     lines.append("")
     lines.append("---")
     lines.append("")
@@ -1098,6 +1134,7 @@ def build_dashboard(repo_root: Path | None = None) -> dict:
         "mission": _constitution_mission(root / "CONSTITUTION.md"),
         "manifest_summary": _manifest_summary(manifest),
         "compat_warnings": _compat_warnings(manifest),
+        "version_status": _version_status(),
     }
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0

--- a/src/ai_engineering/templates/.ai-engineering/scripts/session_bootstrap.py
+++ b/src/ai_engineering/templates/.ai-engineering/scripts/session_bootstrap.py
@@ -1146,6 +1146,14 @@ def build_dashboard(repo_root: Path | None = None) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # The dashboard markdown is inherently UTF-8 (◈ brand mark, box-drawing,
+    # em-dashes, →). Force a UTF-8 stdout so a legacy cp1252 console (Windows)
+    # never crashes with UnicodeEncodeError. Fail-open if reconfigure is absent.
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        with contextlib.suppress(ValueError, OSError):
+            reconfigure(encoding="utf-8")
+
     parser = argparse.ArgumentParser(
         prog="session_bootstrap",
         description="Emit /ai-start dashboard (deterministic, <3s incl. board).",

--- a/src/ai_engineering/version/__init__.py
+++ b/src/ai_engineering/version/__init__.py
@@ -4,6 +4,7 @@ Public API:
 - VersionStatus, VersionEntry, VersionRegistry — data models.
 - VersionCheckResult — check outcome.
 - load_registry, check_version, find_latest_version — checker functions.
+- resolve_latest_known — authoritative latest-version SSOT across signals.
 """
 
 from ai_engineering.version import cache, install_method, pypi, refresh
@@ -14,6 +15,7 @@ from ai_engineering.version.checker import (
     find_version_entry,
     load_registry,
 )
+from ai_engineering.version.latest import resolve_latest_known
 from ai_engineering.version.models import VersionEntry, VersionRegistry, VersionStatus
 
 __all__ = [
@@ -29,4 +31,5 @@ __all__ = [
     "load_registry",
     "pypi",
     "refresh",
+    "resolve_latest_known",
 ]

--- a/src/ai_engineering/version/latest.py
+++ b/src/ai_engineering/version/latest.py
@@ -1,0 +1,64 @@
+"""Authoritative "latest known release" resolver — single source of truth.
+
+Before this module two independent signals each claimed to be "the latest
+version" and disagreed in practice:
+
+- the bundled ``registry.json`` high-water mark (offline, known at build time,
+  read by :mod:`ai_engineering.version.checker`), and
+- the live PyPI poll cache (:mod:`ai_engineering.version.cache`, refreshed out
+  of band by :mod:`ai_engineering.version.refresh`).
+
+``ai-eng version`` rendered one from each, producing contradictory output, and
+the update notice consulted only the cache, so it stayed silent whenever the
+cache lagged the bundled registry. This resolver reconciles both into one value
+— the newer of the two by PEP 440 comparison — so every surface (the inline
+update notice, ``ai-eng version``, and the ``/ai-start`` dashboard) agrees.
+
+Fail-open (D-010-3): any IO/parse error yields ``None`` so the CLI hot path
+never breaks.
+"""
+
+from __future__ import annotations
+
+from ai_engineering.version import cache
+from ai_engineering.version.checker import find_latest_version, load_registry
+from ai_engineering.version.compare import is_newer
+
+
+def _registry_latest() -> str | None:
+    """Highest version in the bundled registry, or None on any error."""
+    try:
+        registry = load_registry()
+        if registry is None:
+            return None
+        latest = find_latest_version(registry)
+        return latest if isinstance(latest, str) and latest else None
+    except Exception:
+        return None
+
+
+def _cache_latest() -> str | None:
+    """Latest version from the PyPI poll cache, or None on any error."""
+    try:
+        latest = cache.read().get("latest")
+        return latest if isinstance(latest, str) and latest else None
+    except Exception:
+        return None
+
+
+def resolve_latest_known() -> str | None:
+    """Return the authoritative latest-known release across all signals.
+
+    Reconciles the bundled registry high-water mark and the live PyPI cache by
+    returning whichever is newer (PEP 440). Returns ``None`` only when neither
+    signal yields a usable version, so callers can fall back to "version
+    registry unavailable" semantics. Pure read; no side effects.
+    """
+    candidates = [v for v in (_registry_latest(), _cache_latest()) if v]
+    if not candidates:
+        return None
+    best = candidates[0]
+    for candidate in candidates[1:]:
+        if is_newer(candidate, best):
+            best = candidate
+    return best

--- a/tests/unit/cli_commands/test_version_upgrade.py
+++ b/tests/unit/cli_commands/test_version_upgrade.py
@@ -47,53 +47,63 @@ def _check_result(message: str = "0.1.0 (current)") -> VersionCheckResult:
 # ---------------------------------------------------------------------------
 
 
+_RESOLVE_TARGET = "ai_engineering.version.resolve_latest_known"
+
+
 class TestVersionShow:
-    """``ai-eng version`` shows installed version and lifecycle message."""
+    """``ai-eng version`` shows installed version + single-source status.
 
-    def test_shows_installed_and_message(self) -> None:
-        app = create_app()
-        with patch(_CHECK_TARGET, return_value=_check_result("0.1.0 (current)")):
-            result = runner.invoke(app, ["version"])
-        assert result.exit_code == 0
-        assert "0.1.0 (current)" in result.output
+    The latest figure now comes from the SSOT resolver, so the human surface
+    renders ONE coherent line (no more contradictory ``latest known release``
+    vs lifecycle ``message``).
+    """
 
-    def test_shows_cached_latest_when_available(self) -> None:
+    def test_shows_up_to_date_when_current(self) -> None:
         app = create_app()
         with (
             patch(_CHECK_TARGET, return_value=_check_result()),
-            patch(
-                "ai_engineering.version.cache.read",
-                return_value={"latest": "0.9.0"},
-            ),
+            patch(_RESOLVE_TARGET, return_value=__version__),
         ):
             result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
-        assert "0.9.0" in result.output
+        assert __version__ in result.output
+        assert "up to date" in result.output
 
-    def test_degrades_gracefully_when_cache_empty(self) -> None:
+    def test_shows_update_available_when_behind(self) -> None:
         app = create_app()
         with (
-            patch(_CHECK_TARGET, return_value=_check_result("0.1.0 (current)")),
-            patch("ai_engineering.version.cache.read", return_value={}),
+            patch(_CHECK_TARGET, return_value=_check_result()),
+            patch(_RESOLVE_TARGET, return_value="999.0.0"),
         ):
             result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
-        assert "0.1.0 (current)" in result.output
+        assert "999.0.0" in result.output
+        assert "update available" in result.output
+        assert "ai-eng version upgrade" in result.output
+
+    def test_degrades_gracefully_when_latest_unknown(self) -> None:
+        app = create_app()
+        with (
+            patch(_CHECK_TARGET, return_value=_check_result()),
+            patch(_RESOLVE_TARGET, return_value=None),
+        ):
+            result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+        assert "up to date" in result.output
 
     def test_json_mode_emits_envelope(self) -> None:
         app = create_app()
         with (
             patch(_CHECK_TARGET, return_value=_check_result()),
-            patch(
-                "ai_engineering.version.cache.read",
-                return_value={"latest": "0.9.0"},
-            ),
+            patch(_RESOLVE_TARGET, return_value="999.0.0"),
         ):
             result = runner.invoke(app, ["--json", "version"])
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["result"]["version"] == __version__
-        assert payload["result"]["latest"] == "0.9.0"
+        assert payload["result"]["latest"] == "999.0.0"
+        assert payload["result"]["update_available"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli_commands/test_version_upgrade.py
+++ b/tests/unit/cli_commands/test_version_upgrade.py
@@ -78,7 +78,7 @@ class TestVersionShow:
             result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert "999.0.0" in result.output
-        assert "update available" in result.output
+        # CliRunner captures stdout (non-tty) -> the pure-ASCII plain path.
         assert "ai-eng version upgrade" in result.output
 
     def test_degrades_gracefully_when_latest_unknown(self) -> None:

--- a/tests/unit/scripts/test_session_bootstrap.py
+++ b/tests/unit/scripts/test_session_bootstrap.py
@@ -636,6 +636,54 @@ class TestHooksUnverifiedHint:
         assert "regenerate-hooks-manifest.py" not in rendered
 
 
+@pytest.mark.unit
+class TestVersionUpdateBanner:
+    """The dashboard surfaces a single-source ``update available`` line.
+
+    Wired into the ``/ai-start`` dashboard so a new release shows at session
+    start. Silent when up to date or when the status is unknown (fail-open).
+    """
+
+    @staticmethod
+    def _d(version_status: dict | None) -> dict:
+        return {
+            "hooks_health": "ok",
+            "recent_events_7d": 0,
+            "version_status": version_status,
+        }
+
+    def test_renders_when_update_available(self) -> None:
+        mod = _load_session_bootstrap_module()
+        rendered = mod._render_markdown(
+            self._d({"installed": "0.9.1", "latest": "0.9.2", "update_available": True})
+        )
+        assert "◈ ai-engineering 0.9.1 → 0.9.2" in rendered
+        assert "ai-eng version upgrade" in rendered
+
+    def test_shows_version_when_up_to_date(self) -> None:
+        # The version is ALWAYS visible at session start — up to date shows the
+        # installed version, not silence (operators asked "where's the version").
+        mod = _load_session_bootstrap_module()
+        rendered = mod._render_markdown(
+            self._d({"installed": "0.9.2", "latest": "0.9.2", "update_available": False})
+        )
+        assert "◈ ai-engineering 0.9.2 · up to date" in rendered
+        assert "version upgrade" not in rendered
+
+    def test_silent_when_status_unknown(self) -> None:
+        # Fail-open: status unknowable (ai_engineering not importable) → no line.
+        mod = _load_session_bootstrap_module()
+        rendered = mod._render_markdown(self._d(None))
+        assert "◈ ai-engineering" not in rendered
+
+    def test_version_status_fails_open_without_package(self) -> None:
+        # _version_status swallows import/IO errors and returns None so the
+        # dashboard renders even when ai_engineering is not importable.
+        mod = _load_session_bootstrap_module()
+        result = mod._version_status()
+        assert result is None or isinstance(result, dict)
+
+
 # ---------------------------------------------------------------------------
 # T-14 RED: JSON output includes `surface_resolved`
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_notice_exempt.py
+++ b/tests/unit/test_cli_notice_exempt.py
@@ -46,6 +46,52 @@ def test_notice_suppressed_on_exempt_commands() -> None:
         assert _run_post_notice(cmd, json_mode=False) is False, cmd
 
 
+def _run_gated(*, json_mode: bool) -> bool:
+    """Return whether the shared gate would invoke the renderer."""
+    with (
+        patch("ai_engineering.cli_output.is_json_mode", return_value=json_mode),
+        patch(
+            "ai_engineering.cli_ui._load_version_check_config",
+            return_value=_EnabledVersionCheck(),
+        ),
+        patch("ai_engineering.cli_ui.maybe_render_update_notice") as render,
+    ):
+        cf._render_update_notice_gated()
+    return render.called
+
+
+def test_gated_renders_for_human() -> None:
+    assert _run_gated(json_mode=False) is True
+
+
+def test_gated_suppressed_in_json_mode() -> None:
+    assert _run_gated(json_mode=False) is True
+    assert _run_gated(json_mode=True) is False
+
+
+def test_bare_invocation_renders_notice() -> None:
+    """Bare ``ai-eng`` exits in the app callback, so it must render the notice
+    inline via the shared gate (not via the post-command boundary)."""
+    from typer.testing import CliRunner
+
+    from ai_engineering.cli_factory import create_app
+
+    with patch("ai_engineering.cli_factory._render_update_notice_gated") as gate:
+        CliRunner().invoke(create_app(), [])
+    gate.assert_called_once()
+
+
+def test_bare_invocation_suppressed_in_json_mode() -> None:
+    """``ai-eng --json`` (no subcommand) emits the command tree, never the notice."""
+    from typer.testing import CliRunner
+
+    from ai_engineering.cli_factory import create_app
+
+    with patch("ai_engineering.cli_factory._render_update_notice_gated") as gate:
+        CliRunner().invoke(create_app(), ["--json"])
+    gate.assert_not_called()
+
+
 def test_refresh_touches_checked_at_on_failure(tmp_path, monkeypatch) -> None:
     """spec-156 D-156-13: failed fetch advances checked_at (no respawn storm)."""
     from ai_engineering.version import cache, refresh

--- a/tests/unit/test_cli_ui_notice.py
+++ b/tests/unit/test_cli_ui_notice.py
@@ -33,6 +33,19 @@ def _clear_console(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _resolver_reads_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    # These tests exercise the RENDERER, not the SSOT reconciliation (covered in
+    # tests/unit/version/test_latest.py). Pin the resolver to the seeded cache so
+    # the bundled registry's real high-water mark never leaks into renderer
+    # assertions — the renderer looks up resolve_latest_known on the version
+    # package at call time, so patch it there.
+    monkeypatch.setattr(
+        "ai_engineering.version.resolve_latest_known",
+        lambda: cache.read().get("latest") or None,
+    )
+
+
 def _seed_cache(latest: str, *, shown_hours_ago: float | None = None) -> None:
     payload: dict = {
         "latest": latest,

--- a/tests/unit/test_version_lifecycle.py
+++ b/tests/unit/test_version_lifecycle.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
+from ai_engineering import __version__
 from ai_engineering.cli_factory import _EXEMPT_COMMANDS, create_app
 from ai_engineering.version.checker import VersionCheckResult
 from ai_engineering.version.models import VersionStatus
@@ -21,6 +22,7 @@ runner = CliRunner()
 # All patches target the canonical module where check_version is defined,
 # because cli_factory.py and core.py import it locally inside functions.
 _PATCH_TARGET = "ai_engineering.version.checker.check_version"
+_RESOLVE_TARGET = "ai_engineering.version.resolve_latest_known"
 
 
 def _make_check_result(
@@ -200,20 +202,24 @@ class TestVersionCmd:
     """Tests for the version command output."""
 
     def test_shows_lifecycle_status(self) -> None:
-        # Arrange
+        # Arrange: resolver agrees with installed -> coherent "up to date" line.
         app = create_app()
         result_mock = _make_check_result(
             is_current=True,
             status=VersionStatus.CURRENT,
-            message="0.1.0 (current)",
+            message=f"{__version__} (current)",
         )
 
         # Act
-        with patch(_PATCH_TARGET, return_value=result_mock):
+        with (
+            patch(_PATCH_TARGET, return_value=result_mock),
+            patch(_RESOLVE_TARGET, return_value=__version__),
+        ):
             result = runner.invoke(app, ["version"])
 
-        # Assert
-        assert "0.1.0 (current)" in result.output
+        # Assert: single-source status block, no contradictory dual-latest lines.
+        assert __version__ in result.output
+        assert "up to date" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/version/test_latest.py
+++ b/tests/unit/version/test_latest.py
@@ -1,0 +1,70 @@
+"""Tests for the latest-version SSOT resolver (``version.latest``).
+
+``resolve_latest_known`` reconciles two signals — the bundled registry
+high-water mark and the live PyPI cache — into one authoritative value (the
+newer of the two), so the inline notice, ``ai-eng version``, and the
+``/ai-start`` dashboard can never contradict each other. Fail-open on any error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_engineering.version import latest
+
+
+@pytest.fixture
+def _sources(monkeypatch: pytest.MonkeyPatch):
+    """Patch both signal sources; return a setter (registry, cache)."""
+
+    def _set(registry: str | None, cache: str | None) -> None:
+        monkeypatch.setattr(latest, "_registry_latest", lambda: registry)
+        monkeypatch.setattr(latest, "_cache_latest", lambda: cache)
+
+    return _set
+
+
+def test_returns_newer_when_cache_ahead(_sources) -> None:
+    _sources("0.9.0", "0.9.2")
+    assert latest.resolve_latest_known() == "0.9.2"
+
+
+def test_returns_newer_when_registry_ahead(_sources) -> None:
+    _sources("0.9.2", "0.9.0")
+    assert latest.resolve_latest_known() == "0.9.2"
+
+
+def test_registry_only(_sources) -> None:
+    _sources("0.9.2", None)
+    assert latest.resolve_latest_known() == "0.9.2"
+
+
+def test_cache_only(_sources) -> None:
+    _sources(None, "0.9.1")
+    assert latest.resolve_latest_known() == "0.9.1"
+
+
+def test_none_when_no_signal(_sources) -> None:
+    _sources(None, None)
+    assert latest.resolve_latest_known() is None
+
+
+def test_equal_sources_collapse(_sources) -> None:
+    _sources("0.9.2", "0.9.2")
+    assert latest.resolve_latest_known() == "0.9.2"
+
+
+def test_registry_helper_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a, **_k):
+        raise OSError("no package data")
+
+    monkeypatch.setattr("ai_engineering.version.latest.load_registry", _boom)
+    assert latest._registry_latest() is None
+
+
+def test_cache_helper_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> dict:
+        raise OSError("no home")
+
+    monkeypatch.setattr("ai_engineering.version.latest.cache.read", _boom)
+    assert latest._cache_latest() is None


### PR DESCRIPTION
## Summary

- **Fixes the dual-source-of-truth bug** behind `ai-eng version` and the update notice. Two independent "latest" signals — the bundled `registry.json` high-water mark and the live PyPI poll cache — disagreed in practice: `ai-eng version` printed contradictory lines (`outdated — latest is 0.9.2` beside `latest known release: 0.9.1`), and the inline notice consulted only the cache, so it stayed **silent whenever the cache lagged the registry** (it never fired). New `version.resolve_latest_known()` reconciles both into one value (the newer, PEP 440) — single source of truth for every surface.
- **Surfaces the version on every human entry point** (operators asked "where does the version show?"):
  - `ai-eng version` → coherent `◈` status block (`up to date` / `update available → X`); `--json` envelope adds `latest`, `update_available`, `status`.
  - bare `ai-eng` → notice on the no-subcommand help screen (was silent).
  - `/ai-start` dashboard → version line on **every** start (`◈ ai-engineering X · up to date`), upgrading to `◈ ai-engineering X → Y · run ai-eng version upgrade` when behind.
  - `install`/`update`/`status` keep the existing post-command notice.
- Automation / `--json` / hook hot paths stay silent. `/ai-brainstorm` deliberately excluded — a version nag mid-design-interrogation breaks focus.

Iterates spec-157 (version-update-notice). No active spec slot; placeholder unchanged.

## Test Plan

- `tests/unit/version/test_latest.py` (new) — SSOT reconciliation: newer-wins, registry-only, cache-only, none, fail-open on each signal.
- `tests/unit/test_cli_ui_notice.py` — renderer pinned to cache seam (SSOT covered separately).
- `tests/unit/cli_commands/test_version_upgrade.py` — `ai-eng version` up-to-date / update-available / unknown-latest / JSON envelope.
- `tests/unit/test_version_lifecycle.py` — coherent single-source status block.
- `tests/unit/test_cli_notice_exempt.py` — bare-`ai-eng` renders via shared gate; `--json` suppresses.
- `tests/unit/scripts/test_session_bootstrap.py` — dashboard version line (always-show + update CTA + fail-open).
- Template byte-parity + `hooks-manifest.json` re-pinned for the edited trusted script.
- Local gate green (ruff, ty, gitleaks, pytest-smoke, validate, docs); 147 targeted tests pass.

## Checklist

- [x] Lint (ruff) clean
- [x] Secret scan (gitleaks) clean
- [x] Tests added + green
- [x] CHANGELOG updated ([Unreleased])
- [x] No breaking changes (additive; `ai-eng version` human output redesigned, JSON envelope additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)