### PR TITLE
feat(version): bare ai-eng bypasses update-notice throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- feat(version): bare `ai-eng` (the no-subcommand help screen) now shows the
+  update notice on EVERY run, bypassing the once-per-`ttl_hours` show throttle
+  — it is an explicit "look at the tool" surface, like `ai-eng version`, not a
+  frequent automation command. Frequent commands (`install`/`update`/`status`/…)
+  keep the throttle so they never nag twice in a window. Threaded via a new
+  `force` flag on `maybe_render_update_notice` (bypasses only the throttle, not
+  the up-to-date / disabled / JSON gates).
+
 ## [0.10.0] - 2026-06-02
 
 ### Fixed

--- a/src/ai_engineering/cli_factory.py
+++ b/src/ai_engineering/cli_factory.py
@@ -150,12 +150,16 @@ def _maybe_render_post_command_notice() -> None:
     _render_update_notice_gated()
 
 
-def _render_update_notice_gated() -> None:
+def _render_update_notice_gated(*, force: bool = False) -> None:
     """Shared notice gate: JSON / env opt-out / manifest flag → cli_ui renderer.
 
     Extracted so both the post-command path and the bare ``ai-eng`` invocation
     (which exits in the app callback, never reaching the error boundary) render
     the notice through one set of gates. Fail-open: the renderer swallows errors.
+
+    ``force`` is threaded to the renderer to bypass the once-per-``ttl_hours``
+    show throttle — used by bare ``ai-eng`` so it behaves like an explicit
+    version check rather than a throttled frequent command.
     """
     import os
 
@@ -171,7 +175,7 @@ def _render_update_notice_gated() -> None:
     config = _load_version_check_config()
     if not getattr(config, "enabled", True):
         return
