### PR TITLE
fix: ARC-314 residual main-rojo — linked-worktree hooks install + install-time-budget green on 3 OS

### DIFF
--- a/.github/workflows/install-time-budget.yml
+++ b/.github/workflows/install-time-budget.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Install prereq binaries (gitleaks + jq [+ semgrep])
         env:
           GITLEAKS_VERSION: "8.30.0"
+          JQ_VERSION: "1.7.1"
         run: |
           set -euo pipefail
           BIN="$HOME/.local/bin"
@@ -144,7 +145,12 @@ jobs:
               # Git-bash `tar` is GNU tar (no zip support); use PowerShell.
               powershell -NoProfile -Command "Expand-Archive -Force gitleaks.zip gitleaks_unzip"
               cp gitleaks_unzip/gitleaks.exe "$BIN/gitleaks.exe"
-              cp "$(command -v jq)" "$BIN/jq.exe"
+              # The runner's `jq` is a Chocolatey shim whose payload carries a
+              # relative `..\lib\jq\tools\jq.exe` reference; copying it to
+              # ~/.local/bin breaks that reference ("Cannot find file at
+              # ..\lib\jq\tools\jq.exe"). Download the standalone, relocatable
+              # jq.exe release binary instead so it runs from the user-scope bin.
+              curl -sSfL -o "$BIN/jq.exe" "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-windows-amd64.exe"
               ;;
           esac
 
@@ -162,9 +168,15 @@ jobs:
           fi
 
       # T-4.7: median-of-3. Each run is `git clone <fixture> && cd <fixture>
-      # && ai-eng install . && git commit --allow-empty -m "chore: smoke"`.
+      # && ai-eng install . && git switch -c smoke/run-N && git commit
+      # --allow-empty -m "chore: smoke"`.
       # The conventional-commit prefix satisfies the framework's own
-      # commit-msg-format gate, which the just-installed hooks enforce. We
+      # commit-msg-format gate, which the just-installed hooks enforce. The
+      # smoke commit runs on a feature branch, never the default branch: the
+      # branch-protection gate (also part of the commit-msg gate) correctly
+      # blocks direct commits to `main`, so committing there would fail the
+      # step even though the install succeeded. The smoke commit exists to
+      # prove the installed hooks fire and PASS on a legitimate commit. We
       # use a local file:// clone to keep network noise out of the wall-clock.
       - name: T-4.7 median-of-3 install + smoke commit
         run: |
@@ -186,7 +198,7 @@ jobs:
             START=$(date +%s)
             git clone fixture.git "run-$run"
             (cd "run-$run" && ai-eng install . --non-interactive)
-            (cd "run-$run" && git commit --allow-empty -m "chore: smoke commit")
+            (cd "run-$run" && git switch -c "smoke/run-$run" && git commit --allow-empty -m "chore: smoke commit")
             END=$(date +%s)
             ELAPSED=$((END - START))
             echo "Run $run: ${ELAPSED}s"

--- a/src/ai_engineering/doctor/runtime/secrets_gate.py
+++ b/src/ai_engineering/doctor/runtime/secrets_gate.py
@@ -31,12 +31,13 @@ import subprocess
 from pathlib import Path
 
 from ai_engineering.doctor.models import CheckResult, CheckStatus, DoctorContext
+from ai_engineering.hooks.manager import resolve_hooks_dir
 
 _GITLEAKS_CONFIG_FILENAME = ".gitleaks.toml"
 _GITLEAKS_IGNORE_FILENAME = ".gitleaksignore"
 _SEMGREP_CONFIG_FILENAME = ".semgrep.yml"
-_PRE_COMMIT_HOOK = Path(".git") / "hooks" / "pre-commit"
-_PRE_PUSH_HOOK = Path(".git") / "hooks" / "pre-push"
+_PRE_COMMIT_HOOK_NAME = "pre-commit"
+_PRE_PUSH_HOOK_NAME = "pre-push"
 _PRE_COMMIT_MARKER = "ai-eng gate pre-commit"
 _PRE_PUSH_MARKER = "ai-eng gate pre-push"
 
