### PR TITLE
fix(gate-cache): keep momentarily-unreadable entries during prune (spec-104 Windows flake)

### DIFF
--- a/src/ai_engineering/policy/gate_cache.py
+++ b/src/ai_engineering/policy/gate_cache.py
@@ -202,20 +202,14 @@ def _replace_with_retry(src: str, dst: Path) -> None:
         raise last_exc
 
 
-def _read_safe(path: Path) -> dict | None:
-    """Return the parsed JSON dict, or ``None`` for missing/empty/corrupt files.
+def _parse_cache_bytes(raw_bytes: bytes, path: Path) -> dict | None:
+    """Parse cache-entry bytes into a dict, or ``None`` for corrupt *content*.
 
-    Logs a WARNING on corruption so operators see drift; never raises. Handles
-    binary garbage (invalid UTF-8) and truncated JSON in addition to standard
-    decode errors.
+    Pure — does no I/O and never raises, so callers can distinguish a genuine
+    content problem (empty / invalid UTF-8 / invalid JSON / non-object) from a
+    file that merely could not be opened (an ``OSError`` at the I/O layer).
+    Logs a WARNING on corruption so operators see drift.
     """
-    try:
-        raw_bytes = path.read_bytes()
-    except FileNotFoundError:
-        return None
-    except OSError as exc:
-        logger.warning("gate-cache entry unreadable at %s: %s", path, exc)
-        return None
     if not raw_bytes:
         return None
     try:
@@ -244,6 +238,23 @@ def _read_safe(path: Path) -> dict | None:
         )
         return None
     return parsed
+
+
+def _read_safe(path: Path) -> dict | None:
+    """Return the parsed JSON dict, or ``None`` for missing/empty/corrupt files.
+
+    Logs a WARNING on corruption so operators see drift; never raises. Handles
+    binary garbage (invalid UTF-8) and truncated JSON in addition to standard
+    decode errors.
+    """
+    try:
+        raw_bytes = path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning("gate-cache entry unreadable at %s: %s", path, exc)
+        return None
+    return _parse_cache_bytes(raw_bytes, path)
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +537,13 @@ def _prune_if_oversize(cache_dir: Path, max_entries: int = MAX_ENTRIES) -> int:
     are evicted unconditionally — they can't participate in LRU ordering and
     shouldn't waste disk space.
 
+    A file that is present but momentarily *unreadable* (``OSError`` — a
+    transient Windows share-lock from an AV scanner, indexer, or a concurrent
+    ``os.replace`` publishing a sibling entry) is NOT corruption: deleting it
+    would evict a healthy just-written entry (the spec-104 Windows flake where
+    a parallel persist+prune left 4 of 5 cache files). Such files are skipped
+    and left for a later prune to revisit once the lock clears.
+
     Returns the number of files removed (corrupted + LRU-evicted).
     """
     if not cache_dir.exists():
@@ -537,7 +555,20 @@ def _prune_if_oversize(cache_dir: Path, max_entries: int = MAX_ENTRIES) -> int:
     for child in cache_dir.iterdir():
         if not child.is_file() or child.suffix != ".json":
             continue
-        raw = _read_safe(child)
+        try:
+            raw_bytes = child.read_bytes()
+        except FileNotFoundError:
+            # Concurrently removed between iterdir and read — nothing to prune.
+            continue
+        except OSError as exc:
+            # Present-but-unreadable: transient lock, not corruption. Keep it.
+            logger.debug(
+                "gate-cache prune skipping momentarily-unreadable entry %s: %s",
+                child,
+                exc,
+            )
+            continue
+        raw = _parse_cache_bytes(raw_bytes, child)
         if raw is None:
             corrupted.append(child)
             continue

