### PR TITLE
test(cache): serialize Wave 2 dispatch to kill Windows cache-persist flake (ARC-310)

### DIFF
--- a/tests/integration/test_orchestrator_cache_integration.py
+++ b/tests/integration/test_orchestrator_cache_integration.py
@@ -233,6 +233,32 @@ def _clean_cache_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AIENG_CACHE_DEBUG", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _serialize_gate_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force serial Wave 2 dispatch for the cache-semantics suite.
+
+    ``run_gate`` fans the 5 Wave 2 checks out across a ``ThreadPoolExecutor``
+    (default 4 workers, spec-139 M1.T5). Each check's cache-miss path calls
+    ``gate_cache.persist`` → ``_atomic_write`` → ``os.replace``. On Windows,
+    concurrent ``persist`` calls against neighbouring keys race an AV scanner /
+    Search indexer that momentarily locks freshly-created entries; under
+    pytest-xdist load the transient lock can outlast the bounded replace retry,
+    the orchestrator swallows the resulting error (best-effort cache contract),
+    and one ``<key>.json`` never lands. The suite's assertions count persisted
+    files (and expect all-hits on an identical re-run), so a single dropped
+    write flips them — the observed ``found 4`` flake in
+    ``test_run_gate_mixed_hit_miss`` on ``Integration (windows)``.
+
+    Cache hit/miss semantics are independent of dispatch concurrency, so we pin
+    ``AIENG_MAX_THREAD_WORKERS=1`` here to serialize the writes and make the
+    file-count preconditions deterministic on every platform. The parallel
+    dispatch path itself is covered by the dedicated ``run_wave2`` (T-2.4)
+    tests, so this loses no coverage.
+    """
+
+    monkeypatch.setenv("AIENG_MAX_THREAD_WORKERS", "1")
+
+
 def _findings_doc_dict(doc: object) -> dict[str, object]:
     """Coerce the orchestrator's return value to a plain dict.
 


### PR DESCRIPTION
## What & why

`Integration (windows)` intermittently fails with:

```
test_orchestrator_cache_integration.py::test_run_gate_mixed_hit_miss
AssertionError: precondition: first run must have persisted ≥5 cache files
for the 5 Wave 2 checks; found 4
(1 failed / 1136 passed, pytest-xdist popen-gw2, Windows)
```

This flake tumbled **#625** and can randomly tumble `Integration (windows)` on
**#620/#621**, so their "green" was not guaranteed. Root cause (grounded, not a
blind retry):

`run_gate` fans the 5 Wave 2 checks over a `ThreadPoolExecutor` (default 4
workers, spec-139 M1.T5). Each cache-miss runs
`gate_cache.persist → _atomic_write → os.replace`. On Windows, concurrent
`persist()` calls against neighbouring keys race an AV scanner / Search indexer
that briefly locks freshly-created entries. Under pytest-xdist load the lock can
outlast the bounded replace retry in `_replace_with_retry`; the orchestrator
swallows the resulting error (best-effort cache contract, `orchestrator.py`
~L1149), and **one `<key>.json` never lands**. The suite asserts persisted-file
counts (and all-hits on an identical re-run), so a single dropped write flips
the assertion.

## Fix

Pin `AIENG_MAX_THREAD_WORKERS=1` via a **module-scoped autouse fixture** so
dispatch is serial for this cache-semantics suite. This uses the documented
spec-139 M1.T5 seam — **no production behaviour change**.

- Cache hit/miss semantics are independent of dispatch concurrency, so the
  assertions keep their full intent.
- The parallel dispatch path stays covered by the dedicated `run_wave2` (T-2.4)
  tests → **no coverage lost**.
- Serializing also removes any concurrent-`git`-subprocess contention on the
  same window, so the fix is robust to either race source.

## Verification

Local (Linux), package installed via `uv`:

- `pytest tests/integration/test_orchestrator_cache_integration.py` → **8 passed**
- Under the flake config, 5 consecutive runs:
  `pytest ... -n 4` → **8 passed** each time.

## Scope note

This PR fixes **only** the test-quality flake (ARC-310 item 2). ARC-310 item 1
(#624) is already resolved: its git-init fixture root cause landed via **#619
(ARC-268)** and is in `main`; #624 was correctly closed as superseded by Dachi.

Two **separate** failures remain red on `main` HEAD `cb0fdb34` and are **out of
scope** for this PR (filed/escalated separately): `Worktree Fast (Second)`
(`FileNotFoundError: Git hooks directory not found: .../wt-1/.git/hooks` — the
installer doesn't handle linked worktrees where `.git` is a gitdir-pointer file)
and `Install Time Budget` (exit-80 `auto_remediation` tool-gap on macos+ubuntu).

Refs: ARC-310 · relates to ARC-306 / ARC-305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
