### PR TITLE
fix(ci): provision install-time-budget prereqs into user-scope across 3 OS (ARC-291)

### DIFF
--- a/.github/workflows/install-time-budget.yml
+++ b/.github/workflows/install-time-budget.yml
@@ -86,6 +86,81 @@ jobs:
           pip install dist/*.whl
           which ai-eng
 
+      # Provision the fixture's baseline prereq binaries (gitleaks + jq +
+      # semgrep) into a user-scope prefix BEFORE the timed loop. Same root
+      # cause as worktree-fast (ARC-268), now across the full 3-OS matrix:
+      # the fixture manifest sets `python_env.mode: uv-tool`, so the installer
+      # verify guard (D-101-02 user-scope allowlist,
+      # user_scope_install.py::_install_target_prefixes) accepts a tool ONLY
+      # when it resolves under a user-scope prefix. Runner-prebaked binaries in
+      # /usr/bin or /usr/local/bin raise UserScopeViolation and are counted
+      # MISSING even though they are on PATH -- `ai-eng install` then exits 80
+      # on unresolved tool gaps before wiring the post-install gate.
+      #
+      # `$HOME/.local` is an allowlisted install-target prefix on EVERY OS, so
+      # we land gitleaks + jq there uniformly (Linux/macOS/Windows) rather than
+      # depending on OS-specific brew/scoop prefixes. semgrep goes through
+      # `uv tool install` (shim -> the uv user-executable dir under ~/.local),
+      # NOT `pip install` -- pip would drop the console script in the
+      # hosted-toolcache Python bin, which is OUTSIDE the allowlist and would
+      # itself trip UserScopeViolation. semgrep has no Windows release, so it
+      # is skipped there (fixture manifest: platform_unsupported: [windows]).
+      #
+      # All provisioning is outside the timed loop, so the G-11 600s budget is
+      # unaffected.
+      - name: Install prereq binaries (gitleaks + jq [+ semgrep])
+        env:
+          GITLEAKS_VERSION: "8.30.0"
+        run: |
+          set -euo pipefail
+          BIN="$HOME/.local/bin"
+          mkdir -p "$BIN"
+          # Prepend the user-scope bin to PATH for all later steps. On Windows,
+          # translate the msys path to a native Windows path so the (native)
+          # Python installer resolves it via shutil.which -- a raw /c/... msys
+          # entry is invisible to native-Windows PATH lookup.
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            cygpath -w "$BIN" >> "$GITHUB_PATH"
+          else
+            echo "$BIN" >> "$GITHUB_PATH"
+          fi
+
+          case "${RUNNER_OS}" in
+            Linux)
+              curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+                | tar xz -C "$BIN" gitleaks
+              chmod +x "$BIN/gitleaks"
+              install -m 0755 "$(command -v jq)" "$BIN/jq"
+              ;;
+            macOS)
+              # macos-latest runners are Apple Silicon (arm64).
+              curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz" \
+                | tar xz -C "$BIN" gitleaks
+              chmod +x "$BIN/gitleaks"
+              install -m 0755 "$(command -v jq)" "$BIN/jq"
+              ;;
+            Windows)
+              curl -sSfL -o gitleaks.zip "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_windows_x64.zip"
+              # Git-bash `tar` is GNU tar (no zip support); use PowerShell.
+              powershell -NoProfile -Command "Expand-Archive -Force gitleaks.zip gitleaks_unzip"
+              cp gitleaks_unzip/gitleaks.exe "$BIN/gitleaks.exe"
+              cp "$(command -v jq)" "$BIN/jq.exe"
+              ;;
+          esac
+
+          # gitleaks + jq land user-scoped on every OS; verify from ~/.local/bin.
+          "$BIN/gitleaks" version
+          "$BIN/jq" --version
+
+          # semgrep: Linux + macOS only (no Windows release). uv is provisioned
+          # by ./.github/actions/setup-env; `uv tool install` shims semgrep into
+          # the user-scope executable dir under ~/.local so the verify guard
+          # accepts it.
+          if [ "${RUNNER_OS}" != "Windows" ]; then
+            uv tool install --quiet semgrep
+            semgrep --version
+          fi
+
       # T-4.7: median-of-3. Each run is `git clone <fixture> && cd <fixture>
       # && ai-eng install . && git commit --allow-empty -m "chore: smoke"`.
       # The conventional-commit prefix satisfies the framework's own


### PR DESCRIPTION
## What

Adds a **prereq-provisioning step** to `.github/workflows/install-time-budget.yml` (spec-101 G-11) so the fixture's baseline binaries (`gitleaks`, `jq`, `semgrep`) exist in a **user-scope** location before the timed loop — fixing the `exit 80 "unresolved tool gaps"` failure across the full **ubuntu / macos / windows** matrix.

Follow-up to **ARC-268**, gobernado (proposer≠executor; this PR is the human review gate).

## Why (root cause)

Same class as worktree-fast (ARC-268), now on 3 OS. The fixture manifest sets `python_env.mode: uv-tool`, so the installer verify guard (`D-101-02` user-scope allowlist — `src/ai_engineering/installer/user_scope_install.py::_install_target_prefixes` / `_safe_run`) accepts a required tool **only** when it resolves under a user-scope prefix. `gitleaks`/`jq` prebaked in `/usr/bin` or `/usr/local/bin` raise `UserScopeViolation` and are counted **MISSING** even though they're on `PATH` → `ai-eng install --non-interactive` exits 80 before the median loop can run. `install-time-budget` provisioned **no** prereqs, so it failed on every OS.

## How

Provision into `$HOME/.local/bin` — an **allowlisted install-target prefix on every OS** — so the change is uniform and independent of OS-specific brew/scoop/winget prefixes:

| Tool | Linux | macOS (arm64) | Windows |
|---|---|---|---|
| gitleaks | pinned `v8.30.0` `linux_x64` tarball → `~/.local/bin` | `darwin_arm64` tarball → `~/.local/bin` | `windows_x64` zip (PowerShell `Expand-Archive` — git-bash `tar` is GNU tar, no zip) → `~/.local/bin` |
| jq | copy runner-prebaked jq → `~/.local/bin` | same | same (`jq.exe`) |
| semgrep | `uv tool install semgrep` (shim under `~/.local`) | same | **skipped** — no Windows release (manifest: `platform_unsupported: [windows]`) |

Key correctness points:
- **`uv tool install semgrep`, not `pip install`** — pip would drop the console script in the hosted-toolcache Python `bin`, which is **outside** the allowlist and would itself trip `UserScopeViolation`.
- **Windows PATH**: the user-scope bin is written to `$GITHUB_PATH` as a **native** Windows path via `cygpath -w` — a raw `/c/...` msys entry is invisible to native-Python `shutil.which` lookup. (Addresses the PowerShell/msys PATH-semantics concern called out in ARC-291.)
- Provisioning runs **outside** the timed loop → the G-11 600s budget is unaffected.

## Verification

- ✅ `actionlint` clean (includes shellcheck of the embedded bash).
- ✅ YAML parses.
- ⏳ **Cross-OS CI is not locally reproducible** (macos/windows) — validated empirically by dispatching the workflow on this branch (`workflow_dispatch`). Result linked in a follow-up comment once the 3-OS matrix reports.

## Dependency / stacking

Based on `fix/arc-268-perf-workflow-fixtures` (**PR #619**, still open), which carries the prerequisite fixture-staging fix (`7d91a6a8`, exit-128 bare-clone) this builds on. **Merge #619 first**, then this retargets cleanly to `main`.

## Governance

- proposer≠executor: this PR **is** the human review/merge gate — do not self-merge.
- reviewer≠builder: assign a reviewer of a **separate identity / distinct model family**.
- Scope: CI workflow only (`+75` lines, one file); no product/business code, no prod state.

Closes ARC-291 (on merge, after #619).