### PR TITLE
fix(ci): stabilize Nightly Matrix — cross-platform test fixes + timeout (ARC-269)

### DIFF
--- a/.github/workflows/nightly-matrix.yml
+++ b/.github/workflows/nightly-matrix.yml
@@ -25,7 +25,13 @@ jobs:
   nightly-matrix:
     name: Nightly Matrix (Python ${{ matrix.python-version }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Windows cells legitimately run the full unit+integration suite in ~29min
+    # (2x ubuntu; no compiled-wheel cache parity). A 30min cap cancelled the
+    # slowest Windows cell mid-run every night, and a *cancelled* job forces the
+    # whole run's conclusion to `cancelled` even under continue-on-error — which
+    # masked the real advisory signal. 45min leaves headroom without hiding a
+    # genuine hang (GitHub's hard job ceiling is 6h).
+    timeout-minutes: 45
     # spec-140 W2 D-140-03: advisory only — cell failures do not block.
     continue-on-error: true
     defaults:
@@ -47,8 +53,12 @@ jobs:
           git config --global user.email "ci@test.com"
           git config --global user.name "CI"
       - name: Run unit + integration tests (advisory)
+        # No `-x`: `-x` is `--maxfail=1` and silently overrode `--maxfail=3`,
+        # aborting the sweep at the first failing test and hiding every later
+        # cell result. Let the intended 3-failure budget stand so one flaky
+        # cell no longer masks real regressions elsewhere in the suite.
         run: |
-          uv run pytest tests/unit tests/integration -q -x --maxfail=3
+          uv run pytest tests/unit tests/integration -q --maxfail=3
 
   reachability-audit:
     name: Pinned-SHA reachability audit (advisory)

--- a/src/ai_engineering/policy/orchestrator.py
+++ b/src/ai_engineering/policy/orchestrator.py
@@ -242,21 +242,30 @@ def _has_active_spec(project_root: Path | None = None) -> bool:
     return active_work_plane_has_active_spec(root)
 
 
-def _snapshot_mtimes(paths: list[Path]) -> dict[Path, int]:
-    snapshot: dict[Path, int] = {}
+# Snapshot both mtime and size. Relying on ``st_mtime_ns`` alone is unreliable
+# on filesystems with coarse timestamp resolution (notably Windows/NTFS via
+# Python's stat): a fixer that rewrites a file within the same mtime tick as the
+# pre-snapshot leaves ``mtime_ns`` unchanged and the edit goes undetected. Size
+# is a cheap, resolution-independent tie-breaker — a real reformat/autofix
+# almost always changes the byte count — so a change in *either* field flags the
+# file as modified.
+def _snapshot_mtimes(paths: list[Path]) -> dict[Path, tuple[int, int]]:
+    snapshot: dict[Path, tuple[int, int]] = {}
     for p in paths:
         try:
-            snapshot[p] = p.stat().st_mtime_ns
+            st = p.stat()
+            snapshot[p] = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
-            snapshot[p] = 0
+            snapshot[p] = (0, -1)
     return snapshot
 
 
-def _modified_since(pre: dict[Path, int]) -> list[str]:
+def _modified_since(pre: dict[Path, tuple[int, int]]) -> list[str]:
     modified: list[str] = []
     for p, before in pre.items():
         try:
-            now = p.stat().st_mtime_ns
+            st = p.stat()
+            now = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
             continue
         if now != before:
@@ -636,7 +645,30 @@ def _atomic_write_text(path: Path, payload: str) -> None:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
         raise
-    os.replace(tmp_path, str(path))
+    _replace_with_retry(tmp_path, str(path))
+
+
+# Windows does not allow ``os.replace`` to atomically clobber a destination
+# that another handle currently holds open (a concurrent reader, or a racing
+# replace onto the same target). POSIX has no such restriction. The failure
+# surfaces as ``PermissionError(13, 'Access is denied')`` and is transient:
+# the conflicting handle is released within microseconds. Retry with a short
+# bounded back-off so concurrent atomic publishes converge on every platform.
+# On POSIX the first attempt always succeeds, so this is a no-op there.
+_REPLACE_RETRIES: int = 10
+_REPLACE_BACKOFF_S: float = 0.01
+
+
+def _replace_with_retry(src: str, dst: str) -> None:
+    """``os.replace`` with a bounded retry on transient Windows lock errors."""
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(_REPLACE_BACKOFF_S * (attempt + 1))
 
 
 def publish_gate_document(

--- a/tests/unit/test_orchestrator_wave2.py
+++ b/tests/unit/test_orchestrator_wave2.py
@@ -85,8 +85,16 @@ _CI_CHECKERS: tuple[str, ...] = _LOCAL_CHECKERS + _CI_EXTRA_CHECKERS
 # would gap by check duration (>=100ms typical).
 _PARALLEL_SPAWN_WINDOW_S: float = 0.100  # 100 ms
 
-# Wall-clock parallelism overhead allowance: total <= 1.5x slowest checker.
-_PARALLEL_OVERHEAD_FACTOR: float = 1.5
+# Wall-clock parallelism discriminator. The test proves the run is *parallel*
+# (~max of the checker durations) and not *serial* (~sum). Rather than pin an
+# absolute-ms ceiling off the slowest checker — which is dominated by
+# ThreadPool spawn + scheduler jitter and flakes on shared macOS/Windows CI
+# runners (observed 95-130ms against a 90ms 1.5x bound) — we assert the run
+# lands comfortably inside the parallel regime: at most this fraction of the
+# serial sum. A genuinely serial implementation physically cannot beat the
+# serial sum, so 0.7x is impossible to reach serially while leaving generous
+# headroom for runner noise.
+_MAX_FRACTION_OF_SERIAL: float = 0.7
 
 
 # ---------------------------------------------------------------------------
@@ -541,13 +549,14 @@ def test_wave2_wall_clock_ms_is_max_not_sum(tmp_path: Path) -> None:
         result = run_wave2(staged_files=[tmp_path / "f.py"], mode="local")
     elapsed_s = time.monotonic() - t0
 
-    upper_bound_s = slowest_s * _PARALLEL_OVERHEAD_FACTOR
+    upper_bound_s = sum_s * _MAX_FRACTION_OF_SERIAL
     assert elapsed_s <= upper_bound_s, (
-        f"Wave 2 wall-clock MUST be max-not-sum: parallel run should "
-        f"finish in <= {upper_bound_s * 1000:.1f}ms ("
-        f"{_PARALLEL_OVERHEAD_FACTOR}x slowest = {slowest_s * 1000:.1f}ms); "
-        f"observed {elapsed_s * 1000:.1f}ms (serial sum would be "
-        f"{sum_s * 1000:.1f}ms)"
+        f"Wave 2 wall-clock MUST be max-not-sum: a parallel run finishes near "
+        f"the slowest checker ({slowest_s * 1000:.1f}ms) plus pool overhead, "
+        f"well under the serial sum ({sum_s * 1000:.1f}ms). Observed "
+        f"{elapsed_s * 1000:.1f}ms, which exceeds the {_MAX_FRACTION_OF_SERIAL:g}x "
+        f"serial-sum ceiling of {upper_bound_s * 1000:.1f}ms — the run is not "
+        f"parallel."
     )
     # And the orchestrator's reported wall_clock_ms MUST be <= same bound.
     assert result.wall_clock_ms <= int(upper_bound_s * 1000) + 50, (


### PR DESCRIPTION
## What & why

`Nightly Matrix (advisory)` in this repo has reported **recurrent macOS/Windows cell failures** and a **workflow-level `cancelled`** most nights (e.g. run `28700461738`, 2026-07-04: ubuntu ✅, macOS ❌×3, windows ❌/cancelled). It is a `schedule`/advisory workflow (`continue-on-error: true`), so `main` is **not** broken for merge/deploy — but the persistent red **masks future real regressions**, which is exactly what an advisory sweep must not do.

Triaged by the IT-Admin GitHub health sweep → **ARC-269** (split out of ARC-268 / #619; **not** in scope of that PR). Root-caused into four independent issues below. Ubuntu was always green.

**Proposer ≠ executor:** this PR is the proposal; **merge is the human gate** and the reviewer must be a **separate identity**.

## Root causes & fixes

### 1. macOS (all py) — flaky wall-clock perf assertion
`tests/unit/test_orchestrator_wave2.py::test_wave2_wall_clock_ms_is_max_not_sum` pinned an **absolute** ceiling of `1.5× slowest = 90ms`. That bound is dominated by `ThreadPool` spawn + scheduler jitter on shared runners (observed **95–128ms** on macOS). The test's real job is to prove the run is **parallel (≈max), not serial (≈sum=200ms)**.
**Fix:** re-anchor to a fraction of the **serial sum** — `0.7× = 140ms`. A serial implementation physically cannot finish under the sum, so this still proves max-not-sum while tolerating runner noise. (test-only change)

### 2. Windows (3.12/3.13) — atomic-write `PermissionError(13)`
`test_emit_findings_atomic_write` failed under concurrent emit: Windows forbids `os.replace` from atomically clobbering a destination another handle currently holds open (racing replace / concurrent reader). The error is **transient** — POSIX has no such restriction.
**Fix:** bounded `PermissionError` retry with short back-off around the atomic publish in `orchestrator._atomic_write_text`. No-op on POSIX (first attempt always succeeds). This is a genuine cross-platform **robustness** improvement, not just a test fix.

### 3. Windows (3.13) — intermittently missed file modification
`test_wave1_records_files_modified` occasionally saw `files_modified == []`: coarse NTFS mtime resolution left `st_mtime_ns` unchanged when a fixer rewrote a file within the same tick.
**Fix:** snapshot `(st_mtime_ns, st_size)` and flag modified on a change in **either** field. Size is a cheap, resolution-independent tie-breaker (a real reformat/autofix changes the byte count).

### 4. Workflow-level `cancelled`
Windows cells legitimately run the full unit+integration suite in **~29min** (2× ubuntu). The `timeout-minutes: 30` cap **cancelled** the slowest Windows cell mid-run, and a *cancelled* job forces the whole run's conclusion to `cancelled` **even under `continue-on-error`** — which is what surfaced as the nightly red.
**Fix:** `timeout-minutes: 30 → 45` (headroom without hiding a genuine hang). Also dropped the redundant **`-x`** from the pytest step: `-x` is `--maxfail=1` and silently overrode the intended `--maxfail=3`, aborting the sweep at the **first** failure and hiding every later cell result.

## Verification
- Locally (ubuntu): the three targeted tests + the full `test_orchestrator_emit_findings.py` module pass; `ruff check`, `ruff format --check`, and `ty check` clean on the changed source.
- Cross-platform (macOS/Windows) validation: `Nightly Matrix (advisory)` dispatched on this branch via `workflow_dispatch` — see the linked run. **This is the real green signal** (the matrix does not run on PR events).

## Scope / risk
- Advisory scheduled workflow — **not** a push/deploy gate.
- Source changes (`orchestrator.py`) are additive robustness (retry + size tie-breaker); the perf change is test-only; the workflow change is timeout + flag.
- Reviewer ≠ builder: I authored this; a separate human/identity merges.

Closes ARC-269 on merge.
