### PR TITLE
fix(ci): restore worktree-fast fixture + fix install-time-budget bare clone (ARC-268)

### DIFF
--- a/.github/workflows/install-time-budget.yml
+++ b/.github/workflows/install-time-budget.yml
@@ -94,8 +94,17 @@ jobs:
       - name: T-4.7 median-of-3 install + smoke commit
         run: |
           . .smoke-venv/bin/activate || . .smoke-venv/Scripts/activate
-          # Stage a bare repo from the fixture so `git clone` is realistic.
-          git clone --bare "$FIXTURE_DIR" fixture.git
+          # The fixture is tracked as plain files inside this repo, not as a
+          # nested git repo, so `git clone --bare "$FIXTURE_DIR"` fails with
+          # `fatal: repository '<dir>' does not exist` (exit 128). Stage the
+          # fixture into a throwaway repo first, then bare-clone from that so
+          # the per-run `git clone` stays realistic. Staging is outside the
+          # timed loop, so it does not count against the G-11 budget.
+          rm -rf fixture-src fixture.git
+          mkdir -p fixture-src
+          cp -R "$FIXTURE_DIR"/. fixture-src/
+          (cd fixture-src && git init -b main -q && git add -A && git commit -q -m "chore: fixture init")
+          git clone --bare fixture-src fixture.git
           declare -a TIMINGS
           for run in 1 2 3; do
             rm -rf "run-$run"

