### PR TITLE
test(ci): accept actions/cache@v5 in the gate-cache schema gate (unblocks #568)

### DIFF
--- a/tests/integration/test_ci_cache_key_schema.py
+++ b/tests/integration/test_ci_cache_key_schema.py
@@ -135,20 +135,22 @@ def _iter_cache_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
     return cache_steps
 
 
-def _is_v4(uses: str, *, workflow_path: Path | None = None) -> bool:
-    """``actions/cache@v4`` accepted as either an explicit tag or a
-    SHA-pinned form annotated with ``# v4.x.y`` in the workflow file.
+def _is_supported_cache_version(uses: str, *, workflow_path: Path | None = None) -> bool:
+    """``actions/cache@v4`` or ``@v5`` accepted, as either an explicit tag or
+    a SHA-pinned form annotated with ``# v4.x.y`` / ``# v5.x.y``.
 
-    Spec-110 (Article VI supply chain hardening) pinned all GitHub
-    Actions to commit SHAs with a trailing ``# v<version>`` comment
-    (e.g. ``actions/cache@<sha> # v4.3.0``). PyYAML's ``safe_load``
-    strips the comment, so when a SHA-pinned form is detected this
-    helper falls back to scanning the raw workflow text for a line
-    that contains both the SHA and the ``# v4`` annotation. Without
-    that fallback, the test would force an unpinned tag (`@v4`) and
-    contradict Article VI.
+    v4 was the original gate-cache pin (D-104-03); v5 is its maintained
+    successor after GitHub deprecated the v4 cache-service backend. v5 is
+    key+path compatible with the ``gate_cache`` storage contract, so the
+    dependabot v4->v5 bump is accepted (spec-163). Spec-110 (Article VI
+    supply-chain hardening) pins all Actions to commit SHAs with a trailing
+    ``# v<version>`` comment (e.g. ``actions/cache@<sha> # v5.0.5``). PyYAML's
+    ``safe_load`` strips the comment, so for a SHA-pinned form this helper
+    scans the raw workflow text for a line carrying both the SHA and a
+    ``# v4``/``# v5`` annotation. Without that fallback, the test would force
+    an unpinned tag and contradict Article VI.
     """
-    if uses.startswith(f"{CACHE_ACTION_PREFIX}v4"):
+    if uses.startswith((f"{CACHE_ACTION_PREFIX}v4", f"{CACHE_ACTION_PREFIX}v5")):
         return True
     if workflow_path is None:
         return False
@@ -157,7 +159,9 @@ def _is_v4(uses: str, *, workflow_path: Path | None = None) -> bool:
         return False
     raw = workflow_path.read_text(encoding="utf-8")
     pin_marker = f"{CACHE_ACTION_PREFIX}{sha}"
-    return any(pin_marker in line and "# v4" in line for line in raw.splitlines())
+    return any(
+        pin_marker in line and ("# v4" in line or "# v5" in line) for line in raw.splitlines()
+    )
 
 
 def _tier_segment(cache_entry: str) -> str:
@@ -265,11 +269,15 @@ def test_ci_check_yml_has_cache_step() -> None:
         f"{CI_CHECK_PATH.relative_to(REPO_ROOT)} has no actions/cache@v4 step. "
         "T-8.2 must add one for security/test jobs."
     )
-    v4_steps = [s for s in cache_steps if _is_v4(s["uses"], workflow_path=CI_CHECK_PATH)]
+    v4_steps = [
+        s
+        for s in cache_steps
+        if _is_supported_cache_version(s["uses"], workflow_path=CI_CHECK_PATH)
+    ]
     assert v4_steps, (
-        f"{CI_CHECK_PATH.relative_to(REPO_ROOT)} cache step is not pinned to v4. "
+        f"{CI_CHECK_PATH.relative_to(REPO_ROOT)} cache step is not pinned to v4 or v5. "
         f"Found: {[s['uses'] for s in cache_steps]}. "
-        "Required: actions/cache@v4 (cross-job save-always semantics)."
+        "Required: actions/cache@v4 or @v5 (gate-cache storage contract)."
     )
 
 


### PR DESCRIPTION
Unblocks dependabot **#568** (bumps `actions/cache` v4.3.0 → v5.0.5), which currently fails `test_ci_check_yml_has_cache_step` because the schema test hard-pins `actions/cache@v4`.

**Why v5 is correct, not a workaround:** v4 was the original gate-cache pin (D-104-03); v5 is its **maintained successor** after GitHub deprecated the v4 cache-service backend, and is key+path compatible with the `gate_cache` storage contract. Keeping v4 forever would eventually break as the old backend is retired.

Generalized `_is_v4` → `_is_supported_cache_version` to accept **v4 OR v5** (explicit tag or SHA-pinned `# v4`/`# v5`), preserving the Article VI SHA-pin requirement.

Verified locally: passes on current `main` (v4); accepts v5; rejects v3. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)