### PR TITLE
fix(readiness): catch OSError (ENOEXEC) in _get_version so a bad PATH binary can't abort install (ARC-292)

### DIFF
--- a/src/ai_engineering/detector/readiness.py
+++ b/src/ai_engineering/detector/readiness.py
@@ -234,7 +234,12 @@ def _get_version(name: str) -> str | None:
             line = line.strip()
             if line:
                 return line
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+        # OSError subsumes FileNotFoundError and also covers exec anomalies such
+        # as ``Errno 8 ENOEXEC`` ("Exec format error") from a mis-formatted or
+        # wrong-arch binary that happens to be resolvable on PATH. A version
+        # probe must never abort the install because of a bad binary on PATH:
+        # treat any of these as "version unavailable" and return None.
         pass
     return None
 

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -19,6 +19,7 @@ from ai_engineering.detector.readiness import (
     _STACK_TOOLS,
     ReadinessReport,
     ToolInfo,
+    _get_version,
     check_all_tools,
     check_operational_readiness,
     check_tool,
@@ -129,6 +130,54 @@ class TestCheckTool:
         assert info.available is False
         assert info.version is None
         assert info.path is None
+
+
+# ---------------------------------------------------------------------------
+# _get_version() robustness (ARC-292)
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionRobustness:
+    """A version probe must never abort the install on a bad binary on PATH."""
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_enoexec_returns_none(self, mock_run: MagicMock) -> None:
+        """ARC-292: an ENOEXEC (Errno 8) binary on PATH must not propagate.
+
+        Regression for the ``worktree-fast`` install crash where ``gitleaks``
+        resolved to a mis-formatted target inside ``ai-eng install`` and
+        ``_get_version`` re-raised ``OSError: [Errno 8] Exec format error``,
+        tearing down the entire install.
+        """
+        import errno
+
+        mock_run.side_effect = OSError(errno.ENOEXEC, "Exec format error")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_generic_oserror_returns_none(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = OSError("permission denied")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_file_not_found_still_returns_none(self, mock_run: MagicMock) -> None:
+        # FileNotFoundError is an OSError subclass; behaviour must be preserved.
+        mock_run.side_effect = FileNotFoundError("no such file")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.shutil.which")
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_check_tool_survives_enoexec(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        """End-to-end: a resolvable-but-unexecutable binary stays 'available'."""
+        import errno
+
+        resolved = "/home/runner/.local/bin/gitleaks"
+        mock_which.return_value = resolved
+        mock_run.side_effect = OSError(errno.ENOEXEC, "Exec format error")
+        info = check_tool("gitleaks")
+        assert info.available is True
+        assert info.version is None
+        assert info.path == resolved
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What / Why

`detector/readiness.py::_get_version` caught `(subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired)` but **not** `OSError`. When a mis-formatted / wrong-arch binary is *resolvable on PATH*, `subprocess.run` raises `OSError: [Errno 8] Exec format error` (**ENOEXEC**). That propagated up:

```
_get_version (readiness.py:225)
  -> check_tool (readiness.py:106)
  -> check_tools_for_stacks (readiness.py:159)
  -> _run_operational_phases (installer/service.py:553)
```

…and tore down the **entire `ai-eng install`**.

### Evidence (from ARC-268 → ARC-292 CI diagnosis)
In the *same* runner step-env, immediately before `ai-eng install`:
- `file ~/.local/bin/gitleaks` → `ELF 64-bit LSB executable, x86-64 … statically linked` (valid).
- `which -a gitleaks` → `/home/runner/.local/bin/gitleaks`.
- Identical Python probe `subprocess.run(["gitleaks","version"])` → **rc:0, "8.30.0"**.

~5s later, the identical call **inside** `ai-eng install` (`_get_version`) → `OSError Exec format error`. A version *probe* must never abort the install because of a bad binary on PATH — regardless of the exec-resolution root cause.

## Change (surgical)
- Widen the `except` in `_get_version` to `OSError` (which **subsumes `FileNotFoundError`** and covers `ENOEXEC`) → return `None`.
- Add `TestGetVersionRobustness`:
  - ENOEXEC (`errno.ENOEXEC`) stub → `None`
  - generic `OSError` → `None`
  - `FileNotFoundError` regression guard (behaviour preserved)
  - end-to-end `check_tool()` → a resolvable-but-unexecutable tool stays `available=True`, `version=None` instead of crashing.

## Verification
- `pytest tests/unit/test_readiness.py` → **26 passed**
- `ruff check` (changed files) → clean
- `ty check` (readiness.py) → All checks passed

## Scope note (for reviewer)
This is **layer 4 / robustness** only — the deliberate minimal defensive fix from ARC-292 §1. The **root-cause investigation** (§2 — *why* `gitleaks` resolves to a malformed target *inside* uv-tool-mode install: suspected partial/wrong-arch binary from a baseline-tool install prepended on PATH, or `os.environ['PATH']` mutation at install start) is intentionally **out of scope here** and tracked separately. I noticed the pip-fallback branch in `_try_install` (readiness.py:303) has the same narrow `except` and would exhibit the same class of failure if `pip` itself is malformed on PATH — flagging for your call on whether to fold in; left untouched to keep this diff to the documented crash site.

## Governance
Authored by **it-admin** (proposer≠executor). This PR **is** the human review gate — reviewer≠builder: please review/merge separately. Do not self-merge.

Refs: ARC-292 (Paperclip), ARC-268, PR #619 (layers 1–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)