-    maybe_render_update_notice(config=config)
+    maybe_render_update_notice(config=config, force=force)
 
 
 def _app_callback(
@@ -231,8 +235,10 @@ def _app_callback(
             show_logo()
             typer.echo(ctx.get_help())
             # Bare `ai-eng` exits here, never reaching the error boundary, so
-            # render the update notice inline before exiting.
-            _render_update_notice_gated()
+            # render the update notice inline before exiting. force=True: it is
+            # an explicit "look at the tool" surface (like `ai-eng version`), so
+            # it bypasses the once-per-TTL throttle that gates frequent commands.
+            _render_update_notice_gated(force=True)
             raise typer.Exit(code=0)
 
     if not json_output and ctx.invoked_subcommand not in {"version", "internal"}:

--- a/src/ai_engineering/cli_ui.py
+++ b/src/ai_engineering/cli_ui.py
@@ -413,7 +413,7 @@ def _load_version_check_config() -> object:
         return VersionCheckConfig()
 
 
-def maybe_render_update_notice(config: object | None = None) -> None:
+def maybe_render_update_notice(config: object | None = None, *, force: bool = False) -> None:
     """Render a one-line "update available" notice when appropriate.
 
     Reads the version-check cache, the installed ``__version__``, and the
@@ -424,6 +424,11 @@ def maybe_render_update_notice(config: object | None = None) -> None:
     stale (older than TTL) it fires a detached background refresh and still
     renders from whatever the cache currently holds.
 
+    ``force`` bypasses ONLY the once-per-``ttl_hours`` show throttle (not the
+    up-to-date / disabled / JSON gates), for explicit "look at the tool"
+    surfaces like bare ``ai-eng`` that should behave like ``ai-eng version``
+    rather than a frequent automation command.
+
     When ``config`` (the resolved ``version_check`` block) is supplied by the
     caller, the manifest is NOT re-parsed here — the CLI hot path loads it
     once and threads it in (spec-157 review F7). When ``None`` the config is
@@ -431,12 +436,12 @@ def maybe_render_update_notice(config: object | None = None) -> None:
     never breaks.
     """
     try:
-        _render_update_notice(config)
+        _render_update_notice(config, force=force)
     except Exception:
         return
 
 
-def _render_update_notice(config: object | None = None) -> None:
+def _render_update_notice(config: object | None = None, *, force: bool = False) -> None:
     from ai_engineering.cli_output import is_json_mode
     from ai_engineering.version import cache, resolve_latest_known
     from ai_engineering.version.compare import is_newer
@@ -468,10 +473,12 @@ def _render_update_notice(config: object | None = None) -> None:
 
     data = cache.read()
 
-    # Throttle: suppress if shown within the TTL window.
+    # Throttle: suppress if shown within the TTL window — unless ``force`` (the
+    # caller is an explicit version-check surface, e.g. bare ``ai-eng``).
     last_shown = data.get("last_shown_at")
     if (
-        isinstance(last_shown, str)
+        not force
+        and isinstance(last_shown, str)
         and last_shown
         and not _shown_window_elapsed(last_shown, ttl_hours)
     ):

--- a/tests/unit/test_cli_notice_exempt.py
+++ b/tests/unit/test_cli_notice_exempt.py
@@ -71,14 +71,30 @@ def test_gated_suppressed_in_json_mode() -> None:
 
 def test_bare_invocation_renders_notice() -> None:
     """Bare ``ai-eng`` exits in the app callback, so it must render the notice
-    inline via the shared gate (not via the post-command boundary)."""
+    inline via the shared gate (not via the post-command boundary), and with
+    ``force=True`` so it bypasses the throttle like an explicit version check."""
     from typer.testing import CliRunner
 
     from ai_engineering.cli_factory import create_app
 
     with patch("ai_engineering.cli_factory._render_update_notice_gated") as gate:
         CliRunner().invoke(create_app(), [])
-    gate.assert_called_once()
+    gate.assert_called_once_with(force=True)
+
+
+def test_gate_threads_force_to_renderer() -> None:
+    """The shared gate forwards ``force`` to the cli_ui renderer."""
+    with (
+        patch("ai_engineering.cli_output.is_json_mode", return_value=False),
+        patch(
+            "ai_engineering.cli_ui._load_version_check_config",
+            return_value=_EnabledVersionCheck(),
+        ),
+        patch("ai_engineering.cli_ui.maybe_render_update_notice") as render,
+    ):
+        cf._render_update_notice_gated(force=True)
+    render.assert_called_once()
+    assert render.call_args.kwargs.get("force") is True
 
 
 def test_bare_invocation_suppressed_in_json_mode() -> None:

--- a/tests/unit/test_cli_ui_notice.py
+++ b/tests/unit/test_cli_ui_notice.py
@@ -90,6 +90,23 @@ def test_silent_when_throttled(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     assert capsys.readouterr().err == ""
 
 
+def test_force_bypasses_throttle(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    # Bare `ai-eng` passes force=True so it renders even within the throttle
+    # window (explicit version-check surface, like `ai-eng version`).
+    monkeypatch.setattr(cli_ui, "__version__", "0.1.0")
+    _seed_cache("0.9.0", shown_hours_ago=1.0)  # within 24h window
+    cli_ui.maybe_render_update_notice(force=True)
+    assert "0.9.0" in capsys.readouterr().err
+
+
+def test_force_still_silent_when_current(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    # force bypasses ONLY the throttle, never the up-to-date gate.
+    monkeypatch.setattr(cli_ui, "__version__", "0.9.0")
+    _seed_cache("0.9.0")
+    cli_ui.maybe_render_update_notice(force=True)
+    assert capsys.readouterr().err == ""
+
+
 def test_renders_when_throttle_expired(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     monkeypatch.setattr(cli_ui, "__version__", "0.1.0")
     _seed_cache("0.9.0", shown_hours_ago=48.0)  # past 24h window


### PR DESCRIPTION
## Summary

- Bare `ai-eng` (the no-subcommand help screen) now shows the update notice on **every** run, bypassing the once-per-`ttl_hours` throttle. It is an explicit "look at the tool" surface — like `ai-eng version` — not a frequent automation command, so it should always tell you when you're behind.
- Frequent commands (`install`/`update`/`status`/…) **keep** the throttle so they never nag twice within a window.
- Implemented as a `force` flag threaded `_app_callback (bare) → _render_update_notice_gated → maybe_render_update_notice → _render_update_notice`. `force` bypasses **only** the show throttle — never the up-to-date, `version_check.enabled`, `AIENG_NO_UPDATE_CHECK`, or JSON-mode gates.

Follow-up to #567 (version-notice SSOT + surfaces): operator observed bare `ai-eng` staying silent because the notice had already fired on an earlier command in the 24h window.

## Test Plan

- `tests/unit/test_cli_ui_notice.py`: `test_force_bypasses_throttle` (renders within the throttle window), `test_force_still_silent_when_current` (force never overrides the up-to-date gate).
- `tests/unit/test_cli_notice_exempt.py`: `test_bare_invocation_renders_notice` asserts `force=True`; `test_gate_threads_force_to_renderer` asserts the gate forwards it.
- Live: seeded a just-shown + outdated cache → bare `ai-eng` renders, `ai-eng status` stays throttled/silent. 49 targeted tests green; ruff clean; local gate exit 0.

## Checklist

- [x] Lint (ruff) clean
- [x] Tests added + green
- [x] CHANGELOG updated ([Unreleased])
- [x] No breaking changes (additive flag, default `force=False` preserves existing throttle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)