### PR TITLE
ci(deps): bump the github-actions group with 3 updates

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -66,7 +66,7 @@ jobs:
           fi
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-env
       - name: Cache spec-104 gate-cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .ai-engineering/cache/gate/
           key: gate-cache-${{ github.event_name == 'pull_request' && 'pr' || 'main' }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', '.ruff.toml', '.gitleaks.toml') }}-${{ github.sha }}
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-env
       - name: Cache spec-104 gate-cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .ai-engineering/cache/gate/
           key: gate-cache-${{ github.event_name == 'pull_request' && 'pr' || 'main' }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', '.ruff.toml', '.gitleaks.toml') }}-${{ github.sha }}
@@ -293,7 +293,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
       - name: Cache spec-104 gate-cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .ai-engineering/cache/gate/
           key: gate-cache-${{ github.event_name == 'pull_request' && 'pr' || 'main' }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', '.ruff.toml', '.gitleaks.toml') }}-${{ github.sha }}
@@ -382,7 +382,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
       - name: Cache spec-104 gate-cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .ai-engineering/cache/gate/
           key: gate-cache-${{ github.event_name == 'pull_request' && 'pr' || 'main' }}-${{ runner.os }}-${{ hashFiles('pyproject.toml', '.ruff.toml', '.gitleaks.toml') }}-${{ github.sha }}
@@ -764,7 +764,7 @@ jobs:
         # registry on first invocation; the resolved YAML lives under
         # ~/.semgrep. Cache key includes the pinned CLI version + OS so
         # bumping the pin invalidates cleanly (D-141-05 reproducibility).
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.semgrep
           key: semgrep-packs-${{ github.event_name == 'pull_request' && 'pr' || 'main' }}-${{ runner.os }}-1.163.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
           path: dist
 
       - name: Generate GitHub artifact attestations
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*
 

--- a/.github/workflows/test-hooks-matrix.yml
+++ b/.github/workflows/test-hooks-matrix.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-env
       - name: Cache spec-104 gate-cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .ai-engineering/cache/gate/
           key: gate-cache-hooks-${{ runner.os }}-${{ hashFiles('pyproject.toml', '.ruff.toml') }}


### PR DESCRIPTION
## What
Bumps the **github-actions** dependency group (3 SHA-pinned updates) — a governed reconstruction of dependabot **#625**:
- `dorny/paths-filter` v4.0.1 → v4.0.2
- `actions/cache` v6.0.0 → v6.1.0
- `actions/attest-build-provenance` v4.1.0 → v4.1.1

## Why not just merge #625
#625's branch was tainted by a stray `gh pr update-branch` merge commit (my earlier mistake), which flipped the CI run actor off `dependabot[bot]` and **un-waived `Verify Gate Trailers`**; dependabot then refused to rebase an externally-edited branch. This PR rebuilds the exact same bump as a single governed `soydachi` commit off the current main — which already carries the **#626** gate-cache prune fix that resolves the Windows `Integration` flake that originally blocked #625. As a non-dependabot PR the trailer gate runs and **passes** (trailer present, earned via the real `ai-eng gate commit-msg`).

Supersedes #625 (will be closed). Ref: ARC-306 (ARC-305a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
