### PR TITLE
fix(installer): stop clobbering user-scope binaries + ENOEXEC crash (ARC-300)

### DIFF
--- a/src/ai_engineering/detector/readiness.py
+++ b/src/ai_engineering/detector/readiness.py
@@ -234,7 +234,12 @@ def _get_version(name: str) -> str | None:
             line = line.strip()
             if line:
                 return line
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+        # OSError subsumes FileNotFoundError and also covers exec anomalies such
+        # as ``Errno 8 ENOEXEC`` ("Exec format error") from a mis-formatted or
+        # wrong-arch binary that happens to be resolvable on PATH. A version
+        # probe must never abort the install because of a bad binary on PATH:
+        # treat any of these as "version unavailable" and return None.
         pass
     return None
 

--- a/src/ai_engineering/installer/mechanisms/__init__.py
+++ b/src/ai_engineering/installer/mechanisms/__init__.py
@@ -514,6 +514,41 @@ def _download_release_binary(url: str, target_path: Path) -> InstallResult:
     driver actually used inside ``stderr`` of a failed result so callers
     can surface the diagnostic. Raises :class:`SecurityError` only when
     the urllib path triggers a hostname / scheme / cap guard.
+
+    The download is **atomic** (spec: ARC-300 bug #2). Every driver writes
+    into a sibling temp path in ``target_path.parent`` -- ``curl --output`` /
+    ``wget -O`` create+truncate their destination up front, so writing them
+    straight into ``target_path`` would leave a pre-existing binary at 0
+    bytes the instant the transfer 404s. We only ``os.replace(tmp, target)``
+    on the first non-failed outcome (an atomic rename on one filesystem);
+    on failure the temp is unlinked and ``target_path`` is left untouched.
+    The temp lives in the same directory as the target so the rename never
+    crosses a filesystem boundary.
+    """
+    # Sibling temp in the SAME directory so ``os.replace`` is atomic. The
+    # leading dot + pid keeps it out of the way and unique per process; we
+    # do NOT pre-create it (a bare name), so a driver that reports success
+    # without producing a file leaves ``target_path`` genuinely untouched.
+    tmp_path = target_path.parent / f".{target_path.name}.download-{os.getpid()}"
+    try:
+        outcome = _run_download_drivers(url, tmp_path)
+        if not outcome.failed and tmp_path.exists():
+            # First non-failed driver produced bytes -- land them atomically.
+            os.replace(tmp_path, target_path)
+        return outcome
+    finally:
+        # Failure (or a success that already renamed the temp away) leaves no
+        # residue: unlink any leftover temp, never touching ``target_path``.
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+
+
+def _run_download_drivers(url: str, tmp_path: Path) -> InstallResult:
+    """Run the curl -> wget -> urllib chain against ``tmp_path``.
+
+    Returns the first non-failed :class:`InstallResult`, else the last
+    failure. The caller owns the atomic rename of ``tmp_path`` onto the
+    real target; this helper only drives the download into the temp.
     """
     last_failure: InstallResult | None = None
     for driver in _DOWNLOAD_DRIVER_PREFERENCE:
@@ -526,7 +561,7 @@ def _download_release_binary(url: str, target_path: Path) -> InstallResult:
                 )
                 continue
             try:
-                outcome = _try_subprocess_download(driver, url, target_path)
+                outcome = _try_subprocess_download(driver, url, tmp_path)
             except Exception as exc:
                 # _safe_run can raise UserScopeViolation / MissingDriverError
                 # before any subprocess fires. Treat as soft failure so the
@@ -542,7 +577,7 @@ def _download_release_binary(url: str, target_path: Path) -> InstallResult:
             last_failure = outcome
             continue
         # urllib branch
-        outcome = _download_via_urllib(url, target_path)
+        outcome = _download_via_urllib(url, tmp_path)
         if not outcome.failed:
             return outcome
         last_failure = outcome

--- a/src/ai_engineering/installer/phases/tools.py
+++ b/src/ai_engineering/installer/phases/tools.py
@@ -627,6 +627,17 @@ class ToolsPhase:
         if resolve_user_scope_binary(tool.name) is None:
             return False
 
+        # Honour the ``AIENG_TEST_SIMULATE_FAIL`` seam (ARC-300): a tool flagged
+        # to simulate an install failure must be driven through the (failing)
+        # dispatch path, never adopted as pre-existing-healthy. Otherwise the
+        # EXIT-80 integration tests silently pass on runners that pre-provision
+        # the tool user-scoped (e.g. ``ruff`` in ``~/.local/bin`` on macOS),
+        # where adoption would fire before the failure injection. The seam is
+        # inert outside ``AIENG_TEST=1`` (returns ``None``), so production
+        # adoption behaviour is unchanged.
+        if _check_simulate_fail(tool.name) is not None:
+            return False
+
         try:
             verify_result = run_verify(tool_spec or registry_entry)
         except Exception:

--- a/src/ai_engineering/installer/phases/tools.py
+++ b/src/ai_engineering/installer/phases/tools.py
@@ -50,6 +50,7 @@ from ai_engineering.installer.user_scope_install import (
     _check_simulate_fail,
     _check_simulate_install_ok,
     capture_os_release,
+    resolve_user_scope_binary,
     run_verify,
 )
 from ai_engineering.state.manifest import load_python_env_mode, load_required_tools
@@ -603,6 +604,49 @@ class ToolsPhase:
         return bool(getattr(verify_result, "passed", False))
 
     @staticmethod
+    def _adopt_preexisting_user_scope(
+        tool: ToolSpec,
+        *,
+        registry_entry: dict[str, Any],
+        tool_spec: dict[str, Any] | None,
+        state: InstallState,
+        result: PhaseResult,
+        current_os_release: str,
+    ) -> bool:
+        """Adopt an already-healthy user-scope binary on a fresh install.
+
+        Returns True (and records ``INSTALLED``) when ``tool`` resolves to a
+        user-scope path AND its offline-safe verify probe passes -- so the
+        caller skips ``mechanism.install()`` entirely (ARC-300 bug #4).
+        Returns False otherwise, leaving the caller to dispatch the install.
+
+        The user-scope decision is delegated to
+        :func:`resolve_user_scope_binary` so the ``~/.local/bin`` prefix
+        logic stays single-sourced in ``user_scope_install``.
+        """
+        if resolve_user_scope_binary(tool.name) is None:
+            return False
+
+        try:
+            verify_result = run_verify(tool_spec or registry_entry)
+        except Exception:
+            # ``run_verify`` raises ``UnsafeVerifyCommand`` on a forbidden
+            # probe; any raise means we cannot prove health, so fall through
+            # to a normal install rather than adopt an unverified binary.
+            return False
+        if not getattr(verify_result, "passed", False):
+            return False
+
+        state.required_tools_state[tool.name] = _build_record(
+            state=ToolInstallState.INSTALLED,
+            mechanism="preexisting-user-scope",
+            version=getattr(verify_result, "version", None),
+            os_release=current_os_release,
+        )
+        result.skipped.append(f"tool:{tool.name}:preexisting-user-scope")
+        return True
+
+    @staticmethod
     def _should_skip_idempotent(
         tool: ToolSpec,
         *,
@@ -622,7 +666,23 @@ class ToolsPhase:
         """
         existing_record = state.required_tools_state.get(tool.name)
         if existing_record is None:
-            return False
+            # ARC-300 bug #4: on a FRESH install (no prior state record) a
+            # functional user-scope binary may already exist on the machine
+            # (e.g. the CI runner pre-provisions a healthy gitleaks). Without
+            # this guard the phase falls through to ``mechanism.install()``
+            # and the download clobbers the healthy binary. If the tool
+            # already resolves user-scoped AND its verify probe passes, adopt
+            # it as INSTALLED and skip -- never hand it to a mechanism.
+            # ``--force`` is honoured upstream (the caller skips this whole
+            # predicate when force is set), so a forced run still re-installs.
+            return ToolsPhase._adopt_preexisting_user_scope(
+                tool,
+                registry_entry=registry_entry,
+                tool_spec=tool_spec,
+                state=state,
+                result=result,
+                current_os_release=current_os_release,
+            )
         if existing_record.state != ToolInstallState.INSTALLED:
             return False
 

--- a/src/ai_engineering/installer/user_scope_install.py
+++ b/src/ai_engineering/installer/user_scope_install.py
@@ -51,6 +51,7 @@ __all__ = (
     "capture_os_release",
     "emit_path_snippet",
     "resolve_driver",
+    "resolve_user_scope_binary",
     "run_verify",
 )
 
@@ -496,6 +497,28 @@ def _is_under_user_scope(resolved: Path) -> bool:
     # ``.venv/bin/...`` segments are also accepted via marker detection so
     # any ancestor virtualenv (not just CWD-rooted) is honoured.
     return ".venv" in resolved.parts
+
+
+def resolve_user_scope_binary(name: str) -> Path | None:
+    """Return the resolved Path for ``name`` when it lives in user scope.
+
+    Resolves ``name`` on ``PATH`` (``shutil.which``) and returns the
+    absolute Path only when it lands under one of the D-101-02 (a)
+    install-target prefixes (``~/.local``, ``~/.cargo``, an active venv,
+    ...). Returns ``None`` when the tool is absent, or resolves to a
+    system / privileged location outside user scope.
+
+    Single source of truth for "is this tool already a healthy user-scope
+    install?" -- delegates the prefix decision to :func:`_is_under_user_scope`
+    so callers never hand-roll the ``~/.local/bin`` check (ARC-300 bug #4).
+    """
+    located = shutil.which(name)
+    if located is None:
+        return None
+    resolved = Path(located)
+    if not resolved.is_absolute():
+        resolved = resolved.resolve()
+    return resolved if _is_under_user_scope(resolved) else None
 
 
 def _is_under_driver_allowlist(resolved: Path) -> bool:

--- a/tests/unit/test_github_release_binary_fallback.py
+++ b/tests/unit/test_github_release_binary_fallback.py
@@ -127,7 +127,13 @@ def test_wget_used_when_curl_absent(tmp_path: Path) -> None:
     assert seen_argv[0][0] == "wget"
     # BusyBox-safe argv: only ``-O <path> <url>`` (no --show-progress).
     assert seen_argv[0][1] == "-O"
-    assert seen_argv[0][2] == str(target)
+    # ARC-300 bug #2 (atomic download): the driver writes into a sibling temp
+    # in ``target.parent``, NOT straight into ``target`` -- so a 404 can't
+    # truncate a pre-existing binary. ``os.replace`` lands it on ``target``
+    # only on success. wget's ``-O`` destination is therefore that temp path.
+    wget_dest = Path(seen_argv[0][2])
+    assert wget_dest.parent == target.parent
+    assert wget_dest.name.startswith(f".{target.name}.download-")
     assert seen_argv[0][3].startswith("https://github.com/")
 
 

--- a/tests/unit/test_install_mechanisms.py
+++ b/tests/unit/test_install_mechanisms.py
@@ -579,3 +579,113 @@ def test_all_12_mechanisms_have_install_method() -> None:
         install = getattr(cls, "install", None)
         assert install is not None, f"{cls.__name__} is missing `install`"
         assert callable(install), f"{cls.__name__}.install is not callable"
+
+
+# ---------------------------------------------------------------------------
+# ARC-300 bug #2: _download_release_binary must be clobber-safe (atomic)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadReleaseBinaryAtomicity:
+    """`_download_release_binary` writes into a sibling temp and only
+    ``os.replace`` on the first non-failed outcome.
+
+    Regression: ``curl --output`` / ``wget -O`` create+truncate the
+    destination BEFORE the transfer, so a 404 left a pre-existing healthy
+    binary at 0 bytes. The atomic path must leave ``target_path``
+    byte-for-byte unchanged on failure and land the new bytes on success.
+    """
+
+    _URL = "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks"
+
+    def _import(self):
+        from ai_engineering.installer import mechanisms
+
+        return mechanisms
+
+    def test_failed_download_leaves_preexisting_target_byte_for_byte(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mechanisms = self._import()
+        target = tmp_path / "gitleaks"
+        healthy = b"HEALTHY-GITLEAKS-BINARY-v8.30.0\x00\x01\x02"
+        target.write_bytes(healthy)
+
+        def _truncating_fail(driver: str, _url: str, temp_path: Path) -> Any:
+            # Mimic curl --output / wget -O: create+truncate the destination
+            # to 0 bytes up front, THEN report the 404. If the temp were the
+            # real target, the healthy binary would now be gone.
+            Path(temp_path).write_bytes(b"")
+            return mechanisms.InstallResult(
+                failed=True, stderr=f"{driver}: HTTP 404", mechanism="GitHubReleaseBinaryMechanism"
+            )
+
+        monkeypatch.setattr(mechanisms.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(mechanisms, "_try_subprocess_download", _truncating_fail)
+        monkeypatch.setattr(
+            mechanisms,
+            "_download_via_urllib",
+            lambda _url, _tp: mechanisms.InstallResult(
+                failed=True, stderr="urllib: HTTP 404", mechanism="GitHubReleaseBinaryMechanism"
+            ),
+        )
+
+        result = mechanisms._download_release_binary(self._URL, target)
+
+        assert result.failed is True
+        assert target.exists(), "failed download must NOT delete the pre-existing binary"
+        assert target.read_bytes() == healthy, "target must be unchanged (not 0 bytes)"
+        # No temp residue left behind in the target directory.
+        residue = sorted(p.name for p in tmp_path.iterdir() if p.name != "gitleaks")
+        assert residue == [], f"temp download artefacts leaked: {residue}"
+
+    def test_successful_download_replaces_atomically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mechanisms = self._import()
+        target = tmp_path / "gitleaks"
+        target.write_bytes(b"OLD-BINARY")
+        new_bytes = b"NEW-GITLEAKS-BINARY-v9.0.0"
+
+        def _writing_ok(_driver: str, _url: str, temp_path: Path) -> Any:
+            Path(temp_path).write_bytes(new_bytes)
+            return mechanisms.InstallResult(failed=False, mechanism="GitHubReleaseBinaryMechanism")
+
+        monkeypatch.setattr(mechanisms.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(mechanisms, "_try_subprocess_download", _writing_ok)
+
+        result = mechanisms._download_release_binary(self._URL, target)
+
+        assert result.failed is False
+        assert target.read_bytes() == new_bytes, "successful download must land the new bytes"
+        residue = sorted(p.name for p in tmp_path.iterdir() if p.name != "gitleaks")
+        assert residue == [], f"temp download artefacts leaked: {residue}"
+
+    def test_failed_download_no_preexisting_target_creates_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mechanisms = self._import()
+        target = tmp_path / "gitleaks"  # does not exist
+
+        monkeypatch.setattr(mechanisms.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            mechanisms,
+            "_try_subprocess_download",
+            lambda driver, _url, _tp: mechanisms.InstallResult(
+                failed=True, stderr=f"{driver}: HTTP 404", mechanism="GitHubReleaseBinaryMechanism"
+            ),
+        )
+        monkeypatch.setattr(
+            mechanisms,
+            "_download_via_urllib",
+            lambda _url, _tp: mechanisms.InstallResult(
+                failed=True, stderr="urllib: HTTP 404", mechanism="GitHubReleaseBinaryMechanism"
+            ),
+        )
+
+        result = mechanisms._download_release_binary(self._URL, target)
+
+        assert result.failed is True
+        assert not target.exists(), "a failed fresh download must not leave a partial target"
+        residue = sorted(p.name for p in tmp_path.iterdir())
+        assert residue == [], f"temp download artefacts leaked: {residue}"

--- a/tests/unit/test_installer_phase_tools.py
+++ b/tests/unit/test_installer_phase_tools.py
@@ -597,12 +597,61 @@ class TestPreexistingUserScopeAdoption:
                 "resolve_user_scope_binary",
                 return_value=Path.home() / ".local" / "bin" / "gitleaks",
             ),
-            patch.object(
-                tools_phase, "run_verify", side_effect=RuntimeError("probe blew up")
-            ),
+            patch.object(tools_phase, "run_verify", side_effect=RuntimeError("probe blew up")),
         ):
             phase = tools_phase.ToolsPhase()
             plan = phase.plan(context)
             phase.execute(plan, context)
 
         mech.install.assert_called_once()
+
+    def test_simulate_fail_seam_defeats_adoption(
+        self, context: InstallContext, monkeypatch: Any
+    ) -> None:
+        """A tool flagged via ``AIENG_TEST_SIMULATE_FAIL`` is NOT adopted.
+
+        Regression (ARC-300): on runners that pre-provision a healthy
+        user-scope binary (e.g. ``ruff`` in ``~/.local/bin`` on macOS), the
+        adoption path fired *before* the simulate-fail injection and returned
+        exit 0 -- silently defeating the EXIT-80 integration tests. Adoption
+        must defer to the failure seam so the (failing) dispatch path runs.
+        """
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.installer.user_scope_install import VerifyResult
+        from ai_engineering.state.models import InstallState
+
+        monkeypatch.setenv("AIENG_TEST", "1")
+        monkeypatch.setenv("AIENG_TEST_SIMULATE_FAIL", "gitleaks")
+
+        install_state = InstallState()  # FRESH: no prior record
+        context.existing_state = install_state
+
+        mech = MagicMock()
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            # Healthy, user-scope, verify-passing -- adoption WOULD fire if the
+            # simulate-fail seam were not honoured first.
+            patch.object(
+                tools_phase,
+                "resolve_user_scope_binary",
+                return_value=Path.home() / ".local" / "bin" / "gitleaks",
+            ),
+            patch.object(
+                tools_phase,
+                "run_verify",
+                return_value=VerifyResult(passed=True, version="8.30.0"),
+            ),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            result = phase.execute(plan, context)
+
+        # Not adopted: the failure seam drove the dispatch path to FAILED.
+        record = install_state.required_tools_state["gitleaks"]
+        assert record.state == ToolInstallState.FAILED_NEEDS_MANUAL
+        assert any("simulated-fail" in f for f in result.failed)
+        # The real mechanism is never invoked (the seam short-circuits it).
+        mech.install.assert_not_called()

--- a/tests/unit/test_installer_phase_tools.py
+++ b/tests/unit/test_installer_phase_tools.py
@@ -416,3 +416,193 @@ class TestStackLevelPlatformSkip:
         records = context.existing_state.required_tools_state
         assert "swiftlint" not in records
         assert "swift-format" not in records
+
+
+# ---------------------------------------------------------------------------
+# ARC-300 bug #4: adopt a healthy pre-existing user-scope tool on a FRESH
+# install (no prior state record) instead of re-provisioning + clobbering it.
+# ---------------------------------------------------------------------------
+
+
+def _single_gitleaks_load_result() -> _FakeLoadResult:
+    """Fake ``LoadResult`` carrying only gitleaks (USER_GLOBAL)."""
+    return _FakeLoadResult(tools=[ToolSpec(name="gitleaks", scope=ToolScope.USER_GLOBAL)])
+
+
+class TestPreexistingUserScopeAdoption:
+    """Fresh install + healthy user-scope binary => INSTALLED, no install()."""
+
+    def _registry(self, mech: Any) -> dict[str, Any]:
+        return {
+            "gitleaks": {
+                "darwin": [mech],
+                "linux": [mech],
+                "win32": [mech],
+                # spec: verify probe gitleaks detect --no-git --source /dev/null
+                "verify": {
+                    "cmd": ["gitleaks", "detect", "--no-git", "--source", "/dev/null"],
+                    "regex": r"\d+\.\d+\.\d+",
+                },
+            }
+        }
+
+    def test_healthy_user_scope_recorded_installed_without_install_call(
+        self, context: InstallContext
+    ) -> None:
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.installer.user_scope_install import VerifyResult
+        from ai_engineering.state.models import InstallState
+
+        install_state = InstallState()  # FRESH: no prior record for gitleaks
+        context.existing_state = install_state
+        assert "gitleaks" not in install_state.required_tools_state
+
+        mech = MagicMock()
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            patch.object(
+                tools_phase,
+                "resolve_user_scope_binary",
+                return_value=Path.home() / ".local" / "bin" / "gitleaks",
+            ),
+            patch.object(
+                tools_phase,
+                "run_verify",
+                return_value=VerifyResult(passed=True, version="8.30.0"),
+            ),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            result = phase.execute(plan, context)
+
+        record = install_state.required_tools_state["gitleaks"]
+        assert record.state == ToolInstallState.INSTALLED
+        assert record.mechanism == "preexisting-user-scope"
+        assert record.version == "8.30.0"
+        # The load-bearing assertion: the broken download is NEVER reached.
+        mech.install.assert_not_called()
+        assert any("preexisting-user-scope" in s for s in result.skipped)
+
+    def test_force_still_installs_over_healthy_user_scope(self, context: InstallContext) -> None:
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.installer.user_scope_install import VerifyResult
+        from ai_engineering.state.models import InstallState
+
+        install_state = InstallState()
+        context.existing_state = install_state
+        context.force = True  # --force must bypass the adoption skip
+
+        mech = MagicMock()
+        mech.install.return_value = _ok_install_result("GitHubReleaseBinaryMechanism")
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            patch.object(
+                tools_phase,
+                "resolve_user_scope_binary",
+                return_value=Path.home() / ".local" / "bin" / "gitleaks",
+            ),
+            patch.object(
+                tools_phase,
+                "run_verify",
+                return_value=VerifyResult(passed=True, version="8.30.0"),
+            ),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            phase.execute(plan, context)
+
+        # --force ignores the adoption path and re-installs via the mechanism.
+        mech.install.assert_called_once()
+
+    def test_not_user_scope_falls_through_to_install(self, context: InstallContext) -> None:
+        """A system-scope (non-user) gitleaks is NOT adopted -> mechanism runs."""
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.state.models import InstallState
+
+        install_state = InstallState()
+        context.existing_state = install_state
+
+        mech = MagicMock()
+        mech.install.return_value = _ok_install_result("GitHubReleaseBinaryMechanism")
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            # Resolver returns None -> not under user scope (e.g. /usr/bin).
+            patch.object(tools_phase, "resolve_user_scope_binary", return_value=None),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            phase.execute(plan, context)
+
+        mech.install.assert_called_once()
+
+    def test_user_scope_but_verify_fails_falls_through_to_install(
+        self, context: InstallContext
+    ) -> None:
+        """A user-scope gitleaks whose verify FAILS is not adopted."""
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.installer.user_scope_install import VerifyResult
+        from ai_engineering.state.models import InstallState
+
+        install_state = InstallState()
+        context.existing_state = install_state
+
+        mech = MagicMock()
+        mech.install.return_value = _ok_install_result("GitHubReleaseBinaryMechanism")
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            patch.object(
+                tools_phase,
+                "resolve_user_scope_binary",
+                return_value=Path.home() / ".local" / "bin" / "gitleaks",
+            ),
+            patch.object(tools_phase, "run_verify", return_value=VerifyResult(passed=False)),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            phase.execute(plan, context)
+
+        mech.install.assert_called_once()
+
+    def test_user_scope_but_verify_raises_falls_through_to_install(
+        self, context: InstallContext
+    ) -> None:
+        """A raising verify probe (e.g. UnsafeVerifyCommand) is not adopted."""
+        from ai_engineering.installer.phases import tools as tools_phase
+        from ai_engineering.state.models import InstallState
+
+        install_state = InstallState()
+        context.existing_state = install_state
+
+        mech = MagicMock()
+        mech.install.return_value = _ok_install_result("GitHubReleaseBinaryMechanism")
+        with (
+            patch.object(
+                tools_phase, "load_required_tools", return_value=_single_gitleaks_load_result()
+            ),
+            patch.object(tools_phase, "TOOL_REGISTRY", self._registry(mech)),
+            patch.object(
+                tools_phase,
+                "resolve_user_scope_binary",
+                return_value=Path.home() / ".local" / "bin" / "gitleaks",
+            ),
+            patch.object(
+                tools_phase, "run_verify", side_effect=RuntimeError("probe blew up")
+            ),
+        ):
+            phase = tools_phase.ToolsPhase()
+            plan = phase.plan(context)
+            phase.execute(plan, context)
+
+        mech.install.assert_called_once()

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -19,6 +19,7 @@ from ai_engineering.detector.readiness import (
     _STACK_TOOLS,
     ReadinessReport,
     ToolInfo,
+    _get_version,
     check_all_tools,
     check_operational_readiness,
     check_tool,
@@ -129,6 +130,54 @@ class TestCheckTool:
         assert info.available is False
         assert info.version is None
         assert info.path is None
+
+
+# ---------------------------------------------------------------------------
+# _get_version() robustness (ARC-292)
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionRobustness:
+    """A version probe must never abort the install on a bad binary on PATH."""
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_enoexec_returns_none(self, mock_run: MagicMock) -> None:
+        """ARC-292: an ENOEXEC (Errno 8) binary on PATH must not propagate.
+
+        Regression for the ``worktree-fast`` install crash where ``gitleaks``
+        resolved to a mis-formatted target inside ``ai-eng install`` and
+        ``_get_version`` re-raised ``OSError: [Errno 8] Exec format error``,
+        tearing down the entire install.
+        """
+        import errno
+
+        mock_run.side_effect = OSError(errno.ENOEXEC, "Exec format error")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_generic_oserror_returns_none(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = OSError("permission denied")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_file_not_found_still_returns_none(self, mock_run: MagicMock) -> None:
+        # FileNotFoundError is an OSError subclass; behaviour must be preserved.
+        mock_run.side_effect = FileNotFoundError("no such file")
+        assert _get_version("gitleaks") is None
+
+    @patch("ai_engineering.detector.readiness.shutil.which")
+    @patch("ai_engineering.detector.readiness.subprocess.run")
+    def test_check_tool_survives_enoexec(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        """End-to-end: a resolvable-but-unexecutable binary stays 'available'."""
+        import errno
+
+        resolved = "/home/runner/.local/bin/gitleaks"
+        mock_which.return_value = resolved
+        mock_run.side_effect = OSError(errno.ENOEXEC, "Exec format error")
+        info = check_tool("gitleaks")
+        assert info.available is True
+        assert info.version is None
+        assert info.path == resolved
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Surgical, network-free safety tier (M1 of ARC-299) that stops `ai-eng install` from destroying a healthy user-scope binary and from crashing the whole install when a bad binary exists on PATH. Three independently-correct fixes:

- **Bug #4 — re-provision of a healthy tool (root cause of the CI clobber):** on a fresh install (no prior state record) a tool that already resolves user-scoped **and** passes `run_verify` is recorded `INSTALLED` (mechanism `preexisting-user-scope`) and skipped — never handed to `mechanism.install()`. `--force` still re-installs. User-scope check delegates to a new `resolve_user_scope_binary()` reusing `_is_under_user_scope` (no hand-rolled `~/.local/bin` prefix).
- **Bug #2 — the clobber itself:** release-binary download is now **atomic**. Every driver (curl/wget/urllib) writes into a sibling temp `.{name}.download-<pid>` in `target_path.parent`; only `os.replace(tmp, target)` on the first non-failed outcome; on failure the temp is unlinked in a `finally` and `target_path` is left **untouched**. spec-101 curl-argv contract preserved.
- **Bug #3 — ENOEXEC crash:** `detector/readiness.py::_get_version` now catches `OSError` (subsumes `FileNotFoundError`, covers `Errno 8 Exec format error`) and degrades to `None` instead of aborting the install.

## Test Plan (unit, no network)
- `test_readiness.py`: `_get_version` returns `None` (not raises) when `subprocess.run` raises `OSError(Errno 8)`.
- `test_install_mechanisms.py`: pre-existing valid target survives a 404/all-driver-fail download **byte-for-byte unchanged** (0-byte clobber regression); successful download replaces atomically with no temp residue.
- `test_installer_phase_tools.py`: healthy user-scope + passing verify → recorded `INSTALLED`, `mechanism.install()` **not called** even with no prior state record; `--force` still installs; non-user-scope / failing-verify / raising-verify all fall through to install.

Verification on the branch: **93 targeted pass**; broad installer/detector sweep **1351 passed, 11 skipped, 1 xfailed**. `ruff check` + `ruff format` clean.

## Work Items
- Milestone M1 of **ARC-299**; unblocks **ARC-291** (G-11 install-time-budget) and **ARC-268** (G-12 worktree-fast-second) cross-OS. (Paperclip tracking IDs — not GitHub issues, no auto-close.)
- Does **not** cover fresh provisioning of gitleaks/jq/opa — that is M2 (bug #1, sibling issue).

## Checklist
- [x] Lint/format clean (`ruff check`, `ruff format`)
- [x] Unit tests added + green (93 targeted; 1351 sweep)
- [x] No `# noqa` / `# nosec` / `# pragma: no cover` introduced (CONSTITUTION §13)
- [x] SHA-pin / download-URL path untouched (M1 changes no download URL)
- [x] Conventional commits (3)
- [ ] **Review by a separate identity** (reviewer ≠ builder) — recommended: **CSO** for the download-path security surface (temp/rename/allowlist), or QA / Architect
- [ ] Merge is a human gate (proposer ≠ executor; no auto-merge enabled)

---
Author: IT-Admin (proposer ≠ executor). Builder: Tech-Lead. This PR is the human review/merge gate; auto-merge intentionally **not** enabled.
