### PR TITLE
fix(ci): commit on a feature branch in install-time-budget smoke loop

### DIFF
--- a/.github/workflows/install-time-budget.yml
+++ b/.github/workflows/install-time-budget.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Install prereq binaries (gitleaks + jq [+ semgrep])
         env:
           GITLEAKS_VERSION: "8.30.0"
+          JQ_VERSION: "1.7.1"
         run: |
           set -euo pipefail
           BIN="$HOME/.local/bin"
@@ -144,7 +145,11 @@ jobs:
               # Git-bash `tar` is GNU tar (no zip support); use PowerShell.
               powershell -NoProfile -Command "Expand-Archive -Force gitleaks.zip gitleaks_unzip"
               cp gitleaks_unzip/gitleaks.exe "$BIN/gitleaks.exe"
-              cp "$(command -v jq)" "$BIN/jq.exe"
+              # The runner's `jq` on Windows is a Chocolatey shim that resolves
+              # the real exe relative to its own location, so copying the shim
+              # breaks it (exit 127: "Cannot find file ..\lib\jq\tools\jq.exe").
+              # Download the real jq binary instead, matching the gitleaks path.
+              curl -sSfL -o "$BIN/jq.exe" "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-windows-amd64.exe"
               ;;
           esac
 
@@ -186,7 +191,12 @@ jobs:
             START=$(date +%s)
             git clone fixture.git "run-$run"
             (cd "run-$run" && ai-eng install . --non-interactive)
-            (cd "run-$run" && git commit --allow-empty -m "chore: smoke commit")
+            # `ai-eng install` configures branch protection on `main`, so the
+            # first commit must land on a feature branch -- the governed model
+            # a real user follows. Committing on `main` trips the just-installed
+            # commit-msg gate ("branch-protection: Direct commits to 'main' are
+            # blocked"). Branch creation is a local no-cost op inside the loop.
+            (cd "run-$run" && git checkout -q -b smoke && git commit --allow-empty -m "chore: smoke commit")
             END=$(date +%s)
             ELAPSED=$((END - START))
             echo "Run $run: ${ELAPSED}s"


### PR DESCRIPTION
## Problem

`Install Time Budget` (spec-101 G-11) has been failing on `main` on all three OSes. Once #619 (bare-clone) and #621 (user-scope prereqs) landed and `ai-eng install` finally reached READY, the **next** action in the smoke loop failed:

```
Gate [commit-msg] FAIL
  ✗ FAIL branch-protection: failed
  Direct commits to 'main' are blocked. Use a feature branch.
```

## Root cause

Each timed run does `git clone fixture.git run-$run`, which checks out the fixture's default branch **`main`**. Then `ai-eng install` configures branch protection on `main`, and the smoke `git commit` lands on `main` — which the just-installed commit-msg gate correctly blocks. This is the **third and final layer** of the install-time-budget breakage (clone → #619, prereqs → #621, smoke-commit-branch → this PR).

## Fix

Check out a feature branch (`git checkout -b smoke`) before the smoke commit, modelling the governed first-commit flow a real user follows. Branch creation is a local no-cost op, so the G-11 600s budget is unaffected. No gate touched, no suppressor, no shim.

`worktree-fast-second` is **unaffected**: `git worktree add ../wt-$run` already lands each worktree on a non-main branch (`wt-$run`).

## Verification

- Local gates all PASS (pre-commit, pre-push, commit-msg 4/4 incl. `branch-protection` on the feature branch). Trailer `Ai-Eng-Gate: passed` earned, not pasted.
- `perf` label added so `Install Time Budget` runs on this PR across the 3-OS matrix. Merge only on real green.

🤖 Tech-Lead fix under CTO sweep [ARC-297](/ARC/issues/ARC-297) · lane [ARC-306](/ARC/issues/ARC-306)