### PR TITLE
chore(spec-169): consolidate to SHIPPED (archive + clear live slot)

### DIFF
--- a/.ai-engineering/specs/_history.md
+++ b/.ai-engineering/specs/_history.md
@@ -162,5 +162,6 @@ Completed specs. Details in git history.
 | spec-165 | Observation consolidation nudge + scheduled sweep | shipped | 2026-06-03 | 2026-06-04 | 586 | fix/soul-md-install-wiring |
 | spec-167 | Session-watch sweep engine + brainstorm slot-clobber guard | shipped | 2026-06-04 | 2026-06-04 | 588 | claude/spec-167-lifecycle-execution-gaps |
 | spec-168 | ARCHITECTURE.md and error-handling fail-open/closed policy | shipped | 2026-06-04 | 2026-06-07 | 589 | spec-168-arch-docs-error-policy |
+| spec-169 | Runbook header translations: template parity + cross-IDE | shipped | 2026-06-07 | 2026-06-08 | 585 | feat_translations |
 
 ---

--- a/.ai-engineering/specs/archive/spec-169-runbook-template-parity/plan.md
+++ b/.ai-engineering/specs/archive/spec-169-runbook-template-parity/plan.md
@@ -1,0 +1,130 @@
+---
+title: "Plan — Runbook header translations: template parity + cross-IDE"
+spec: runbook-template-parity
+status: approved
+pipeline: standard
+architecture_pattern: ad-hoc
+execution_route:
+  version: 1
+  spec: runbook-template-parity
+  executor: build
+  automation: assisted
+  concern_count: 1
+  estimated_files: 15
+  reason: "Single concern (runbook template parity) — 14 mechanical template translations + 1 parity-guard test. Low risk, no cross-module coupling, no design surface. Routes to /ai-build, not /ai-autopilot."
+  safe_next_command: "/ai-build"
+---
+
+# Plan — Runbook header translations: template parity + cross-IDE
+
+Implements spec `runbook-template-parity` (sidecar `spec-169`). Completes
+PR #585 by translating the 14 template runbook twins and adding a byte-parity
+guard.
+
+## Architecture
+
+**Pattern: ad-hoc.** Mechanical content parity + one test. No new module, no
+interface change, no data flow. The only structural addition is a CI assertion
+in an existing test module that already imports both `RUNBOOK_ROOT` and
+`TEMPLATE_ROOT`.
+
+## Base branch (delivery)
+
+Work targets the PR #585 fork branch `eramos/ai-engineering:feat_translations`
+(`maintainerCanModify: true`), where the 14 **live** runbooks are already
+English. `/ai-build` must base its worktree on that branch (not `main`), so the
+parity guard (T-1) goes RED before T-2 (live English vs template Spanish) and
+GREEN after. Delivery is a push back onto that same branch — one PR, original
+author retained (spec D-runbook-template-parity-03).
+
+## Phase 1 — Parity guard (RED)
+
+- [x] T-1 — Add repo↔template runbook byte-parity test
+- Agent: build
+- Files: tests/unit/test_runbook_contracts.py
+- Principles applied: §10.5 TDD (RED before GREEN), §10.7 Clean Code (reuse existing roots/list)
+- Patch (deterministic): append a test that fails loud on any twin mismatch, reusing the module's existing `RUNBOOK_ROOT`, `TEMPLATE_ROOT`, and `ALL_RUNBOOKS`.
+
+```diff
+--- a/tests/unit/test_runbook_contracts.py
++++ b/tests/unit/test_runbook_contracts.py
+@@
++@pytest.mark.parametrize("name", ALL_RUNBOOKS)
++def test_runbook_template_byte_parity(name: str) -> None:
++    """Each live runbook must be byte-identical to its install-template twin.
++
++    Guards the silent drift fixed in PR #585: a live edit (e.g. header
++    translation) that never reached ``src/ai_engineering/templates/`` would
++    ship Spanish headers to downstream installs. (spec runbook-template-parity
++    D-runbook-template-parity-02.)
++    """
++    live = RUNBOOK_ROOT / f"{name}.md"
++    template = TEMPLATE_ROOT / f"{name}.md"
++    assert live.read_bytes() == template.read_bytes(), (
++        f"runbook drift: {name}.md differs between "
++        f".ai-engineering/runbooks/ and the install template — "
++        f"re-sync the template twin."
++    )
+```
+
+- Gate: `.venv/bin/python -m pytest tests/unit/test_runbook_contracts.py -k byte_parity` — RED on the fork branch (live English, template Spanish) before T-2.
+
+## Phase 2 — Template translation (GREEN)
+
+- [x] T-2 — Translate the 3 headers in all 14 template runbook twins
+- Agent: build
+- Files: src/ai_engineering/templates/.ai-engineering/runbooks/*.md (14 files)
+- Principles applied: §10.4 DRY (single canonical content, twin re-synced), §10.5 TDD (GREEN)
+- Patch (deterministic): apply the identical substitution PR #585 made to the live copies. Verified: exactly 3 header swaps per file, all 14 files carry all 3 headers, no other Spanish remains.
+
+```bash
+sed -i '' \
+  -e 's/^## Objetivo$/## Objective/' \
+  -e 's/^## Precondiciones$/## Prerequisites/' \
+  -e 's/^## Procedimiento$/## Procedure/' \
+  src/ai_engineering/templates/.ai-engineering/runbooks/*.md
+```
+
+- Gate: `.venv/bin/python -m pytest tests/unit/test_runbook_contracts.py` — all GREEN, including the new parity test for every one of the 14 runbooks.
+
+## Phase 3 — Verify
+
+- [x] T-3 — Full runbook-contract suite + lint
+- Agent: verify
+- Files: tests/unit/test_runbook_contracts.py, src/ai_engineering/templates/.ai-engineering/runbooks/*.md
+- Principles applied: §10.7 Clean Code (no residual drift), §10.5 TDD (suite green)
+- Gate: `.venv/bin/python -m pytest tests/unit/test_runbook_contracts.py` AND `ruff check tests/unit/test_runbook_contracts.py` AND a final `diff` sweep proving all 14 live↔template pairs identical. No `## Objetivo|Precondiciones|Procedimiento` remain anywhere under `src/ai_engineering/templates/.ai-engineering/runbooks/`.
+
+## Gate criteria (plan-level)
+
+- New parity test goes RED before T-2, GREEN after — proves the guard works.
+- All 14 template twins byte-identical to live copies post-T-2.
+- No Spanish headers remain in template runbooks.
+- `ruff check` clean on the touched test file.
+- No CHANGELOG entry (not user-facing runtime behavior; matches PR #585 scope).
+
+## Quality Outcome
+
+- **T-1 RED → GREEN proven:** parity test failed on all 14 twins before
+  translation (live English vs template Spanish), passes after.
+- **Extra bug caught + fixed (in scope):** PR #585 translated the runbook
+  headers but left `REQUIRED_SECTIONS` in `test_runbook_contracts.py` pointing
+  at the old Spanish names (`## Objetivo`, `## Precondiciones`,
+  `## Procedimiento`), so `test_runbook_contract_schema` was already RED on the
+  PR branch. Updated the constant to the English names. Also fixed an inline
+  cross-reference `(see Precondiciones)` → `(see Prerequisites)` in the
+  `performance.md` template twin to match the live copy.
+- **Suites:** `tests/unit/test_runbook_contracts.py` (73) +
+  `test_template_parity.py` + `test_sync_mirrors.py` → **132 passed**.
+- **Lint:** `ruff check tests/unit/test_runbook_contracts.py` clean.
+- **Sweep:** zero `Objetivo|Precondiciones|Procedimiento` remaining under the
+  template runbooks; all 14 live↔template pairs byte-identical.
+- **Changed set:** 14 template runbooks + 1 test file — matches plan scope, no
+  drive-by edits.
+
+## Out of scope (from spec Non-Goals)
+
+- No body/frontmatter/other-file translation.
+- No per-IDE mirroring (`.codex/`, `.github/`, `.agents/`).
+- No parity guard for other template trees.
+- No separate upstream branch or second PR.

--- a/.ai-engineering/specs/archive/spec-169-runbook-template-parity/spec.md
+++ b/.ai-engineering/specs/archive/spec-169-runbook-template-parity/spec.md
@@ -1,0 +1,116 @@
+---
+spec: runbook-template-parity
+slug: runbook-template-parity
+title: "Runbook header translations: template parity + cross-IDE"
+status: in-progress
+effort: small
+summary: "Complete PR #585 by translating the 14 template runbook twins to match the live repo and adding a repo↔template byte-parity CI guard; deliver on the PR #585 fork branch."
+---
+
+# Runbook header translations: template parity + cross-IDE
+
+## Summary
+
+PR #585 (`eramos/ai-engineering:feat_translations`) translates three Spanish
+section headers to English across the 14 runbook files under
+`.ai-engineering/runbooks/`:
+
+- `## Objetivo` → `## Objective`
+- `## Precondiciones` → `## Prerequisites`
+- `## Procedimiento` → `## Procedure`
+
+These three are the *only* Spanish headers present (verified by accent/keyword
+sweep — no residual remains). However the PR edits the **live repo copies
+only**. Each runbook has a byte-identical twin under
+`src/ai_engineering/templates/.ai-engineering/runbooks/` that ships to every
+downstream install via `ai-eng install`. The PR leaves those twins in Spanish,
+so installs of every IDE would still receive Spanish headers — the change is
+not yet cross-IDE.
+
+There is no CI guard enforcing repo↔template runbook byte-parity today
+(`validate_runbooks` only asserts files exist), so this drift is silent — the
+same gap class previously seen with `.ai-engineering/scripts/*` template twins.
+
+This spec completes PR #585 by (1) applying the identical three-header
+translation to the 14 template twins so installs match the live repo, and
+(2) adding a CI parity guard so repo↔template runbook drift can never ship
+silently again. Delivery is a commit pushed directly onto the PR #585 fork
+branch (`maintainerCanModify: true`), keeping it a single PR under the original
+author.
+
+## Goals
+
+- Translate the same three headers (`Objetivo`→`Objective`,
+  `Precondiciones`→`Prerequisites`, `Procedimiento`→`Procedure`) in all 14
+  template runbooks so each template twin is byte-identical to its live repo
+  counterpart after PR #585.
+- Add a CI test asserting every `.ai-engineering/runbooks/*.md` is
+  byte-identical to its `src/ai_engineering/templates/.ai-engineering/runbooks/`
+  twin (extending `tests/unit/test_runbook_contracts.py`, which already imports
+  both roots and lists all 14 runbooks).
+- Land the fix as a commit on the existing PR #585 fork branch — one PR, single
+  author, complete change.
+
+## Non-Goals
+
+- Translating any content other than the three named headers (no body prose,
+  no frontmatter, no other files). PR #585 already covers the live copies.
+- Mirroring runbooks to per-IDE surfaces (`.codex/`, `.github/`, `.agents/`).
+  Runbooks are IDE-agnostic and live only under the shared `.ai-engineering/`
+  tree plus its install template; "cross-IDE" here means install/template
+  parity, not per-IDE duplication.
+- Generalising the parity guard to other template trees (scripts, hooks already
+  have their own parity tests). Scope is runbooks only.
+- Opening a separate upstream branch or second PR.
+
+## Decisions
+
+### D-runbook-template-parity-01 — Translate the 14 template twins to match the live repo copies
+
+Apply the identical three-header substitution to every file under
+`src/ai_engineering/templates/.ai-engineering/runbooks/*.md` so each twin equals
+its `.ai-engineering/runbooks/` counterpart byte-for-byte after PR #585's live
+edits.
+
+**Rationale**: The template tree is what `ai-eng install` ships to downstream
+projects regardless of IDE. Leaving it Spanish means the PR's intent (English
+consistency, noticed during the workshop) never reaches installs. Byte-parity
+with the live copy is the established contract for the runbook twins.
+
+### D-runbook-template-parity-02 — Add a repo↔template runbook byte-parity CI guard
+
+Extend `tests/unit/test_runbook_contracts.py` with a test that, for each of the
+14 runbooks, asserts `RUNBOOK_ROOT/<name>.md` and `TEMPLATE_ROOT/<name>.md`
+have identical bytes; fail loud with the offending filename(s).
+
+**Rationale**: The drift PR #585 introduced was silent — no gate caught the
+template twin lagging the live copy. A byte-parity assertion closes the gap
+permanently at near-zero cost, reusing the roots and runbook list the test
+module already defines. This is the runbook analogue of the existing hook/script
+template-parity tests.
+
+### D-runbook-template-parity-03 — Deliver as a commit on the PR #585 fork branch
+
+Push the template translations + parity guard onto
+`eramos/ai-engineering:feat_translations` (`maintainerCanModify: true`) rather
+than opening a new branch/PR.
+
+**Rationale**: The operator asked to "fix this PR." A single PR keeps authorship
+and review history intact, and the parity guard will run against the combined
+(live + template) change in one CI pass — proving completeness before merge.
+
+## Risks
+
+- **Template twin not byte-identical after edit** — a stray whitespace or
+  line-ending difference would make D2's guard fail. Mitigation: apply the
+  substitution mechanically and run the new parity test locally before pushing.
+- **Parity guard surfaces *other* pre-existing drift** — if any of the 14 twins
+  already differs beyond the three headers, the new test will flag it. This is
+  desirable (it is the bug the guard exists to catch) but may expand the diff.
+  Mitigation: a pre-flight `diff` over all 14 pairs confirmed they are currently
+  identical, so post-translation they will match.
+- **Pushing to a fork branch requires maintainer push access** — verified
+  `maintainerCanModify: true`. If push is rejected, fall back to a new upstream
+  branch (the rejected delivery option) without changing D1/D2.
+- **Missing CHANGELOG entry** — header translation is not user-facing runtime
+  behavior; no CHANGELOG entry required, consistent with PR #585's own scope.

--- a/.ai-engineering/state/specs/spec-169.json
+++ b/.ai-engineering/state/specs/spec-169.json
@@ -1,0 +1,11 @@
+{
+  "branch": "feat_translations",
+  "created": "2026-06-07T21:36:41.553921+00:00",
+  "extra": {},
+  "pr": "585",
+  "shipped": "2026-06-08T08:59:20.329242+00:00",
+  "slug": "runbook-template-parity",
+  "spec_id": "spec-169",
+  "state": "shipped",
+  "title": "Runbook header translations: template parity + cross-IDE"
+}


### PR DESCRIPTION
Post-merge consolidation for spec-169 (runbook header translations: template parity + cross-IDE), shipped via PR #585 (merge `da6f348d`).

- Mark spec-169 SHIPPED in its sidecar (pr=585, branch=feat_translations).
- Archive spec.md + plan.md under `.ai-engineering/specs/archive/spec-169-runbook-template-parity/`.
- Append the `_history.md` row.
- Live `spec.md`/`plan.md` slot cleared back to placeholder.

Governance-only; no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)