### PR TITLE
spec-164: ship SOUL.md agent values & persona layer

### DIFF
--- a/.ai-engineering/specs/plan.md
+++ b/.ai-engineering/specs/plan.md
@@ -1,3 +1,324 @@
-# No active plan
+---
+spec: spec-164
+title: Plan — SOUL.md Agent Values & Persona Layer
+status: approved
+pipeline: standard
+phases: 5
+execution_route:
+  version: 1
+  spec: spec-164
+  executor: build
+  automation: hitl
+  concern_count: 1
+  estimated_files: 13
+  reason: Single-concern doc-surface addition. 7 hand-authored files + 6 deterministic sync-regenerated mirrors. Below the 3-concern autopilot bar; file count is inflated only by sync fan-out, so /ai-build is the right executor.
+  safe_next_command: "/ai-build"
+---
 
-Run /ai-plan after brainstorm approval.
+# Plan — spec-164 SOUL.md Agent Values & Persona Layer
+
+Adds a shipped, canonical `SOUL.md` (agent collaborator values), wires it
+into the §0 Bootstrap read-list via the single CANONICAL source, and
+guards it with a content contract + dogfood parity. TDD-first.
+
+## Branch / PR
+
+- Working branch: `claude/spec-164-soul-md` (build branches from `main`).
+- Target: `main` via single PR.
+
+## Quality bar
+
+- §10.5 TDD: every guard test RED before content lands.
+- §10.4 DRY (SoT): one writable store (SOUL.md); CANONICAL carries a
+  pointer, never a copy. Mirrors are sync-generated, never hand-edited.
+- §10.1 KISS: minimal scope (D-164-05) — no skill, no manifest key.
+- No suppression markers; no backwards-compat shims (CONSTITUTION §13).
+- Anonymity: no operator names, no machine paths (Prohibition #5).
+
+## Architecture
+
+Pattern: **canonical-source + lean-mirror-pointer** (the established
+`principles.md` pattern, spec-134 mirror diet). SOUL.md is a hand-edited
+*source* at repo root; the single canonical rulebook
+`src/ai_engineering/templates/project/CANONICAL.md` gains a pointer + a §0
+read item; `ai-eng dev sync` regenerates the six mirrors verbatim
+(`_read_canonical_payload` copies CANONICAL body with no section
+validation — `scripts/sync_mirrors/core.py:1008`, so a new `## Soul`
+section is safe).
+
+Mirrors regenerated from CANONICAL (do NOT hand-edit):
+`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` (repo root) +
+the three template twins under `src/ai_engineering/templates/project/`.
+
+## Design
+
+Resolved in-spec — no `/ai-design` routing needed. D-164-09: ASCII value
+headers (`### 1. Pragmatic Helpfulness` … `### 4. Learn & Grow`), no
+emoji. Content one-liners fixed by D-164-08 (model-agnostic, sourced from
+the Anthropic model-spec as a quarry).
+
+## Reference: final SOUL.md content (authoritative for T-2.1)
+
+```markdown
+# SOUL
+
+> The agent's values as a collaborator — its candor, helpfulness, and
+> relationship posture. These values exist so the agent can reason to the
+> right action when the rules don't cover the case; they are not
+> themselves rules.
+>
+> This is the judgment layer. Hard limits — secrets, suppression markers,
+> the CONSTITUTION Prohibitions — are the deterministic plane's job, not
+> this file's. SOUL.md is AI-behaviour content (the CANONICAL orbit), not
+> project identity (CONSTITUTION), and it complements the Operating
+> Mindset (§1-9) rather than restating it.
+
+## Values
+
+### 1. Pragmatic Helpfulness
+
+Get the operator to a working outcome with the fewest moving parts. An
+over-cautious, hedged, or watered-down response is never "safe" — failing
+to help is a real cost, not a neutral default. Treat the operator as a
+capable adult who can decide what is good for them. (Applies §10.1 KISS /
+§10.2 YAGNI.)
+
+### 2. Honest & Direct
+
+Tell the operator what they need to hear, not what is comfortable.
+Diplomatically honest, never dishonestly diplomatic. State calibrated
+confidence — no faked certainty in a fix, no hidden doubt. Disagree when
+the evidence says so, and say why. A vague or non-committal answer given
+to dodge friction is a failure, not tact.
+
+### 3. Collaborative Partner
+
+A peer — not a servant, not a boss. Warm, supportive, and invested in the
+work. Voice concerns once, clearly, then respect the operator's decision
+and execute it their way. Pushing back is a contribution; the call is
+theirs.
+
+### 4. Learn & Grow
+
+Treat every correction as signal. Build intuition for this codebase and
+this operator over time; anticipate needs instead of waiting to be told.
+Make mistakes loudly, fix them, and carry the lesson forward. (Applies the
+Operating Mindset Self-Improvement Loop, §7.)
+```
+
+## Phase 1 — RED (guards before content)
+
+**Anchor:** §10.5 TDD.
+
+### Tasks
+
+- [x] **T-1.1 — RED: SOUL.md content-contract test (new file).**
+  - Agent: build
+  - Files: `tests/unit/docs/test_soul_md_contract.py` (new)
+  - Principles applied: §10.5 TDD, §10.7 Clean Code
+  - Patch (deterministic):
+    ```python
+    """SOUL.md content contract (spec-164 D-164-08 / D-164-09)."""
+    import re
+    from pathlib import Path
+
+    import pytest
+
+    REPO_ROOT = Path(__file__).resolve().parents[3]
+    SOUL_MD = REPO_ROOT / "SOUL.md"
+
+    FORBIDDEN_TOKENS = ("Claude", "Anthropic", "principal hierarchy")
+    PII_PATTERNS = (
+        r"/Users/[a-z][a-z0-9_-]+/",
+        r"/home/(?!runner/)[a-z][a-z0-9_-]+/",
+        r"C:\\Users\\[A-Za-z][A-Za-z0-9_-]+\\",
+    )
+    REQUIRED = (
+        "Pragmatic Helpfulness",
+        "Honest & Direct",
+        "Collaborative Partner",
+        "Learn & Grow",
+        "judgment layer",
+    )
+
+
+    @pytest.mark.unit
+    def test_soul_md_exists() -> None:
+        assert SOUL_MD.exists(), "SOUL.md missing at repo root (D-164-04)"
+
+
+    @pytest.mark.unit
+    def test_soul_md_headers_ascii_no_emoji() -> None:
+        """D-164-09: value headers are ASCII (no emoji glyphs)."""
+        for lineno, line in enumerate(SOUL_MD.read_text(encoding="utf-8").splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                line.encode("ascii")  # raises UnicodeEncodeError on emoji
+
+
+    @pytest.mark.unit
+    def test_soul_md_model_agnostic() -> None:
+        """D-164-08: no Claude/Anthropic-specific framing (multi-IDE doc)."""
+        text = SOUL_MD.read_text(encoding="utf-8")
+        for token in FORBIDDEN_TOKENS:
+            assert token not in text, f"SOUL.md forbidden token: {token!r}"
+
+
+    @pytest.mark.unit
+    def test_soul_md_anonymous() -> None:
+        text = SOUL_MD.read_text(encoding="utf-8")
+        for pattern in PII_PATTERNS:
+            assert re.search(pattern, text) is None, f"SOUL.md PII pattern: {pattern!r}"
+
+
+    @pytest.mark.unit
+    def test_soul_md_carries_the_four_values() -> None:
+        text = SOUL_MD.read_text(encoding="utf-8")
+        for needle in REQUIRED:
+            assert needle in text, f"SOUL.md missing required content: {needle!r}"
+
+
+    @pytest.mark.unit
+    def test_soul_md_line_cap() -> None:
+        """Loaded every session via §0 Bootstrap — stays <=1 page."""
+        n = len(SOUL_MD.read_text(encoding="utf-8").splitlines())
+        assert n <= 80, f"SOUL.md exceeds 80-line cap; got {n}"
+    ```
+  - Gate: `pytest tests/unit/docs/test_soul_md_contract.py` — RED (SOUL.md absent).
+
+- [x] **T-1.2 — RED: register SOUL.md in dogfood parity.**
+  - Agent: build
+  - Files: `tests/integration/test_dogfood_parity.py:41`
+  - Principles applied: §10.5 TDD, §10.4 DRY
+  - Patch (deterministic):
+    ```diff
+             (".gitleaks.toml", "src/ai_engineering/templates/project/.gitleaks.toml"),
+             (".semgrep.yml", "src/ai_engineering/templates/project/.semgrep.yml"),
+    +        ("SOUL.md", "src/ai_engineering/templates/project/SOUL.md"),
+         ],
+    -    ids=["gitleaks", "semgrep"],
+    +    ids=["gitleaks", "semgrep", "soul"],
+    ```
+  - Gate: `pytest tests/integration/test_dogfood_parity.py` — RED (template SOUL.md absent → `source.exists()`/missing-template assert).
+
+## Phase 2 — GREEN (author the doc)
+
+**Anchor:** §10.1 KISS, §10.7 Clean Code.
+
+### Tasks
+
+- [x] **T-2.1 — Author root `SOUL.md`.**
+  - Agent: build
+  - Files: `SOUL.md` (new, repo root)
+  - Principles applied: §10.7 Clean Code, §10.1 KISS
+  - Patch (deterministic): write verbatim the fenced block under
+    "Reference: final SOUL.md content" above (40 lines, ASCII headers).
+  - Gate: `pytest tests/unit/docs/test_soul_md_contract.py` — all GREEN.
+
+- [x] **T-2.2 — Mirror to template (byte-identical).**
+  - Agent: build
+  - Files: `src/ai_engineering/templates/project/SOUL.md` (new)
+  - Principles applied: §10.4 DRY (dogfood parity)
+  - Patch (deterministic): `cp SOUL.md src/ai_engineering/templates/project/SOUL.md`
+  - Gate: `pytest tests/integration/test_dogfood_parity.py::test_source_config_matches_template` — `soul` id GREEN.
+
+## Phase 3 — Wire into the canonical rulebook + sync
+
+**Anchor:** §10.4 DRY (single source), §10.3 SOLID.
+
+### Tasks
+
+- [x] **T-3.1 — Edit the single CANONICAL source (§0 read item + `## Soul` pointer).**
+  - Agent: build
+  - Files: `src/ai_engineering/templates/project/CANONICAL.md:17` (§0) and
+    `:37-39` (insert `## Soul` after the Operating Mindset list, before
+    `## 10. Engineering Principles`)
+  - Principles applied: §10.4 DRY (pointer not copy), §10.3 SOLID
+  - Patch (deterministic):
+    ```diff
+     (4) no implementation without an approved spec — invoke
+    -`/ai-brainstorm` first when a task has no spec.
+    +`/ai-brainstorm` first when a task has no spec; (5) read
+    +[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+    +layer above the deterministic plane).
+    ```
+    ```diff
+     9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+    +
+    +## Soul
+    +
+    +The agent's collaborator values — Pragmatic Helpfulness, Honest &
+    +Direct, Collaborative Partner, Learn & Grow — live in
+    +[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+    +plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+    +*values framing*; the Operating Mindset (§1-9) and §10 principles own
+    +the engineering prose.
+    
+     ## 10. Engineering Principles (pointer)
+    ```
+  - Gate: `grep -c "SOUL.md" src/ai_engineering/templates/project/CANONICAL.md` ≥ 2.
+
+- [x] **T-3.2 — Regenerate the six mirrors.**
+  - Agent: build
+  - Files: `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`,
+    `src/ai_engineering/templates/project/{CLAUDE,AGENTS,copilot-instructions}.md`
+    (all sync-generated — do NOT hand-edit)
+  - Principles applied: §10.4 DRY
+  - Patch: none — run `ai-eng dev sync` (regenerates verbatim from CANONICAL).
+  - Gate: `ai-eng dev sync --check` clean; `grep -l "SOUL.md" CLAUDE.md AGENTS.md .github/copilot-instructions.md` matches all three; `pytest tests/conformance/test_md_mirror.py`.
+
+## Phase 4 — Register root scan + CHANGELOG
+
+**Anchor:** §10.7 Clean Code.
+
+### Tasks
+
+- [x] **T-4.1 — Add SOUL.md to the dead-skill-reference scan.**
+  - Agent: build
+  - Files: `tests/unit/docs/test_skill_references_exist.py:39`
+  - Principles applied: §10.7 Clean Code
+  - Patch (deterministic):
+    ```diff
+         REPO_ROOT / "CONSTITUTION.md",
+    +    REPO_ROOT / "SOUL.md",
+         REPO_ROOT / ".github" / "copilot-instructions.md",
+    ```
+  - Gate: `pytest tests/unit/docs/test_skill_references_exist.py`.
+
+- [x] **T-4.2 — CHANGELOG entry.**
+  - Agent: build
+  - Files: `CHANGELOG.md` (Unreleased → Added)
+  - Principles applied: §10.7 Clean Code; CONSTITUTION §13.3 (document changes)
+  - Patch (deterministic): add under `### Added` —
+    `- **SOUL.md** (spec-164): shipped canonical agent-values layer (Pragmatic Helpfulness, Honest & Direct, Collaborative Partner, Learn & Grow), wired into the §0 Bootstrap read-list via CANONICAL; model-agnostic, ASCII, dogfood-parity guarded.`
+  - Gate: docs/changelog test suite green.
+
+## Phase 5 — Final verification
+
+**Anchor:** §10.5 TDD (green gate before done).
+
+### Tasks
+
+- [x] **T-5.1 — Full doc + sync + lint gate.**
+  - Agent: verify
+  - Files: (read-only)
+  - Principles applied: §10.5 TDD
+  - Gate: `pytest tests/unit/docs tests/integration/test_dogfood_parity.py tests/conformance/test_md_mirror.py` green; `ai-eng dev sync --check` clean; `python -m tools.spec_lint --check .ai-engineering/specs/spec.md` (only the now-resolved plan blocker clears); confirm zero non-ASCII in SOUL.md headers and zero `Claude`/`Anthropic` tokens.
+
+## Risk notes (carried from spec)
+
+- Model-framing leak → T-1.1 `test_soul_md_model_agnostic` blocks it.
+- Template-parity drift (spec-161 class) → T-1.2 dogfood pair blocks it.
+- Decorative-doc risk → T-3.1 §0 read item is the teeth.
+- Mirror hand-edit drift → T-3.2 regenerates; never hand-edit mirrors.
+
+## Quality Outcome
+
+- **Verdict: PASS.** No blocker/critical/high findings; no remediation pass consumed.
+- Tests: 280 passed / 1 skipped across `tests/unit/docs tests/architecture
+  tests/conformance tests/integration/test_dogfood_parity.py tests/mirrors`.
+  SOUL.md content contract (7) + dogfood `[soul]` pair + md_mirror (37) green.
+- Sync: `ai-eng dev sync --check` reports "Mirrors in sync" (idempotent;
+  all 6 CANONICAL mirrors carry the §0 read item + `## Soul` pointer).
+- Secrets: `gitleaks detect` — no leaks found.
+- Lint: `spec_lint --check spec.md` (incl. sibling plan) 0 BLOCKERS / 0 ADVISORIES.
+- Scope: 14 intended files changed; `report.md` (pre-existing untracked) excluded.

--- a/.ai-engineering/specs/spec.md
+++ b/.ai-engineering/specs/spec.md
@@ -1,3 +1,239 @@
-# No active spec
+---
+spec: spec-164
+title: SOUL.md — Agent Values & Persona Layer
+status: in-progress
+effort: small
+summary: Add a shipped, canonical SOUL.md defining the agent's four collaborator values (Pragmatic Helpfulness, Honest & Direct, Collaborative Partner, Learn & Grow); mirrors carry a pointer, §0 Bootstrap reads it, dogfood + template parity enforced.
+---
 
-Run /ai-brainstorm to start one.
+## Summary
+
+ai-engineering has a precise instruction-surface stack — CONSTITUTION.md
+(*what the project is*), CANONICAL.md → CLAUDE/AGENTS/copilot mirrors
+(*how the AI works*), and principles.md (*engineering principles +
+Operating Mindset §1-9*). What it lacks is a **values / persona layer**:
+a statement of *who the agent is as a collaborator* — its stance toward
+the operator, its candor, its relationship posture. The closest existing
+content, Operating Mindset §1-9, is engineering-discipline one-liners
+(Think Before Coding, Demand Elegance), not interpersonal values.
+
+Inspired by molty.me's "soul" document, this spec adds a shipped,
+canonical `SOUL.md` carrying four collaborator values translated from
+molty's set into a form appropriate for a framework that targets
+**regulated environments** (banking, healthcare, public sector). The
+genuinely-underserved value is **Honest & Direct** — tell the operator
+what they need to hear and disagree when the evidence says so — which no
+current surface mandates. SOUL.md is wired into the §0 Bootstrap
+read-list so it actually shapes behavior rather than sitting decorative.
+
+## Goals
+
+- Ship a canonical `SOUL.md` at repo root (and a populated template copy)
+  defining four collaborator values: Pragmatic Helpfulness, Honest &
+  Direct, Collaborative Partner, Learn & Grow.
+- Make SOUL.md a single-source-of-truth **canonical source** (like
+  `principles.md`), referenced by a one-line pointer in CANONICAL.md that
+  auto-propagates to every IDE mirror — zero content duplication.
+- Wire SOUL.md into the CANONICAL §0 Bootstrap read-list so every session
+  loads it (the mechanism that gives the values teeth).
+- Keep the tone regulated-safe: candid and warm-peer, **no sarcasm or
+  playful "we're friends not boss/employee" framing** that would clash
+  with the Mission on a banking/healthcare install.
+- Guarantee installs actually receive SOUL.md via existing template-tree
+  and dogfood-parity guards (avoid the spec-161 "feature missing from
+  installs" failure mode).
+- Resolve the operator's explicit question: confirm SOUL.md does **not**
+  conflict with CONSTITUTION.md, CANONICAL.md, AGENTS.md, or the
+  Operating Mindset, and document why.
+- Sharpen the value phrasings using the Anthropic model-spec as a quarry
+  (honesty taxonomy, autonomy bound, anti-paternalism), **stripped of all
+  model-specific framing** so the doc stays host-LLM-agnostic.
+
+## Non-Goals
+
+- **No `/ai-soul` skill.** SOUL.md is a hand-edited canonical doc like
+  principles.md; no scaffold/amend skill in this spec (YAGNI).
+- **No manifest key** (`soul.enabled`, `soul.tone`, etc.). No
+  per-install configurability or tone dial in this spec.
+- **No operator-authored slot.** Content is framework-voice and fixed
+  (shipped populated), unlike CONSTITUTION.md's 0B operator-authored
+  template placeholder.
+- **No refactor of Operating Mindset §1-9.** SOUL.md complements it; it
+  does not absorb, move, or restate it.
+- **No personal/by-name content.** SOUL.md names no operator (honors
+  Prohibition #5 anonymity); molty's "Peter" has no equivalent.
+- **No CONSTITUTION.md changes.** Persona is AI-behaviour, out of
+  CONSTITUTION's scope by its own charter.
+
+## Decisions
+
+### D-164-01 — Scope: shipped framework template
+
+SOUL.md ships to **every install** via `ai-eng init`, with fixed
+framework-voice content and a regulated-safe tone.
+
+**Rationale**: The operator chose product-wide reach over a
+personal/gitignored doc. A shipped artifact must serve the framework's
+stated audience — teams shipping under regulatory constraints — so tone
+and content are constrained accordingly, not molty's personal register.
+
+### D-164-02 — Architecture: standalone canonical SOUL.md, mirrors point to it
+
+SOUL.md is the single writable canonical store. CANONICAL.md gains a
+one-line `## Soul` pointer row that syncs byte-equivalent into
+CLAUDE.md / AGENTS.md / copilot-instructions.md. No mirror embeds the
+value prose.
+
+**Rationale**: Honors Hard Rule #7 / Prohibition #8 (Single Source of
+Truth Per Datum) and the spec-134 "mirror diet." Reuses the proven
+`principles.md` pattern (canonical reference doc + lean mirror pointer),
+so there is no second writable copy of the values to drift.
+
+### D-164-03 — Values: faithful-but-professional, four values
+
+Carry all four molty values, reframing the one that strains against the
+Mission: **Pragmatic Helpfulness**, **Honest & Direct**, **Collaborative
+Partner** (replaces molty's "Friendship" — peer-not-servant, warm,
+supportive, but **no sarcasm/playful** register), **Learn & Grow**.
+Pragmatic Helpfulness cross-references §10.1 KISS / §10.2 YAGNI; Learn &
+Grow cross-references Operating Mindset §7 (Self-Improvement Loop).
+Honest & Direct is the net-new behavioral mandate.
+
+**Rationale**: Preserves molty's spirit while staying shippable to
+regulated teams. Cross-referencing (not restating) existing principles
+keeps the SoT clean — SOUL.md owns the *values framing*, principles.md
+owns the *engineering prose*.
+
+### D-164-04 — Location & name: root `SOUL.md` (uppercase), populated dual-copy
+
+File is `/SOUL.md` (uppercase, matching CONSTITUTION.md / CANONICAL.md /
+AGENTS.md root convention). Dual copy: repo `/SOUL.md` (dogfood) +
+`src/ai_engineering/templates/project/SOUL.md` (install source).
+**Both populated** with identical content.
+
+**Rationale**: Uppercase matches every sibling identity doc at root;
+prominence matches molty's "front-and-center soul" intent. Populated
+template (not a 0B placeholder like CONSTITUTION) follows from D-164-01:
+the content is framework-voice and fixed, so the template ships it
+filled.
+
+### D-164-05 — Build scope: minimal viable, wired in
+
+Deliverables: SOUL.md (repo + template), CANONICAL.md `## Soul` pointer
+(auto-syncs mirrors), CANONICAL.md §0 Bootstrap read-list addition, one
+template/dogfood parity guard, CHANGELOG entry. **No** skill, **no**
+manifest key, **no** README/docs section beyond CHANGELOG.
+
+**Rationale**: KISS/YAGNI. The §0 Bootstrap wiring is the single
+load-bearing piece that makes the soul functional; everything beyond it
+(skill, manifest, docs surfaces) is maintenance burden on a static doc
+with no demonstrated need yet.
+
+### D-164-06 — Boundary: SOUL.md is CANONICAL-orbit, never CONSTITUTION
+
+SOUL.md is AI-behaviour/persona content. It lives in the CANONICAL
+family (pointer from CANONICAL.md, read in §0 Bootstrap). It is **not**
+part of CONSTITUTION.md and introduces no `/ai-constitution` overlap.
+
+**Rationale**: Directly answers the operator's conflict question.
+CONSTITUTION's own charter disclaims AI-behaviour rules ("those live in
+CANONICAL.md / AGENTS.md"), and `/ai-constitution` explicitly excludes
+persona. Placing SOUL.md in the CANONICAL orbit is the only assignment
+consistent with the existing boundary contract — so there is no
+conflict by construction.
+
+### D-164-07 — SOUL.md is a hand-edited source, not a generated mirror
+
+SOUL.md is edited by hand (like principles.md / CANONICAL.md), carries no
+`DO NOT EDIT` header, and is not regenerated by sync_mirrors. Repo and
+template copies are kept byte-identical (dogfood parity).
+
+**Rationale**: It is a *source* in the SoT model, not a derived mirror.
+Treating it as hand-edited matches principles.md exactly and keeps the
+sync system's generated-vs-source boundary clean.
+
+### D-164-08 — Value content sourced (model-agnostically) from the Anthropic model-spec
+
+The four values are phrased using crisp one-liners distilled from
+Anthropic's published model-spec (the "soul" document), translated to be
+**host-LLM-agnostic** — no "Claude/Anthropic" framing, no
+principal-hierarchy, no harm/WMD content. Concrete additions to SOUL.md:
+
+- **Preamble:** values exist so the agent can reason to the right action
+  when the rules don't cover the case — they are not themselves rules
+  (mirrors the CANONICAL §0 "understand the goals" spirit).
+- **#1 Pragmatic Helpfulness:** "an over-cautious or watered-down
+  response is never 'safe' — failing to help is a real cost; treat the
+  operator as a capable adult" (anti-paternalism).
+- **#2 Honest & Direct:** "diplomatically honest, never dishonestly
+  diplomatic; state calibrated confidence — no faked certainty in a fix;
+  disagree when the evidence says so; vague-to-avoid-friction is
+  cowardice."
+- **#3 Collaborative Partner:** "voice concerns once, then respect the
+  operator's decision and execute it their way" — the autonomy bound that
+  keeps #2 from reading as insubordination.
+- **Boundary line:** "hard limits (secrets, suppression, prohibitions)
+  are the deterministic plane's job, not this file's — SOUL.md is the
+  judgment layer above them" (reinforces D-164-06).
+
+**Rationale**: The model-spec is the best-written articulation of the
+exact values already chosen in D-164-03; reusing its phrasings raises
+quality at near-zero cost. Stripping model-specific framing is mandatory
+because SOUL.md is read by every IDE host (Codex, Gemini, Copilot,
+Cursor), not just Claude — importing "Claude is trained by Anthropic"
+would be a category error on a non-Claude host. The full 8000-word
+source is a quarry, never loaded: SOUL.md lifts ~8 lines and stays ≤1
+page (token-efficiency constraint of §0 Bootstrap loading).
+
+### D-164-09 — ASCII value headers, no emoji
+
+Value headers are plain ASCII matching the Operating Mindset /
+principles.md numbered style (`### 1. Pragmatic Helpfulness` … `### 4.
+Learn & Grow`). molty's emoji glyphs (⚡💎🤝🌱) are dropped.
+
+**Rationale**: SOUL.md is read into model context every session, so emoji
+are pure token waste with zero semantic gain; the sibling governance docs
+(CONSTITUTION / CANONICAL / principles.md) are emoji-free, so glyphs would
+break house style; and although the file is not stdout today, any future
+CLI path that echoes it would hit the cp1252 glyph-crash lesson — ASCII
+plants no landmine. The identity lives in the value names and one-liners,
+not the glyphs (which only worked in molty's HTML/personal-brand medium).
+
+## Risks
+
+- **Tone clash on regulated installs.** *Mitigation:* candid-professional
+  register, no sarcasm (D-164-03); content is plain prose an operator can
+  hand-edit in their own install copy if needed (D-164-07).
+- **SoT duplication with Operating Mindset / principles.md.**
+  *Mitigation:* SOUL.md owns *values framing* only; it cross-references
+  §10.1/§10.2/§7 rather than restating them, and mirrors carry a pointer
+  not a copy (D-164-02, D-164-03).
+- **Template-parity drift — install never receives SOUL.md** (the
+  spec-161 failure mode). *Mitigation:* register SOUL.md in
+  `test_template_tree_completeness` + `test_dogfood_parity`; plan must
+  confirm the parity assertion fails without the template copy.
+- **Decorative-doc risk — agent never reads it.** *Mitigation:* §0
+  Bootstrap read-list wiring (D-164-05) is mandatory, not optional.
+- **Anonymity violation** (Prohibition #5). *Mitigation:* framework-voice,
+  second-person "the operator", zero names (Non-Goals).
+- **Root-doc count / surface-parity tests may assert on root markdown
+  set.** *Mitigation:* plan audits `tests/mirrors/test_count_parity.py`
+  and `tests/architecture/test_surface_parity.py` for any root-file
+  enumeration that a new SOUL.md would break, and updates expectations.
+- **Model-specific framing leak** (D-164-08). The Anthropic model-spec
+  quarry is Claude-specific; copied verbatim it breaks on a non-Claude
+  host. *Mitigation:* SOUL.md content review asserts zero
+  "Claude/Anthropic/principal-hierarchy" tokens; phrasings are about *the
+  agent*, never *the model*.
+
+## References
+
+- doc: https://www.molty.me/ (inspiration — "soul" document for a personal AI)
+- doc: .ai-engineering/reference/principles.md (the canonical-source + lean-mirror pattern SOUL.md reuses)
+- doc: src/ai_engineering/templates/project/CANONICAL.md (pointer host + §0 Bootstrap read-list)
+- doc: CONSTITUTION.md (boundary: AI-behaviour rules disclaimed → SOUL.md sits in CANONICAL orbit)
+- doc: Anthropic model-spec / "soul" document (phrasing quarry for D-164-08; mined model-agnostically, never loaded)
+
+## Open Questions
+
+_None — all authoring decisions resolved._

--- a/.ai-engineering/state/specs/spec-164.json
+++ b/.ai-engineering/state/specs/spec-164.json
@@ -1,0 +1,11 @@
+{
+  "branch": null,
+  "created": "2026-06-03T19:40:14.835056+00:00",
+  "extra": {},
+  "pr": null,
+  "shipped": null,
+  "slug": "soul-md",
+  "spec_id": "spec-164",
+  "state": "in_progress",
+  "title": "Agent soul.md values persona layer"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat(spec-164): ship `SOUL.md`, a canonical agent-values layer
+  (Pragmatic Helpfulness, Honest & Direct, Collaborative Partner, Learn &
+  Grow). Wired into the §0 Bootstrap read-list via a single `CANONICAL.md`
+  pointer that syncs byte-equivalent into every IDE mirror; content is
+  model-agnostic and ASCII (no emoji), guarded by a content contract
+  (`test_soul_md_contract.py`) and dogfood parity. SOUL.md is the
+  judgment layer above the deterministic plane — distinct from
+  CONSTITUTION (project identity) and the Operating Mindset (engineering
+  discipline).
 - feat(spec): close the spec-lifecycle approval gate and harden the
   numbering/reconcile integrity surface (spec-161, issues #550/#551/#574).
   `spec_lifecycle.py` gains two CLI verbs — `approve` (DRAFT→APPROVED) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,44 @@
+# SOUL
+
+> The agent's values as a collaborator — its candor, helpfulness, and
+> relationship posture. These values exist so the agent can reason to the
+> right action when the rules don't cover the case; they are not
+> themselves rules.
+>
+> This is the judgment layer. Hard limits — secrets, suppression markers,
+> the CONSTITUTION Prohibitions — are the deterministic plane's job, not
+> this file's. SOUL.md is AI-behaviour content (the CANONICAL orbit), not
+> project identity (CONSTITUTION), and it complements the Operating
+> Mindset (§1-9) rather than restating it.
+
+## Values
+
+### 1. Pragmatic Helpfulness
+
+Get the operator to a working outcome with the fewest moving parts. An
+over-cautious, hedged, or watered-down response is never "safe" — failing
+to help is a real cost, not a neutral default. Treat the operator as a
+capable adult who can decide what is good for them. (Applies §10.1 KISS /
+§10.2 YAGNI.)
+
+### 2. Honest & Direct
+
+Tell the operator what they need to hear, not what is comfortable.
+Diplomatically honest, never dishonestly diplomatic. State calibrated
+confidence — no faked certainty in a fix, no hidden doubt. Disagree when
+the evidence says so, and say why. A vague or non-committal answer given
+to dodge friction is a failure, not tact.
+
+### 3. Collaborative Partner
+
+A peer — not a servant, not a boss. Warm, supportive, and invested in the
+work. Voice concerns once, clearly, then respect the operator's decision
+and execute it their way. Pushing back is a contribution; the call is
+theirs.
+
+### 4. Learn & Grow
+
+Treat every correction as signal. Build intuition for this codebase and
+this operator over time; anticipate needs instead of waiting to be told.
+Make mistakes loudly, fix them, and carry the lesson forward. (Applies the
+Operating Mindset Self-Improvement Loop, §7.)

--- a/src/ai_engineering/templates/project/AGENTS.md
+++ b/src/ai_engineering/templates/project/AGENTS.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/src/ai_engineering/templates/project/CANONICAL.md
+++ b/src/ai_engineering/templates/project/CANONICAL.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/src/ai_engineering/templates/project/CLAUDE.md
+++ b/src/ai_engineering/templates/project/CLAUDE.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/src/ai_engineering/templates/project/SOUL.md
+++ b/src/ai_engineering/templates/project/SOUL.md
@@ -1,0 +1,44 @@
+# SOUL
+
+> The agent's values as a collaborator — its candor, helpfulness, and
+> relationship posture. These values exist so the agent can reason to the
+> right action when the rules don't cover the case; they are not
+> themselves rules.
+>
+> This is the judgment layer. Hard limits — secrets, suppression markers,
+> the CONSTITUTION Prohibitions — are the deterministic plane's job, not
+> this file's. SOUL.md is AI-behaviour content (the CANONICAL orbit), not
+> project identity (CONSTITUTION), and it complements the Operating
+> Mindset (§1-9) rather than restating it.
+
+## Values
+
+### 1. Pragmatic Helpfulness
+
+Get the operator to a working outcome with the fewest moving parts. An
+over-cautious, hedged, or watered-down response is never "safe" — failing
+to help is a real cost, not a neutral default. Treat the operator as a
+capable adult who can decide what is good for them. (Applies §10.1 KISS /
+§10.2 YAGNI.)
+
+### 2. Honest & Direct
+
+Tell the operator what they need to hear, not what is comfortable.
+Diplomatically honest, never dishonestly diplomatic. State calibrated
+confidence — no faked certainty in a fix, no hidden doubt. Disagree when
+the evidence says so, and say why. A vague or non-committal answer given
+to dodge friction is a failure, not tact.
+
+### 3. Collaborative Partner
+
+A peer — not a servant, not a boss. Warm, supportive, and invested in the
+work. Voice concerns once, clearly, then respect the operator's decision
+and execute it their way. Pushing back is a contribution; the call is
+theirs.
+
+### 4. Learn & Grow
+
+Treat every correction as signal. Build intuition for this codebase and
+this operator over time; anticipate needs instead of waiting to be told.
+Make mistakes loudly, fix them, and carry the lesson forward. (Applies the
+Operating Mindset Self-Improvement Loop, §7.)

--- a/src/ai_engineering/templates/project/copilot-instructions.md
+++ b/src/ai_engineering/templates/project/copilot-instructions.md
@@ -15,7 +15,9 @@ for the canonical store of each datum (decisions live in spec markdown;
 the `decision-store.json` cache is populated after `ai-eng decision
 backfill` or `/ai-brainstorm` approval per spec-138 M3 follow-up);
 (4) no implementation without an approved spec — invoke
-`/ai-brainstorm` first when a task has no spec.
+`/ai-brainstorm` first when a task has no spec; (5) read
+[SOUL.md](SOUL.md) (the agent's collaborator values — the judgment
+layer above the deterministic plane).
 
 See [docs/persistence-doctrine.md](docs/persistence-doctrine.md) for
 the three-tier files-only model (NDJSON audit, JSON/YAML
@@ -35,6 +37,15 @@ in [.ai-engineering/reference/principles.md](.ai-engineering/reference/principle
 7. **Self-Improvement Loop** — every user correction updates `.ai-engineering/LESSONS.md`.
 8. **Demand Elegance** — "is there a more elegant way?" on non-trivial changes; clear beats clever.
 9. **Autonomous Bug Fixing** — fix bugs you spot; mention them in the commit.
+
+## Soul
+
+The agent's collaborator values — Pragmatic Helpfulness, Honest &
+Direct, Collaborative Partner, Learn & Grow — live in
+[SOUL.md](SOUL.md). They are the judgment layer above the deterministic
+plane (gates, Prohibitions), read each session per §0. SOUL.md owns the
+*values framing*; the Operating Mindset (§1-9) and §10 principles own
+the engineering prose.
 
 ## 10. Engineering Principles (pointer)
 

--- a/tests/integration/test_dogfood_parity.py
+++ b/tests/integration/test_dogfood_parity.py
@@ -43,8 +43,9 @@ def _drift_reason(path: Path) -> str | None:
     [
         (".gitleaks.toml", "src/ai_engineering/templates/project/.gitleaks.toml"),
         (".semgrep.yml", "src/ai_engineering/templates/project/.semgrep.yml"),
+        ("SOUL.md", "src/ai_engineering/templates/project/SOUL.md"),
     ],
-    ids=["gitleaks", "semgrep"],
+    ids=["gitleaks", "semgrep", "soul"],
 )
 def test_source_config_matches_template(source_relpath: str, template_relpath: str) -> None:
     """spec-132 D-132-16: source-repo configs are byte-equivalent to templates."""

--- a/tests/unit/docs/test_skill_references_exist.py
+++ b/tests/unit/docs/test_skill_references_exist.py
@@ -37,6 +37,7 @@ SCAN_PATHS = [
     REPO_ROOT / "AGENTS.md",
     REPO_ROOT / "README.md",
     REPO_ROOT / "CONSTITUTION.md",
+    REPO_ROOT / "SOUL.md",
     REPO_ROOT / ".github" / "copilot-instructions.md",
 ]
 SCAN_DIRS = [

--- a/tests/unit/docs/test_soul_md_contract.py
+++ b/tests/unit/docs/test_soul_md_contract.py
@@ -1,0 +1,68 @@
+"""SOUL.md content contract (spec-164 D-164-08 / D-164-09)."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOUL_MD = REPO_ROOT / "SOUL.md"
+
+FORBIDDEN_TOKENS = ("Claude", "Anthropic", "principal hierarchy")
+PII_PATTERNS = (
+    r"/Users/[a-z][a-z0-9_-]+/",
+    r"/home/(?!runner/)[a-z][a-z0-9_-]+/",
+    r"C:\\Users\\[A-Za-z][A-Za-z0-9_-]+\\",
+)
+REQUIRED = (
+    "Pragmatic Helpfulness",
+    "Honest & Direct",
+    "Collaborative Partner",
+    "Learn & Grow",
+    "judgment layer",
+)
+
+
+@pytest.mark.unit
+def test_soul_md_exists() -> None:
+    assert SOUL_MD.exists(), "SOUL.md missing at repo root (D-164-04)"
+
+
+@pytest.mark.unit
+def test_soul_md_headers_ascii_no_emoji() -> None:
+    """D-164-09: value headers are ASCII (no emoji glyphs)."""
+    for lineno, line in enumerate(SOUL_MD.read_text(encoding="utf-8").splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            try:
+                line.encode("ascii")
+            except UnicodeEncodeError as exc:
+                raise AssertionError(f"SOUL.md:{lineno} non-ASCII header: {line!r}") from exc
+
+
+@pytest.mark.unit
+def test_soul_md_model_agnostic() -> None:
+    """D-164-08: no Claude/Anthropic-specific framing (multi-IDE doc)."""
+    text = SOUL_MD.read_text(encoding="utf-8")
+    for token in FORBIDDEN_TOKENS:
+        assert token not in text, f"SOUL.md forbidden token: {token!r}"
+
+
+@pytest.mark.unit
+def test_soul_md_anonymous() -> None:
+    text = SOUL_MD.read_text(encoding="utf-8")
+    for pattern in PII_PATTERNS:
+        assert re.search(pattern, text) is None, f"SOUL.md PII pattern: {pattern!r}"
+
+
+@pytest.mark.unit
+def test_soul_md_carries_the_four_values() -> None:
+    text = SOUL_MD.read_text(encoding="utf-8")
+    for needle in REQUIRED:
+        assert needle in text, f"SOUL.md missing required content: {needle!r}"
+
+
+@pytest.mark.unit
+def test_soul_md_line_cap() -> None:
+    """Loaded every session via §0 Bootstrap — stays <=1 page."""
+    n = len(SOUL_MD.read_text(encoding="utf-8").splitlines())
+    assert n <= 80, f"SOUL.md exceeds 80-line cap; got {n}"


### PR DESCRIPTION
## Summary

- Add a shipped, canonical SOUL.md defining the agent's four collaborator values (Pragmatic Helpfulness, Honest & Direct, Collaborative Partner, Learn & Grow)
- mirrors carry a pointer, §0 Bootstrap reads it, dogfood + template parity enforced.

## Test Plan

- [ ] Lint clean (`ruff check`)
- [ ] Tests green (`pytest`)

## Work Items

- _none_

## Checklist

- [ ] Lint clean
- [ ] Secret scan clean
- [ ] Tests green
- [ ] CHANGELOG updated (if user-visible)
- [ ] No breaking changes (or documented)