@@ -193,8 +194,13 @@ def _check_gitleaks_config(results: list[CheckResult], target: Path) -> None:
 
 
 def _check_pre_commit_hook(results: list[CheckResult], target: Path) -> None:
-    """Probe 6: ``.git/hooks/pre-commit`` is wired to ``ai-eng gate pre-commit``."""
-    hook_path = target / _PRE_COMMIT_HOOK
+    """Probe 6: ``.git/hooks/pre-commit`` is wired to ``ai-eng gate pre-commit``.
+
+    Resolves the hooks dir via git so a linked worktree (where
+    ``<target>/.git`` is a pointer file) probes the shared common-dir hook
+    rather than a non-existent ``<target>/.git/hooks/`` (ARC-314).
+    """
+    hook_path = resolve_hooks_dir(target) / _PRE_COMMIT_HOOK_NAME
     _check_hook_marker(
         results,
         hook_path,
@@ -209,8 +215,11 @@ def _check_pre_commit_hook(results: list[CheckResult], target: Path) -> None:
 
 
 def _check_pre_push_hook(results: list[CheckResult], target: Path) -> None:
-    """Probe 7: ``.git/hooks/pre-push`` is wired to ``ai-eng gate pre-push``."""
-    hook_path = target / _PRE_PUSH_HOOK
+    """Probe 7: ``.git/hooks/pre-push`` is wired to ``ai-eng gate pre-push``.
+
+    Worktree-aware via :func:`resolve_hooks_dir` (see probe 6, ARC-314).
+    """
+    hook_path = resolve_hooks_dir(target) / _PRE_PUSH_HOOK_NAME
     _check_hook_marker(
         results,
         hook_path,

--- a/src/ai_engineering/hooks/manager.py
+++ b/src/ai_engineering/hooks/manager.py
@@ -215,23 +215,31 @@ def resolve_hooks_dir(project_root: Path) -> Path:
     """Resolve the git hooks directory for ``project_root``.
 
     ``<root>/.git/hooks`` only holds for a *primary* working tree. It breaks
-    for two real configurations the installer must support:
+    for **linked worktrees** (``git worktree add wt-1``), where ``wt-1/.git``
+    is a pointer *file* (``gitdir: …/.git/worktrees/wt-1``), not a directory,
+    so ``wt-1/.git/hooks`` does not exist — hooks live in the shared common
+    dir.
 
-    * **Linked worktrees** (``git worktree add wt-1``): ``wt-1/.git`` is a
-      pointer *file* (``gitdir: …/.git/worktrees/wt-1``), not a directory, so
-      ``wt-1/.git/hooks`` does not exist. Hooks live in the shared common dir.
-    * **``core.hooksPath``**: relocates hooks to an arbitrary directory.
+    Fast path: when ``<root>/.git`` is a real directory (the overwhelmingly
+    common primary-worktree case) we return ``<root>/.git/hooks`` directly.
+    This keeps resolution allocation- and subprocess-free on the install hot
+    path and keeps the mocked-``.git`` unit-test setups byte-identical.
 
-    ``git rev-parse --git-path hooks`` resolves both cases natively, so we ask
-    git first. The result is rebased to an absolute path against
-    ``project_root`` (git returns a relative ``.git/hooks`` for the primary
-    tree).
+    Only when ``<root>/.git`` is *not* a plain directory — a linked-worktree
+    pointer file, or an unusual/bare layout — do we ask git via
+    ``git rev-parse --git-path hooks``, which resolves the shared common-dir
+    hooks. The result is rebased to an absolute path against ``project_root``.
 
     Total -- never raises. Falls back to ``<root>/.git/hooks`` when git is
-    unavailable or ``project_root`` is not inside a git repository (e.g. a
-    mocked ``.git`` with no HEAD, or a genuinely non-git target). That fallback
-    preserves the legacy "Is this a git repository?" signal callers rely on.
+    unavailable or ``project_root`` is not inside a git repository, preserving
+    the legacy "Is this a git repository?" signal callers rely on.
     """
+    legacy = project_root / ".git" / "hooks"
+    # Primary working tree: ``.git`` is a real directory. Return the literal
+    # hooks path without shelling out to git.
+    if (project_root / ".git").is_dir():
+        return legacy
+
     git_path = shutil.which("git")
     if git_path is not None:
         try:
@@ -252,7 +260,7 @@ def resolve_hooks_dir(project_root: Path) -> Path:
                 if not candidate.is_absolute():
                     candidate = (project_root / candidate).resolve()
                 return candidate
-    return project_root / ".git" / "hooks"
+    return legacy
 
 
 def detect_conflicts(project_root: Path) -> list[HookConflict]:

--- a/src/ai_engineering/hooks/manager.py
+++ b/src/ai_engineering/hooks/manager.py
@@ -10,7 +10,9 @@ Provides:
 from __future__ import annotations
 
 import hashlib
+import shutil
 import stat
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -209,6 +211,50 @@ def generate_dispatcher_hook(hook: GateHook, mode: PythonEnvMode = PythonEnvMode
     return generate_bash_hook(hook, mode=mode)
 
 
+def resolve_hooks_dir(project_root: Path) -> Path:
+    """Resolve the git hooks directory for ``project_root``.
+
+    ``<root>/.git/hooks`` only holds for a *primary* working tree. It breaks
+    for two real configurations the installer must support:
+
+    * **Linked worktrees** (``git worktree add wt-1``): ``wt-1/.git`` is a
+      pointer *file* (``gitdir: …/.git/worktrees/wt-1``), not a directory, so
+      ``wt-1/.git/hooks`` does not exist. Hooks live in the shared common dir.
+    * **``core.hooksPath``**: relocates hooks to an arbitrary directory.
+
+    ``git rev-parse --git-path hooks`` resolves both cases natively, so we ask
+    git first. The result is rebased to an absolute path against
+    ``project_root`` (git returns a relative ``.git/hooks`` for the primary
+    tree).
+
+    Total -- never raises. Falls back to ``<root>/.git/hooks`` when git is
+    unavailable or ``project_root`` is not inside a git repository (e.g. a
+    mocked ``.git`` with no HEAD, or a genuinely non-git target). That fallback
+    preserves the legacy "Is this a git repository?" signal callers rely on.
+    """
+    git_path = shutil.which("git")
+    if git_path is not None:
+        try:
+            completed = subprocess.run(
+                [git_path, "rev-parse", "--git-path", "hooks"],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            completed = None
+        if completed is not None and completed.returncode == 0:
+            raw = (completed.stdout or "").strip()
+            if raw:
+                candidate = Path(raw)
+                if not candidate.is_absolute():
+                    candidate = (project_root / candidate).resolve()
+                return candidate
+    return project_root / ".git" / "hooks"
+
+
 def detect_conflicts(project_root: Path) -> list[HookConflict]:
     """Detect third-party hook managers that may conflict.
 
@@ -289,7 +335,7 @@ def install_hooks(
     Raises:
         FileNotFoundError: If ``.git/hooks/`` directory does not exist.
     """
-    hooks_dir = project_root / ".git" / "hooks"
+    hooks_dir = resolve_hooks_dir(project_root)
     if not hooks_dir.is_dir():
         msg = f"Git hooks directory not found: {hooks_dir}. Is this a git repository?"
         raise FileNotFoundError(msg)
@@ -341,7 +387,7 @@ def uninstall_hooks(
     Returns:
         List of hook names that were removed.
     """
-    hooks_dir = project_root / ".git" / "hooks"
+    hooks_dir = resolve_hooks_dir(project_root)
     if not hooks_dir.is_dir():
         return []
 
@@ -371,7 +417,7 @@ def verify_hooks(project_root: Path) -> dict[str, bool]:
     Returns:
         Dict mapping hook name to verification status (True = valid).
     """
-    hooks_dir = project_root / ".git" / "hooks"
+    hooks_dir = resolve_hooks_dir(project_root)
     status: dict[str, bool] = {}
 
     expected_hashes = _load_expected_hook_hashes(project_root)
@@ -425,7 +471,7 @@ def _record_hook_hashes(project_root: Path) -> None:
     from ai_engineering.state.repository import DurableStateRepository
     from ai_engineering.state.service import save_install_state
 
-    hooks_dir = project_root / ".git" / "hooks"
+    hooks_dir = resolve_hooks_dir(project_root)
     if not hooks_dir.is_dir():
         return
 

--- a/src/ai_engineering/installer/phases/hooks.py
+++ b/src/ai_engineering/installer/phases/hooks.py
@@ -15,7 +15,11 @@ import stat
 from contextlib import suppress
 from pathlib import Path
 
-from ai_engineering.hooks.manager import HookInstallResult, install_hooks
+from ai_engineering.hooks.manager import (
+    HookInstallResult,
+    install_hooks,
+    resolve_hooks_dir,
+)
 from ai_engineering.installer.merge import merge_settings
 from ai_engineering.installer.templates import (
     copy_file_if_missing,
@@ -157,7 +161,12 @@ class HooksPhase:
         w: list[str] = []
         errors: list[str] = []
         passed = True
-        if not (context.target / ".git/hooks/pre-commit").exists():
+        # Resolve the real hooks dir via git: in a linked worktree
+        # ``<target>/.git`` is a pointer file, so ``<target>/.git/hooks``
+        # does not exist even though the hook was installed into the shared
+        # common dir. Assuming the literal path here failed the whole phase
+        # (exit 80) in the Worktree Fast health workflow (ARC-314).
+        if not (resolve_hooks_dir(context.target) / "pre-commit").exists():
             errors.append("pre-commit hook not installed")
             passed = False
         hd = context.target / ".ai-engineering" / "scripts" / "hooks"

--- a/src/ai_engineering/policy/checks/branch_protection.py
+++ b/src/ai_engineering/policy/checks/branch_protection.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from ai_engineering.git.operations import PROTECTED_BRANCHES, current_branch
-from ai_engineering.hooks.manager import verify_hooks
+from ai_engineering.hooks.manager import resolve_hooks_dir, verify_hooks
 from ai_engineering.policy.gates import GateCheckResult, GateResult
 
 
@@ -102,7 +102,7 @@ def check_version_deprecation(result: GateResult) -> None:
 
 def check_hook_integrity(project_root: Path, result: GateResult) -> None:
     """Verify managed hooks are intact (marker + optional hash check)."""
-    hooks_dir = project_root / ".git" / "hooks"
+    hooks_dir = resolve_hooks_dir(project_root)
     if not hooks_dir.is_dir():
         result.checks.append(
             GateCheckResult(

--- a/tests/integration/test_hooks_git.py
+++ b/tests/integration/test_hooks_git.py
@@ -15,6 +15,7 @@ from ai_engineering.hooks.manager import (
     _HOOK_MARKER,
     install_hooks,
     is_managed_hook,
+    resolve_hooks_dir,
     uninstall_hooks,
     verify_hooks,
 )
@@ -115,3 +116,94 @@ class TestInstallHooksInRealRepo:
         assert result.conflicts[0].manager == "husky"
         # Hooks still installed despite conflicts (just warned)
         assert len(result.installed) == 3
+
+
+@pytest.fixture()
+def linked_worktree(git_repo: Path) -> Path:
+    """Add a linked worktree ``wt-1`` and return its path.
+
+    In a linked worktree ``wt-1/.git`` is a pointer *file* (not a directory),
+    so ``wt-1/.git/hooks`` does not exist — the exact CI configuration
+    (``Worktree Fast (Second)``, ARC-314) that broke the naive
+    ``<root>/.git/hooks`` assumption.
+    """
+    subprocess.run(
+        ["git", "-C", str(git_repo), "config", "user.email", "t@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(git_repo), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(git_repo), "commit", "--allow-empty", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(git_repo), "worktree", "add", "wt-1"],
+        check=True,
+        capture_output=True,
+    )
+    return git_repo / "wt-1"
+
+
+class TestInstallHooksInLinkedWorktree:
+    """Hook lifecycle from a linked worktree (ARC-314 regression).
+
+    ``git worktree add`` makes ``wt-1/.git`` a pointer file; hooks live in the
+    shared common dir. Every hook operation must resolve that shared dir via
+    ``git rev-parse --git-path hooks`` instead of assuming ``<root>/.git/hooks``.
+    """
+
+    def test_worktree_git_is_a_pointer_file(self, linked_worktree: Path) -> None:
+        # Guard the premise: if this ever became a directory the regression
+        # would silently stop being exercised.
+        assert (linked_worktree / ".git").is_file()
+        assert not (linked_worktree / ".git" / "hooks").exists()
+
+    def test_resolve_points_at_shared_common_hooks(
+        self, git_repo: Path, linked_worktree: Path
+    ) -> None:
+        resolved = resolve_hooks_dir(linked_worktree)
+        assert resolved.is_dir()
+        # Hooks are shared: the worktree resolves to the primary tree's dir.
+        assert resolved == (git_repo / ".git" / "hooks")
+
+    def test_install_from_worktree_succeeds(self, linked_worktree: Path) -> None:
+        # Previously raised FileNotFoundError: "Git hooks directory not found".
+        result = install_hooks(linked_worktree)
+        assert len(result.installed) == 3
+
+        hooks_dir = resolve_hooks_dir(linked_worktree)
+        for hook in GateHook:
+            hook_path = hooks_dir / hook.value
+            assert hook_path.is_file()
+            assert _HOOK_MARKER in hook_path.read_text(encoding="utf-8")
+
+    def test_verify_and_uninstall_from_worktree(self, linked_worktree: Path) -> None:
+        state_dir = linked_worktree / ".ai-engineering" / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        save_install_state(state_dir, default_install_state())
+
+        install_hooks(linked_worktree)
+        assert all(verify_hooks(linked_worktree).values())
+
+        removed = uninstall_hooks(linked_worktree)
+        assert len(removed) == 3
+
+
+class TestResolveHooksDirCoreHooksPath:
+    """``resolve_hooks_dir`` honours ``core.hooksPath`` relocation."""
+
+    def test_custom_hooks_path(self, git_repo: Path, tmp_path: Path) -> None:
+        custom = tmp_path / "custom-hooks"
+        custom.mkdir()
+        subprocess.run(
+            ["git", "-C", str(git_repo), "config", "core.hooksPath", str(custom)],
+            check=True,
+            capture_output=True,
+        )
+        assert resolve_hooks_dir(git_repo) == custom

--- a/tests/integration/test_hooks_git.py
+++ b/tests/integration/test_hooks_git.py
@@ -195,15 +195,16 @@ class TestInstallHooksInLinkedWorktree:
         assert len(removed) == 3
 
 
-class TestResolveHooksDirCoreHooksPath:
-    """``resolve_hooks_dir`` honours ``core.hooksPath`` relocation."""
+class TestResolveHooksDirPrimaryTree:
+    """``resolve_hooks_dir`` fast-paths a primary working tree."""
 
-    def test_custom_hooks_path(self, git_repo: Path, tmp_path: Path) -> None:
-        custom = tmp_path / "custom-hooks"
-        custom.mkdir()
-        subprocess.run(
-            ["git", "-C", str(git_repo), "config", "core.hooksPath", str(custom)],
-            check=True,
-            capture_output=True,
-        )
-        assert resolve_hooks_dir(git_repo) == custom
+    def test_primary_tree_returns_literal_hooks_dir(self, git_repo: Path) -> None:
+        # ``.git`` is a real directory -> literal path, no git subprocess.
+        assert resolve_hooks_dir(git_repo) == git_repo / ".git" / "hooks"
+
+    def test_non_git_dir_falls_back_to_legacy_path(self, tmp_path: Path) -> None:
+        # No ``.git`` at all: fall back to the legacy path so callers still
+        # get the "not a git repository" signal (dir will not exist).
+        resolved = resolve_hooks_dir(tmp_path)
+        assert resolved == tmp_path / ".git" / "hooks"
+        assert not resolved.exists()


### PR DESCRIPTION
## What & why — ARC-314 residual `main`-rojo (parent [ARC-306])

Two health workflows on `main` (`Worktree Fast (Second)`, `Install Time Budget`) were red. Grounded against live CI runs (`28776885577`, `28776877945`) and reproduced locally before fixing. **The `Install Time Budget` root cause was NOT the tool-gap the issue first suspected** — `ai-eng install` finishes `ok:true` with an empty `auto_remediation` block.

### A) `fix(hooks)` — linked-worktree hooks dir (lineage ARC-268/#619)
In a **linked worktree** (`git worktree add wt-1`), `wt-1/.git` is a pointer *file*, so the literal `wt-1/.git/hooks` path doesn't exist. Two layers assumed it:
1. `install_hooks` (+ uninstall/verify/record + `branch_protection` hook-integrity) → `FileNotFoundError: Git hooks directory not found` (run `28776885577`, T-4.8).
2. `HooksPhase.verify()` + doctor secrets-gate probes 6/7 → after (1) was fixed, live CI on this branch surfaced the hooks *phase* still failing **exit 80** because verify checked the literal path; doctor (the tool the failure tells you to run) gave the same false negative.

**Fix:** new `resolve_hooks_dir()` returns `<root>/.git/hooks` on a primary tree (fast, subprocess-free) and only shells to `git rev-parse --git-path hooks` for the linked-worktree pointer-file case. All hook-dir consumers routed through it. Scope is linked worktrees; `core.hooksPath` on a primary tree is intentionally not honoured (it never was; no workflow exercises it). Regression tests exercise a real linked worktree end-to-end.

### B) `fix(ci)` — install-time-budget green on all 3 OS (lineage ARC-291/#621)
- **macOS + ubuntu:** the T-4.7 smoke commit ran on `main`; the freshly-installed commit-msg **branch-protection** gate correctly blocks direct commits to the default branch → `git commit` failed the step. **Fix:** run the smoke commit on a `smoke/run-N` feature branch (also makes the smoke test stronger — it now proves the hooks *pass* on a legit conventional commit).
- **windows:** the prereq step copied the runner's Chocolatey `jq` shim, whose payload has a relative `..\lib\jq\tools\jq.exe` reference that breaks once relocated to `~/.local/bin`. **Fix:** download the standalone, relocatable `jq-windows-amd64.exe` release binary (pinned `JQ_VERSION=1.7.1`), mirroring gitleaks.

## Verification
- Reproduced both bugs locally against the fixtures (linked-worktree full-install exit-80 → now exits 0 with smoke commit + `ai-eng doctor` probes green; install-ok-but-commit-blocked-on-main → clean on feature branch).
- `pytest` hooks/installer/policy/doctor sweep: **green** (446 in the focused sweep), ruff clean.
- Workflow Sanity: **actionlint 1.7.12 + shellcheck** clean, `check_workflow_policy.py` pass, `ai-eng dev sync --check` in-sync.
- No suppressors/shims; Conventional Commits with earned `Ai-Eng-Gate` trailer; never `--no-verify`.
- **Real gate:** both health workflows re-dispatched against this branch (see checks) — must be green on all 3 OS before merge.

## Merge protocol
reviewer ≠ builder. Author is the `soydachi` app → **merge by IT-Admin only once CI is genuinely green on all 3 OS** (real gate, no bypass unless Dachi authorizes admin-merge on a truly-green run per the ARC-306 precedent).

Closes ARC-314 · notify parent ARC-306 on merge.
