### PR TITLE
docs(readme): darken badge value color for WCAG AA contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
   <p><strong>Turn AI-assisted delivery into a governed local workflow — in any repo, any IDE.</strong></p>
 
   <p>
-    <a href="https://pypi.org/project/ai-engineering/"><img src="https://img.shields.io/pypi/v/ai-engineering.svg?style=flat-square&color=00D4AA&labelColor=0B1120" alt="PyPI version"></a>
-    <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11%2B-00D4AA.svg?style=flat-square&labelColor=0B1120" alt="Python 3.11+"></a>
+    <a href="https://pypi.org/project/ai-engineering/"><img src="https://img.shields.io/pypi/v/ai-engineering.svg?style=flat-square&color=2C7E6D&labelColor=0B1120" alt="PyPI version"></a>
+    <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11%2B-2C7E6D.svg?style=flat-square&labelColor=0B1120" alt="Python 3.11+"></a>
     <a href="https://github.com/arcasilesgroup/ai-engineering/actions"><img src="https://img.shields.io/github/actions/workflow/status/arcasilesgroup/ai-engineering/ci-check.yml?branch=main&style=flat-square&labelColor=0B1120" alt="CI"></a>
-    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/quality_gate/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=00D4AA" alt="Quality Gate"></a>
-    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/coverage/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=00D4AA" alt="Coverage"></a>
-    <a href="https://snyk.io/test/github/arcasilesgroup/ai-engineering"><img src="https://img.shields.io/badge/Snyk-monitored-00D4AA?style=flat-square&labelColor=0B1120" alt="Snyk security"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-00D4AA.svg?style=flat-square&labelColor=0B1120" alt="License: MIT"></a>
+    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/quality_gate/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=2C7E6D" alt="Quality Gate"></a>
+    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/coverage/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=2C7E6D" alt="Coverage"></a>
+    <a href="https://snyk.io/test/github/arcasilesgroup/ai-engineering"><img src="https://img.shields.io/badge/Snyk-monitored-2C7E6D?style=flat-square&labelColor=0B1120" alt="Snyk security"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-2C7E6D.svg?style=flat-square&labelColor=0B1120" alt="License: MIT"></a>
   </p>
 
   <p><code>54 skills · 9 agents · 6 surfaces · 1 governed flow</code></p>


### PR DESCRIPTION
## Summary

- README badge value backgrounds used the brand teal \`#00D4AA\`; shields.io renders white text on it at **1.91:1**, below the WCAG AA 4.5:1 floor — the symptom the green made the badge text hard to read.
- Swapped the value color to the repo's AA-safe brand teal \`#2C7E6D\` (**4.87:1**) across all 6 branded badges. Same teal family, just dark enough for white text.
- The CI **build** badge is intentionally untouched — its value color is status-driven (green pass / red fail) and overriding it would hide CI state.

## Test Plan

- Contrast check: white-on-\`#2C7E6D\` = 4.87:1 (PASS AA) vs old white-on-\`#00D4AA\` = 1.91:1 (FAIL).
- \`pytest tests/docs\` — 525 passed, 3 skipped (README line-cap + docs gates green).
- Visual: reload README on GitHub after shields.io cache expires.

## Checklist

- [x] Lint / secret scan (local gate: 0 findings)
- [x] Docs tests pass
- [x] No breaking changes (docs-only, single file)