--- a/tests/unit/test_gate_cache_prune_transient_lock.py
+++ b/tests/unit/test_gate_cache_prune_transient_lock.py
@@ -1,0 +1,108 @@
+"""Regression: ``_prune_if_oversize`` must not evict momentarily-unreadable entries.
+
+Root cause of the spec-104 Windows Integration flake (ARC-305a / #625): the
+gate orchestrator runs Wave 2 checks in parallel, and ``persist`` calls
+``_prune_if_oversize`` after every write. On Windows a prune running in one
+thread opens sibling ``.json`` files via ``_read_safe`` while another thread is
+publishing a fresh entry with ``os.replace``; the momentary share-lock raises
+``PermissionError`` (an ``OSError``), which the old code funnelled to
+``_read_safe`` -> ``None`` -> "corrupted" -> ``path.unlink()``. That deleted a
+healthy just-written cache file, so the first run persisted only 4 of the 5
+Wave 2 entries and ``test_run_gate_mixed_hit_miss`` failed its precondition.
+
+POSIX never surfaces this (readers of an atomically-replaced file never get a
+lock error), which is why the flake is Windows-only. These tests reproduce it
+deterministically on any platform by making ``read_bytes`` raise ``OSError``
+for a specific present file, and assert that such a file is KEPT while genuine
+content corruption is still evicted.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+
+def _write_entry(cache_dir: Path, key: str, *, second: int = 0) -> Path:
+    """Write a valid gate-cache entry named ``<key>.json`` and return its path."""
+    path = cache_dir / f"{key}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "check_name": "ruff",
+                "result": {"outcome": "pass", "findings": []},
+                "verified_at": datetime(2026, 4, 26, 12, 0, second, tzinfo=UTC).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_prune_keeps_present_but_unreadable_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file that raises ``OSError`` on read is a transient lock, not corruption."""
+    from ai_engineering.policy import gate_cache
+
+    cache_dir = tmp_path / "gate-cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    readable = _write_entry(cache_dir, "a" * 32, second=1)
+    locked = _write_entry(cache_dir, "b" * 32, second=2)
+
+    real_read_bytes = Path.read_bytes
+
+    def flaky_read_bytes(self: Path) -> bytes:
+        # Simulate the Windows share-lock: the sibling being published is
+        # momentarily un-openable, exactly as a concurrent os.replace induces.
+        if self == locked:
+            raise PermissionError(13, "The process cannot access the file")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky_read_bytes)
+
+    removed = gate_cache._prune_if_oversize(cache_dir, max_entries=gate_cache.MAX_ENTRIES)
+
+    assert removed == 0, "A momentarily-locked healthy entry must not be evicted"
+    assert locked.exists(), "Locked-but-present entry was wrongly deleted (the flake)"
+    assert readable.exists(), "Unrelated healthy entry must survive"
+
+
+def test_prune_still_evicts_genuine_content_corruption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lock carve-out must not weaken eviction of readable-but-malformed files."""
+    from ai_engineering.policy import gate_cache
+
+    cache_dir = tmp_path / "gate-cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    healthy = _write_entry(cache_dir, "a" * 32, second=1)
+    locked = _write_entry(cache_dir, "b" * 32, second=2)
+
+    # Readable but malformed content — still corruption, still evictable.
+    truncated = cache_dir / ("c" * 32 + ".json")
+    truncated.write_text('{"check_name": "ruff", "result":', encoding="utf-8")
+    binary_garbage = cache_dir / ("d" * 32 + ".json")
+    binary_garbage.write_bytes(b"\x00\x01\x02\xffNOT-JSON")
+
+    real_read_bytes = Path.read_bytes
+
+    def flaky_read_bytes(self: Path) -> bytes:
+        if self == locked:
+            raise OSError(13, "locked")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky_read_bytes)
+
+    removed = gate_cache._prune_if_oversize(cache_dir, max_entries=gate_cache.MAX_ENTRIES)
+
+    assert removed == 2, f"Both malformed files must be evicted; removed={removed}"
+    assert not truncated.exists()
+    assert not binary_garbage.exists()
+    assert healthy.exists()
+    assert locked.exists(), "Locked healthy entry must be kept even amid corruption"


### PR DESCRIPTION
## What & why

Root-cause fix for the **spec-104 Windows `Integration` flake** that blocked the dependabot github-actions bump (**#625**, superseding #615) under ARC-305a / [ARC-306].

`test_orchestrator_cache_integration.py::test_run_gate_mixed_hit_miss` failed on Windows with:

```
precondition: first run must have persisted ≥5 cache files for the 5 Wave 2 checks; found 4
```

### Root cause (real, not flaky-by-luck)
The gate orchestrator runs Wave 2 checks **in parallel**, and `gate_cache.persist` calls `_prune_if_oversize` after **every** write. On Windows, a prune running in one thread opens sibling `.json` entries via `_read_safe` while another thread is publishing a fresh entry with `os.replace`. The momentary share-lock raises `PermissionError` (an `OSError`), which `_read_safe` funnelled to `None`, and `_prune_if_oversize` treats **every** `None` as *corrupted → `path.unlink()`*. So it **deleted a healthy just-written cache file** → only 4 of 5 entries persisted → precondition fails.

POSIX never surfaces this (a reader of an atomically-replaced file never gets a lock error), which is exactly why the flake was **Windows-only**. The same Python code passed on #620/#621's Windows Integration and failed on #625's → confirmed pre-existing race, unrelated to the action-version bump.

### Fix
Distinguish a **present-but-unreadable** file (transient `OSError`) from **genuine content corruption**:
- `_prune_if_oversize` now reads bytes directly and `continue`s (keeps the file) on `OSError` — a later prune revisits it once the lock clears. Only readable-but-malformed content (empty / invalid UTF-8 / invalid JSON / non-object) is still evicted.
- Extracted the pure parse step into `_parse_cache_bytes` so `_read_safe` and prune share it (no duplicated decode/shape logic).

### Test
New `tests/unit/test_gate_cache_prune_transient_lock.py` reproduces the race deterministically on any platform (makes `read_bytes` raise `OSError` for one present entry):
- **RED on old code**: the locked entry is wrongly evicted (`removed=3` vs `2`).
- **GREEN with fix**: the locked entry survives; genuine corruption is still cleaned out.

The immutable spec-104 integration test and the immutable `test_gate_cache_lru_prune.py` are untouched; the corrupt-eviction contract is preserved.

## Verification
- `pytest` gate-cache suites (prune / persist / hit-miss / coverage / new regression): **62 passed**.
- `ruff check` + `ruff format --check` + `ty check`: clean.
- Commit carries the `Ai-Eng-Gate: passed` trailer earned via the real `ai-eng gate commit-msg` (no `--no-verify`, no suppressors, no shims).

Once this lands, **#625** rebases onto main and its Windows `Integration` goes green.

Ref: ARC-306 (ARC-305a) · parent ARC-305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
