### PR TITLE
feat(spec-163): layer-map import-linter gate + session-end instinct consolidation (Workstreams B+C)

### DIFF
--- a/.agents/skills/ai-branch-cleanup/SKILL.md
+++ b/.agents/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/.agents/skills/ai-session-watch/SKILL.md
+++ b/.agents/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/.agents/skills/ai-start/SKILL.md
+++ b/.agents/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet

--- a/.ai-engineering/README.md
+++ b/.ai-engineering/README.md
@@ -108,7 +108,7 @@ Invoke a skill with `/ai-<name>` in your IDE agent surface.
 | `/ai-spec-draft` | Produces a 14-section spec brief in `.ai-engineering/specs/drafts/<topic>-brief.md` so an operator can hand off a fully-researched problem statement to `/ai-brainstorm`. |
 | `/ai-sprint` | Manages sprint lifecycle: plans a new sprint from backlog, runs data-driven retros comparing planned vs shipped, checks mid-sprint goal status, generates sprint review presentations. |
 | `/ai-standup` | Generates standup notes and status updates from actual git commits and PRs — never reconstructed from memory. |
-| `/ai-start` | Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. |
+| `/ai-start` | Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. |
 | `/ai-support` | Investigates customer-reported issues with structure: reproduces, traces to code, documents resolution, builds a searchable knowledge base organized by ticket ID. |
 | `/ai-test` | Writes tests, enforces TDD (RED-GREEN-REFACTOR), analyzes coverage gaps, defines test strategy across Python, TypeScript, .NET, Rust, Go. |
 | `/ai-verify` | Use when verification with evidence is needed — not assumptions. |

--- a/.ai-engineering/solution-intent.md
+++ b/.ai-engineering/solution-intent.md
@@ -13,7 +13,7 @@
 |-------|-------|
 | Name | ai-engineering |
 | Organization | arcasilesgroup/ai-engineering |
-| Versions | 0.4.0 (framework), 2.0 (manifest schema), 0.1.0 (pyproject) |
+| Versions | 0.10.1 (framework), 2.0 (manifest schema), 0.10.1 (pyproject) |
 | Description | AI governance framework for secure software delivery |
 | License | MIT |
 | Python | >= 3.11 |
@@ -258,10 +258,10 @@ graph TB
     end
 
     subgraph Infra["Infrastructure"]
-        pipeline["pipeline<br/>CI/CD compliance"]
         updater["updater<br/>Ownership-safe updates"]
         hooks["hooks<br/>Git hook management"]
         detector["detector<br/>Tool readiness detection"]
+        prereqs["prereqs<br/>SDK prerequisite probes"]
         version["version<br/>Version lifecycle"]
     end
 