--- a/.github/workflows/worktree-fast-second.yml
+++ b/.github/workflows/worktree-fast-second.yml
@@ -84,6 +84,23 @@ jobs:
           pip install dist/*.whl
           which ai-eng
 
+      # Provision the prereq security binaries the G-12 "clean machine with
+      # prereqs" scenario assumes. ai-eng's installer has no real network
+      # mechanism to fetch gitleaks (see install-smoke.yml), and semgrep ships
+      # as a Python package; without them on PATH `ai-eng install` exits 80 on
+      # unresolved tool gaps before it can wire the post-install gate. ubuntu
+      # runners do not prebake gitleaks. Provisioned outside the timed loop so
+      # the G-12 wall-clock budget is unaffected.
+      - name: Install prereq binaries (gitleaks + semgrep)
+        env:
+          GITLEAKS_VERSION: "8.30.0"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin gitleaks
+          gitleaks version
+          python -m pip install --quiet semgrep
+          semgrep --version
+
       - name: Stage primary worktree
         run: |
           . .smoke-venv/bin/activate

--- a/.github/workflows/worktree-fast-second.yml
+++ b/.github/workflows/worktree-fast-second.yml
@@ -84,20 +84,36 @@ jobs:
           pip install dist/*.whl
           which ai-eng
 
-      # Provision the prereq security binaries the G-12 "clean machine with
-      # prereqs" scenario assumes. ai-eng's installer has no real network
-      # mechanism to fetch gitleaks (see install-smoke.yml), and semgrep ships
-      # as a Python package; without them on PATH `ai-eng install` exits 80 on
-      # unresolved tool gaps before it can wire the post-install gate. ubuntu
-      # runners do not prebake gitleaks. Provisioned outside the timed loop so
-      # the G-12 wall-clock budget is unaffected.
-      - name: Install prereq binaries (gitleaks + semgrep)
+      # Provision the fixture's baseline prereq binaries the G-12 "clean
+      # machine with prereqs" scenario assumes. ai-eng's installer has no real
+      # network mechanism to fetch gitleaks (see install-smoke.yml), and
+      # semgrep ships as a Python package; without them `ai-eng install` exits
+      # 80 on unresolved tool gaps before it can wire the post-install gate.
+      #
+      # CRITICAL (ARC-268): the fixture manifest sets `python_env.mode: uv-tool`,
+      # so the installer's verify guard (D-101-02 user-scope allowlist) ONLY
+      # accepts tools resolved under a user-scope prefix (~/.local, the uv tools
+      # dir, ...). Binaries in /usr/local/bin or /usr/bin (jq is prebaked there)
+      # raise UserScopeViolation at verify time and are counted MISSING even
+      # though they are on PATH -- the real cause of the never-green exit 80.
+      # Install gitleaks AND jq into ~/.local/bin and put it ahead on PATH so
+      # the verify guard accepts them. semgrep flows through uv-tool user-scope
+      # already. Provisioned outside the timed loop so the G-12 budget is
+      # unaffected.
+      - name: Install prereq binaries (gitleaks + jq + semgrep)
         env:
           GITLEAKS_VERSION: "8.30.0"
         run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar xz -C /usr/local/bin gitleaks
-          gitleaks version
+            | tar xz -C "$HOME/.local/bin" gitleaks
+          chmod +x "$HOME/.local/bin/gitleaks"
+          "$HOME/.local/bin/gitleaks" version
+          # jq is prebaked at /usr/bin/jq (outside the user-scope allowlist);
+          # copy it into ~/.local/bin so it resolves user-scoped for verify.
+          install -m 0755 "$(command -v jq)" "$HOME/.local/bin/jq"
+          "$HOME/.local/bin/jq" --version
           python -m pip install --quiet semgrep
           semgrep --version
 

--- a/tests/fixtures/worktree-fast/python-multi-worktree/.ai-engineering/manifest.yml
+++ b/tests/fixtures/worktree-fast/python-multi-worktree/.ai-engineering/manifest.yml
@@ -1,0 +1,64 @@
+# Worktree-fast fixture for spec-101 G-12 (T-4.8).
+#
+# Purpose: drive `.github/workflows/worktree-fast-second.yml`. The workflow
+# copies this fixture into a `primary` worktree, primes the user-global uv
+# tool cache once, then measures median-of-3 second-worktree
+# `ai-eng install` + commit wall-clock. G-12 budget: <= 30s when
+# `python_env.mode: uv-tool` (D-101-12), because Python tools live in
+# `~/.local/share/uv/tools/` instead of a per-cwd `.venv/`.
+#
+# Kept intentionally lean and mirrored on the canonical manifest so the
+# fail surface stays small. Sibling of
+# `tests/fixtures/install-time-budget/python-single-stack` and
+# `tests/fixtures/install-smoke/clean-project`.
+#
+# Layout invariants (mirrored from the canonical manifest):
+# - `required_tools:` MUST stay the LAST top-level key (lint normaliser
+#   contract — see `validator/categories/required_tools.py:88-115`).
+# - `prereqs:` and `python_env:` precede it and exercise the same loaders
+#   the production manifest uses (D-101-12 + D-101-14).
+
+schema_version: "2.0"
+framework_version: "0.4.0"
+name: worktree-fast-python-multi-worktree
+version: "0.0.1"
+
+providers:
+  vcs: github
+  ides: [terminal]
+  stacks: [python]
+
+ai_providers:
+  enabled: [claude_code]
+  primary: claude_code
+
+# Quality gates — kept identical to canonical to avoid divergent thresholds.
+quality:
+  coverage: 80
+  duplication: 3
+  cyclomatic: 10
+  cognitive: 15
+
+# Prereqs — pin uv to the supported range so the install exercises the
+# version-range probe (R-8).
+prereqs:
+  uv:
+    version_range: ">=0.4.0,<1.0"
+
+# uv-tool mode is the whole point of G-12: Python tools install to
+# ~/.local/share/uv/tools/ (user-global), so a fresh worktree reuses the hot
+# cache instead of rebuilding a per-cwd .venv/.
+python_env:
+  mode: uv-tool
+
+# Required tools — minimal baseline + python only.
+required_tools:
+  baseline:
+    - {name: gitleaks}
+    - {name: semgrep, platform_unsupported: [windows], unsupported_reason: "semgrep has no Windows release"}
+    - {name: jq}
+  python:
+    - {name: ruff}
+    - {name: ty}
+    - {name: pip-audit}
+    - {name: pytest, scope: user_global}

--- a/tests/fixtures/worktree-fast/python-multi-worktree/.gitignore
+++ b/tests/fixtures/worktree-fast/python-multi-worktree/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.smoke-venv/
+dist/
+.ai-engineering/state/

--- a/tests/fixtures/worktree-fast/python-multi-worktree/pyproject.toml
+++ b/tests/fixtures/worktree-fast/python-multi-worktree/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "worktree-fast-python-multi-worktree"
+version = "0.0.1"
+description = "Worktree-fast fixture for spec-101 G-12 (<= 30s median second-worktree install)."
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## ARC-268 — CI hygiene: worktree-fast + install-time-budget

Restaura la salud de los workflows perf `schedule`/advisory de `ai-engineering` que llevaban 4+ días rojos. Los fallos son **advisory** (no gates de push/deploy), pero enmascaran regresiones reales. Diagnóstico completo (cebolla de capas) en [ARC-268](https://github.com/arcasilesgroup/ai-engineering/issues).

### Commits
1. `test(fixtures)` — recrea el fixture ausente `tests/fixtures/worktree-fast/python-multi-worktree/` (causa del `cp: cannot stat` original).
2. `fix(ci)` install-time-budget — stage del fixture en un repo real antes del bare-clone (arregla `fatal: repository ... does not exist`, exit 128).
3. `fix(ci)` worktree-fast — provisiona gitleaks + semgrep prereqs.
4. `fix(ci)` worktree-fast — **provisiona gitleaks + jq en user-scope `~/.local/bin`**. Bajo `python_env.mode: uv-tool`, el verify guard del installer (D-101-02) rechaza binarios fuera del prefijo user-scope; gitleaks en `/usr/local/bin` y jq en `/usr/bin` contaban como ausentes → `ai-eng install` exit 80. **Verificado localmente: exit 80 → exit 0.**
5. `ci(worktree-fast)` — diagnostic temporal (no-fatal) para la capa 4 (ver abajo).

### Alcance / capas
- ✅ Capa 1 (fixture), 2 (bare-clone), 3 (exit-80 user-scope) — resueltas y verificadas.
- 🔎 Capa 4 (NUEVA, expuesta tras la 3): `detector/readiness.py::_get_version` crashea con `OSError [Errno 8] Exec format error: 'gitleaks'` (no captura `OSError`). Diagnóstico en curso (commit 5) para identificar el binario roto en PATH; se trackea como follow-up.
- install-time-budget exit-80 cross-OS (3 OS) → follow-up ARC-291.

### Gates
- Proposer≠executor, reviewer≠builder: soy AUTOR del PR, no builder ni reviewer. El **merge es el gate humano terminal**.
- CI requerido: verde (incl. `Verify Gate Trailers` — commits llevan `Ai-Eng-Gate: passed` tras correr el gate local real).

Refs: ARC-268 · ARC-291
