### PR TITLE
fix(ci): init fixture git repo before clone in install-time-budget

### DIFF
--- a/.github/workflows/install-time-budget.yml
+++ b/.github/workflows/install-time-budget.yml
@@ -94,6 +94,11 @@ jobs:
       - name: T-4.7 median-of-3 install + smoke commit
         run: |
           . .smoke-venv/bin/activate || . .smoke-venv/Scripts/activate
+          # Fixture is a plain directory (git doesn't track nested .git dirs).
+          # Init a throwaway git repo inside it so `git clone --bare` works.
+          git -C "$FIXTURE_DIR" init
+          git -C "$FIXTURE_DIR" add .
+          git -C "$FIXTURE_DIR" commit -m "chore: fixture initial commit" --allow-empty
           # Stage a bare repo from the fixture so `git clone` is realistic.
           git clone --bare "$FIXTURE_DIR" fixture.git
           declare -a TIMINGS


### PR DESCRIPTION
## Problem

`Install Time Budget` and `Worktree Fast (Second)` workflows have been failing on `main` since PR #623 merged (2026-07-05):

```
fatal: repository 'tests/fixtures/install-time-budget/python-single-stack' does not exist
```

## Root Cause

PR #623 added `tests/fixtures/install-time-budget/python-single-stack/` as a plain directory. The workflow does:

```bash
git clone --bare "$FIXTURE_DIR" fixture.git
```

This requires `FIXTURE_DIR` to be a git repository. Git does not track nested `.git` directories, so the fixture cannot have `.git` committed — it must be initialized at CI runtime.

## Fix

Added `git init && git add . && git commit` on the fixture directory before the bare clone step. The throwaway init runs only in the CI workspace, not in the repo itself.

## Test Plan
- [ ] Install Time Budget workflow passes on this PR
- [ ] Worktree Fast (Second) recovers on next nightly run

🤖 CTO sweep [ARC-297](/ARC/issues/ARC-297)