@@ -283,6 +283,11 @@ graph TB
     Policy --> state
     Platform --> vcs
 ```
+
+> Not graphed as layer components (spec-163 D-163-08): `config` and
+> `prereqs` are shared/Infra utilities, and `templates/` is installer
+> content **data** (Markdown/YAML/JSON shipped to installs), not a code
+> layer. They ride outside the component graph above by design.
 
 | Layer | Component | Technology |
 |-------|-----------|------------|
@@ -716,7 +721,7 @@ No active spec. Run `/ai-brainstorm` to start a new spec.
 
 | ID | Title | Category | Criticality |
 |----|-------|----------|-------------|
-| DEC-001 | Flat skill layout with `ai-` namespace | architecture | high |
+| DEC-001 | `ai-` skill namespace: flat top-level dirs, with nested `handlers/`/`references/`/`scripts/`/`evals/` subdirs permitted (amended spec-163 D-163-04) | architecture | high |
 | DEC-003 | Plan/Execute split with Spec-as-Gate | governance | high |
 | DEC-004 | Flat main with feature branches (no phase branching) | governance | medium |
 | DEC-005 | Multi-IDE governance via single-source generation | architecture | medium |
@@ -739,6 +744,8 @@ No active spec. Run `/ai-brainstorm` to start a new spec.
 | DEC-026 | contexts/orgs eliminated -- no implementation | architecture | low |
 | DEC-027 | contracts replaced by constitution + CLAUDE.md | architecture | medium |
 | DEC-028 | Canonical framework-events stream + agentsview | architecture | high |
+| DEC-029 | Layer-map enforced via import-linter `forbidden` upward-fences with a baseline; gate blocks NEW upward imports, current 43 edges baselined (doctor.* inherent-accepted, rest tech-debt). spec-163 #496/#497 D-163-03/07 | architecture | high |
+| DEC-030 | Complexity thresholds (C901/PLR0912/13/15) are ADVISORY (non-blocking); the largest debt carries `audit:exempt`; offenders reduced opportunistically, never mass-refactored. spec-163 #495 D-163-05 | governance | low |
 
 ---
 

--- a/.ai-engineering/specs/spec.md
+++ b/.ai-engineering/specs/spec.md
@@ -83,6 +83,12 @@ documented posture on complexity thresholds.
    refactor.
 9. **No regressions** — `/ai-verify` is GO on the changeset; the secrets,
    lint, and test gates stay green.
+10. **Workstream C — session-end instinct consolidation.**
+    `/ai-branch-cleanup` runs `/ai-session-watch --review` (gated on
+    `observations.yml`, fail-open) before pruning, closing the no-commit/
+    no-PR consolidation gap; the stale `/ai-start` description and
+    `/ai-session-watch` Step 1 contradictions are corrected at their
+    canonical source and propagated via `ai-eng dev sync`.
 
 ## Non-Goals
 
@@ -103,6 +109,10 @@ documented posture on complexity thresholds.
 - **Mass complexity refactor** of all 189 C901/PLR findings (#495).
 - **Touching hook scripts** in a way that churns `hooks-manifest.json`
   unless strictly required.
+- **Workstream C scope guard** — no hook-script edits (no SessionEnd
+  drain path: `--review` is LLM-driven), no `observe.py`/
+  `instinct-observe.py` rename, no `state/instincts.py` dual-writer
+  changes. C is skill-text + `dev sync` only (D-163-10/11).
 
 ## Decisions
 
@@ -188,6 +198,38 @@ The five instinct proposals are out of scope; handle them via
 (promote/reject/defer), not code defects. Mixing a judgment-grading pass
 into a code-fix spec muddies both. Several likely overlap shipped
 spec-147/spec-162 work and warrant a dedicated trace.
+
+### D-163-10 — Session-end instinct consolidation belongs in `/ai-branch-cleanup`
+Add a fail-open step to `/ai-branch-cleanup`: if
+`.ai-engineering/observations/observations.yml` exists, run
+`/ai-session-watch --review` before pruning branches. Keep the existing
+`/ai-pr` Step 2 and `/ai-commit` Step 2 gates unchanged.
+**Rationale**: An evidence-backed audit (2026-06-03) confirmed the
+LLM-rich `--review` consolidation — the ONLY path that writes the
+`corrections` family — fires today only via `/ai-commit` or `/ai-pr`. A
+session that ends without a commit/PR (exploration, read-only, tidy-up)
+loses all conversation-level `corrections` permanently; the Stop-hook
+`extract_instincts()` only salvages structural recoveries+workflows. A
+SessionEnd hook CANNOT fix this — `--review` is LLM-driven and hooks run
+detached Python with no conversation access. `/ai-branch-cleanup` is the
+canonical end-of-session skill (auto-invoked by `/ai-pr` after merge, run
+manually as "tidy up"), has an LLM in the loop, and currently has zero
+consolidation step — making it the correct home for the no-PR path. The
+`observations.yml`-existence gate matches the established `/ai-pr` /
+`/ai-commit` contract and is OS-portable skill text (no hook fork).
+
+### D-163-11 — Repair the two post-spec-162 stale skill contradictions
+Fix the `/ai-start` description frontmatter (still claims "activates
+session observation", contradicting its own body that delegates to
+always-on hooks) and the `/ai-session-watch` Workflow Step 1 (says
+"invoke at session start to enter listening mode", conflicting with the
+always-on-hooks contract). Edit the canonical `.claude/skills/*/SKILL.md`
+only, then `ai-eng dev sync` to regenerate mirrors.
+**Rationale**: Both are stale artefacts left by the spec-162 refactor
+that removed observation-activation from `/ai-start`. They actively
+mislead operators about how observation works. Editing the canonical
+source + `dev sync` is the mandated multi-IDE propagation path
+(CLAUDE.md §12); hand-editing mirrors would be overwritten.
 
 ## Risks
 

--- a/.claude/skills/ai-branch-cleanup/SKILL.md
+++ b/.claude/skills/ai-branch-cleanup/SKILL.md
@@ -35,6 +35,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -151,7 +165,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/.claude/skills/ai-session-watch/SKILL.md
+++ b/.claude/skills/ai-session-watch/SKILL.md
@@ -20,7 +20,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/.claude/skills/ai-start/SKILL.md
+++ b/.claude/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 model_tier: sonnet
 argument-hint: ""

--- a/.codex/skills/ai-branch-cleanup/SKILL.md
+++ b/.codex/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/.codex/skills/ai-session-watch/SKILL.md
+++ b/.codex/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/.codex/skills/ai-start/SKILL.md
+++ b/.codex/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet

--- a/.github/skills/ai-branch-cleanup/SKILL.md
+++ b/.github/skills/ai-branch-cleanup/SKILL.md
@@ -41,6 +41,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -157,7 +171,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/.github/skills/ai-session-watch/SKILL.md
+++ b/.github/skills/ai-session-watch/SKILL.md
@@ -26,7 +26,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/.github/skills/ai-start/SKILL.md
+++ b/.github/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 mode: agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,131 @@ ignore_imports = [
   "ai_engineering.validator._shared -> ai_engineering.installer.templates",
 ]
 
+# spec-163 #496/#497 — solution-intent.md §3.1 layer-map enforcement.
+# The SI graph is CLI > {Policy, Platform} > Core > {Infra, Auxiliary}.
+# Modelled as three ``forbidden`` upward-fences (not one ``layers`` contract)
+# so legitimate intra-layer imports — e.g. installer -> state within Core —
+# are NOT flagged, while every UPWARD import is. Each fence carries a baseline
+# of the current violations (D-163-07): the gate BLOCKS any NEW upward import;
+# the baselined edges are documented in the spec-163 layer-fence decision as
+# either inherent-and-accepted (e.g. doctor orchestrating installer phases) or
+# tech-debt to invert in a follow-up. Same-tier cycles (e.g. policy <-> verify)
+# are DEC-accepted, not gated here. Enforcement rides the existing
+# ``lint-imports`` + ``tests/architecture/test_hexagonal.py`` path.
+
+[[tool.importlinter.contracts]]
+name = "layer fence: Infra/Auxiliary must not import upward (spec-163 #496)"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+  "ai_engineering.updater",
+  "ai_engineering.hooks",
+  "ai_engineering.detector",
+  "ai_engineering.version",
+  "ai_engineering.git",
+  "ai_engineering.credentials",
+  "ai_engineering.doctor",
+  "ai_engineering.skills",
+  "ai_engineering.issues",
+]
+forbidden_modules = [
+  "ai_engineering.installer",
+  "ai_engineering.vcs",
+  "ai_engineering.state",
+  "ai_engineering.maintenance",
+  "ai_engineering.lib",
+  "ai_engineering.policy",
+  "ai_engineering.validator",
+  "ai_engineering.verify",
+  "ai_engineering.platforms",
+  "ai_engineering.release",
+  "ai_engineering.cli_commands",
+]
+ignore_imports = [
+  "ai_engineering.detector.readiness -> ai_engineering.installer.tools",
+  "ai_engineering.detector.readiness -> ai_engineering.state.service",
+  "ai_engineering.doctor.models -> ai_engineering.state.models",
+  "ai_engineering.doctor.phases.detect -> ai_engineering.installer.autodetect",
+  "ai_engineering.doctor.phases.detect -> ai_engineering.state.service",
+  "ai_engineering.doctor.phases.ide_config -> ai_engineering.installer.templates",
+  "ai_engineering.doctor.phases.scripts -> ai_engineering.installer.phases",
+  "ai_engineering.doctor.phases.scripts -> ai_engineering.installer.phases.scripts",
+  "ai_engineering.doctor.phases.state -> ai_engineering.state.audit_chain",
+  "ai_engineering.doctor.phases.state -> ai_engineering.state.defaults",
+  "ai_engineering.doctor.phases.state -> ai_engineering.state.io",
+  "ai_engineering.doctor.phases.state -> ai_engineering.state.models",
+  "ai_engineering.doctor.phases.state -> ai_engineering.state.repository",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.installer.tool_registry",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.installer.tools",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.installer.user_scope_install",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.state.manifest",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.state.models",
+  "ai_engineering.doctor.phases.tools -> ai_engineering.state.service",
+  "ai_engineering.doctor.service -> ai_engineering.installer.phases",
+  "ai_engineering.doctor.service -> ai_engineering.state.observability",
+  "ai_engineering.doctor.service -> ai_engineering.state.service",
+  "ai_engineering.hooks.asset_runtime -> ai_engineering.installer.templates",
+  "ai_engineering.hooks.manager -> ai_engineering.state.manifest",
+  "ai_engineering.hooks.manager -> ai_engineering.state.models",
+  "ai_engineering.hooks.manager -> ai_engineering.state.repository",
+  "ai_engineering.hooks.manager -> ai_engineering.state.service",
+  "ai_engineering.issues.service -> ai_engineering.state.work_plane",
+  "ai_engineering.issues.service -> ai_engineering.vcs.factory",
+  "ai_engineering.issues.service -> ai_engineering.vcs.protocol",
+  "ai_engineering.updater.service -> ai_engineering.installer.templates",
+  "ai_engineering.updater.service -> ai_engineering.lib.path_safety",
+  "ai_engineering.updater.service -> ai_engineering.state.defaults",
+  "ai_engineering.updater.service -> ai_engineering.state.models",
+  "ai_engineering.updater.service -> ai_engineering.state.observability",
+  "ai_engineering.updater.service -> ai_engineering.state.repository",
+  "ai_engineering.updater.service -> ai_engineering.state.service",
+  "ai_engineering.updater.state_db_export -> ai_engineering.state.defaults",
+  "ai_engineering.updater.state_db_export -> ai_engineering.state.models",
+  "ai_engineering.updater.state_db_export -> ai_engineering.state.repository",
+  "ai_engineering.updater.state_db_export -> ai_engineering.state.service",
+]
+
+[[tool.importlinter.contracts]]
+name = "layer fence: Core must not import Policy/Platform/CLI (spec-163 #496)"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+  "ai_engineering.installer",
+  "ai_engineering.vcs",
+  "ai_engineering.state",
+  "ai_engineering.maintenance",
+  "ai_engineering.lib",
+]
+forbidden_modules = [
+  "ai_engineering.policy",
+  "ai_engineering.validator",
+  "ai_engineering.verify",
+  "ai_engineering.platforms",
+  "ai_engineering.release",
+  "ai_engineering.cli_commands",
+]
+ignore_imports = [
+  "ai_engineering.installer.phases.sdk_prereqs -> ai_engineering.cli_commands._exit_codes",
+  "ai_engineering.state.audit -> ai_engineering.policy.gates",
+]
+
+[[tool.importlinter.contracts]]
+name = "layer fence: Policy/Platform must not import CLI (spec-163 #496)"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+  "ai_engineering.policy",
+  "ai_engineering.validator",
+  "ai_engineering.verify",
+  "ai_engineering.platforms",
+  "ai_engineering.release",
+]
+forbidden_modules = [
+  "ai_engineering.cli_commands",
+]
+ignore_imports = [
+]
+
 [tool.hatch.build.targets.wheel]
 # spec-127 M1: top-level conformance lint packages live under ``tools/``
 # but ship as top-level distribution packages (``skill_domain``,

--- a/src/ai_engineering/templates/.ai-engineering/README.md
+++ b/src/ai_engineering/templates/.ai-engineering/README.md
@@ -108,7 +108,7 @@ Invoke a skill with `/ai-<name>` in your IDE agent surface.
 | `/ai-spec-draft` | Produces a 14-section spec brief in `.ai-engineering/specs/drafts/<topic>-brief.md` so an operator can hand off a fully-researched problem statement to `/ai-brainstorm`. |
 | `/ai-sprint` | Manages sprint lifecycle: plans a new sprint from backlog, runs data-driven retros comparing planned vs shipped, checks mid-sprint goal status, generates sprint review presentations. |
 | `/ai-standup` | Generates standup notes and status updates from actual git commits and PRs — never reconstructed from memory. |
-| `/ai-start` | Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. |
+| `/ai-start` | Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. |
 | `/ai-support` | Investigates customer-reported issues with structure: reproduces, traces to code, documents resolution, builds a searchable knowledge base organized by ticket ID. |
 | `/ai-test` | Writes tests, enforces TDD (RED-GREEN-REFACTOR), analyzes coverage gaps, defines test strategy across Python, TypeScript, .NET, Rust, Go. |
 | `/ai-verify` | Use when verification with evidence is needed — not assumptions. |

--- a/src/ai_engineering/templates/project/.agents/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.agents/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.agents/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.agents/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.agents/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.agents/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet

--- a/src/ai_engineering/templates/project/.claude/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-branch-cleanup/SKILL.md
@@ -35,6 +35,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -151,7 +165,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.claude/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-session-watch/SKILL.md
@@ -20,7 +20,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.claude/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.claude/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 model_tier: sonnet
 argument-hint: ""

--- a/src/ai_engineering/templates/project/.codex/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.codex/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.codex/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.codex/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.codex/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.codex/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet

--- a/src/ai_engineering/templates/project/.cursor/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.cursor/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.cursor/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.cursor/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.cursor/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.cursor/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet

--- a/src/ai_engineering/templates/project/.github/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.github/skills/ai-branch-cleanup/SKILL.md
@@ -41,6 +41,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -157,7 +171,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.github/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.github/skills/ai-session-watch/SKILL.md
@@ -26,7 +26,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.github/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.github/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 mode: agent

--- a/src/ai_engineering/templates/project/.opencode/commands/ai-start.md
+++ b/src/ai_engineering/templates/project/.opencode/commands/ai-start.md
@@ -1,5 +1,5 @@
 ---
-description: 'Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for ''hello'', ''lets start'', ''good morning'', ''whats the status'', ''get me up to speed'', ''I am back''. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead.'
+description: 'Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for ''hello'', ''lets start'', ''good morning'', ''whats the status'', ''get me up to speed'', ''I am back''. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead.'
 mirror_family: opencode-commands
 generated_by: ai-eng sync
 canonical_source: .claude/skills/ai-start/SKILL.md

--- a/src/ai_engineering/templates/project/.opencode/skills/ai-branch-cleanup/SKILL.md
+++ b/src/ai_engineering/templates/project/.opencode/skills/ai-branch-cleanup/SKILL.md
@@ -40,6 +40,20 @@ Full repository hygiene: safely migrate to the default branch, delete merged and
 
 Default (no flags) is equivalent to `--all`: runs sync, branch cleanup, and report.
 
+### Phase 0a: Instinct consolidation (default / `--all`, fail-open)
+
+0. **Consolidate session learnings BEFORE switching branches** -- if
+   `.ai-engineering/observations/observations.yml` exists, run
+   `/ai-session-watch --review` to fold this session's observations
+   (especially the LLM-only `corrections` family) into the corpus. This
+   closes the no-commit/no-PR gap: a session that ends at tidy-up time —
+   without a `/ai-commit` or `/ai-pr` having run `--review` — still
+   consolidates its learnings instead of losing them. Skip silently when
+   the file is absent (fail-open) or when a single-purpose flag
+   (`--branches` / `--sync` / `--specs` / `--runtime` /
+   `--consolidate-spec`) was passed without `--all`. Mirrors the
+   `/ai-pr` Step 2 and `/ai-commit` Step 2 gate.
+
 ### Phase 0: Safe Migration (`--sync` or `--all`)
 
 1. **Detect default branch** -- `git symbolic-ref refs/remotes/origin/HEAD` (main or master).
@@ -156,7 +170,7 @@ Skips sync and spec sweep; runs branch classification + delete + report only.
 
 ## Integration
 
-Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
+Called by: `/ai-pr` (auto after merge), `/ai-start` (session bootstrap). Calls: `/ai-session-watch --review` (Phase 0a, fail-open instinct consolidation), `git`, `python .ai-engineering/scripts/spec_lifecycle.py sweep`, `python .ai-engineering/scripts/runtime_rotate.py`. See also: `/ai-brainstorm` (run before new spec), `/ai-simplify` (code-level cleanup).
 
 ## References
 

--- a/src/ai_engineering/templates/project/.opencode/skills/ai-session-watch/SKILL.md
+++ b/src/ai_engineering/templates/project/.opencode/skills/ai-session-watch/SKILL.md
@@ -25,7 +25,7 @@ Project-local instinct learning for `ai-engineering`. Two modes: passive observa
 
 ## Workflow
 
-1. Session start: invoke `/ai-session-watch` to enter listening mode.
+1. Observation is **always-on** via the `instinct-observe.py` hooks (PreToolUse + PostToolUse) — no manual activation, and `/ai-start` does NOT start it. Invoking bare `/ai-session-watch` is optional and only emits a one-line acknowledgement.
 2. As work happens, the model passively notes corrections, error recoveries, and skill-invocation sequences.
 3. Before a commit or PR, invoke `/ai-session-watch --review` to run the 5-step consolidation: extract → enrich → write → evaluate → create work items.
 4. High-confidence proposals (>= 0.7, evidence >= 3) auto-generate work items via `gh issue create` or `az boards work-item create`.

--- a/src/ai_engineering/templates/project/.opencode/skills/ai-start/SKILL.md
+++ b/src/ai_engineering/templates/project/.opencode/skills/ai-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-start
-description: "Bootstraps a coding session: loads project context, activates session observation, displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
+description: "Bootstraps a coding session: loads project context and displays a welcome dashboard with recent activity, board items, and available commands. Trigger for 'hello', 'lets start', 'good morning', 'whats the status', 'get me up to speed', 'I am back'. Also invokable mid-session to re-bootstrap. Not for human onboarding; use /ai-onboard instead. Not for governance review; use /ai-governance instead."
 effort: mid
 argument-hint: 
 model_tier: sonnet


### PR DESCRIPTION
Continues **spec-163** (Wave 1 shipped in #579). Bundles two workstreams per operator request (single branch / single PR).

---

## Workstream B — architecture-drift CI gate (#496/#497/#498/#421/#495)

Converts the recurring weekly-scan architecture drift into a **PR-time gate**, and resyncs `solution-intent.md` to disk.

**B1 — layer-fence gate.** Adds three `import-linter` `forbidden` upward-fences to the existing `[tool.importlinter]` block, modelling the SI §3.1 layering **CLI > {Policy,Platform} > Core > {Infra,Auxiliary}**. `allow_indirect_imports` keeps each fence to *direct* upward edges; the **43 current violations are baselined** so the gate is green now and **blocks any NEW upward import**. Rides the existing `lint-imports` + `tests/architecture/test_hexagonal.py` CI path — no new wiring.
- Baseline classified (D-163-07): `doctor.*` edges are **inherent** Auxiliary→Core orchestration (accepted); `updater`/`hooks`/`detector`/`issues` edges are **tech-debt** to invert via ports in a follow-up.
- Same-tier cycles (`policy↔verify`) are DEC-accepted, not gated.
- **B2/B3** (the violations + cycles themselves) are resolved by baseline + DEC acceptance per D-163-07 — no risky big-bang rewires.

> ℹ️ Correction to the original plan: import-linter was *already adopted* (spec-132 hexagonal contract); B1 **extends** it with the layer map rather than scaffolding from zero.

**B4 — solution-intent sync.** Removes the ghost `pipeline` node (no such package), adds `prereqs` to Infra, notes `config`/`templates` ride outside the component graph (data), bumps the version banner `0.4.0 → 0.10.1`, amends **DEC-001** to permit nested skill subdirs (resolves the #446 flat-vs-nested contradiction).

**B5 — tech-debt posture.** Records **DEC-030**: complexity thresholds are advisory (non-blocking), largest debt carries `audit:exempt`, offenders reduced opportunistically — never mass-refactored. No code refactor.

---

## Workstream C — session-end instinct consolidation + stale-skill repair

Closes a gap surfaced by an **11-agent instinct/observation audit** (7/7 claims verified) run this session.

**D-163-10 — gap fix.** `/ai-branch-cleanup` gains **Phase 0a**: if `.ai-engineering/observations/observations.yml` exists, run `/ai-session-watch --review` before pruning (fail-open). Today the LLM-rich `--review` — the **only** path that writes the `corrections` family — fires only via `/ai-commit` or `/ai-pr`; a session ending at tidy-up time without a commit/PR loses all conversation-level corrections. A SessionEnd *hook* cannot fix this (`--review` is LLM-driven; hooks run detached). branch-cleanup is the canonical end-of-session skill (auto-run by `/ai-pr` after merge) and had zero consolidation step.

**D-163-11 — stale-skill repair.** Removes the false "activates session observation" claim from the `/ai-start` description (its body already delegates to always-on hooks), and rewrites `/ai-session-watch` Workflow Step 1 (was "invoke at session start to enter listening mode", contradicting the always-on-hooks contract). Both are spec-162 refactor residue.

Propagation: edited canonical `.claude/skills/*/SKILL.md` only → `ai-eng dev sync` regenerated `.codex`/`.github`/`.agents`/`.cursor`/`.opencode` mirrors + install templates; regenerated the template README catalog. **Scope guard:** no hook-script edits, no `observe.py` rename, no `state/instincts.py` change — skill-text + dev sync only.

---

## Verification
- `lint-imports`: **4 contracts kept / 0 broken**; `test_hexagonal` green
- **329 tests pass** (architecture + validator + docs + capability-catalog); 34 surface/mirror parity green
- `spec_lint` clean on the extended spec

Closes #496
Closes #497
Closes #498
Closes #421
Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)