### PR TITLE
docs: sincroniza documentación con v0.12.3 (retira Gemini, inventario real)

### DIFF
--- a/.ai-engineering/LESSONS.md
+++ b/.ai-engineering/LESSONS.md
@@ -21,8 +21,8 @@ When the user corrects AI behavior:
 
 ### Plan tasks must have checkboxes for progress tracking
 
-**Context**: `/ai-plan` generates `plan.md` as the contract for `/ai-dispatch`.
-**Learning**: Every task line MUST use `- [ ] T-N.N:` format, not `- T-N.N:`. Without checkboxes, `/ai-dispatch` cannot track progress and the user cannot see completion state at a glance.
+**Context**: `/ai-plan` generates `plan.md` as the contract for `/ai-build`.
+**Learning**: Every task line MUST use `- [ ] T-N.N:` format, not `- T-N.N:`. Without checkboxes, `/ai-build` cannot track progress and the user cannot see completion state at a glance.
 **Rule**: When writing plan.md, always prefix tasks with `- [ ]`.
 
 ### /ai-pr MUST clear spec.md and plan.md after PR creation

--- a/.ai-engineering/solution-intent.md
+++ b/.ai-engineering/solution-intent.md
@@ -1,7 +1,7 @@
 # Solution Intent -- ai-engineering
 
 > Status: Evolving
-> Last Review: 2026-04-29
+> Last Review: 2026-07-06
 
 ---
 
@@ -13,7 +13,7 @@
 |-------|-------|
 | Name | ai-engineering |
 | Organization | arcasilesgroup/ai-engineering |
-| Versions | 0.10.1 (framework), 2.0 (manifest schema), 0.10.1 (pyproject) |
+| Versions | 0.12.3 (framework/pyproject), 2.0 (manifest schema) |
 | Description | AI governance framework for secure software delivery |
 | License | MIT |
 | Python | >= 3.11 |
@@ -25,7 +25,7 @@
 
 ### 1.2 Objective
 
-Deterministic CLI tooling, 54 AI skills, 9 agents (+ specialist review/verifier sub-agents), and a governance surface that spans Claude Code, GitHub Copilot, Codex, and Antigravity. Targets regulated enterprises (banking, healthcare, investment) that require auditable, governed AI-assisted software delivery.
+Deterministic CLI tooling, 54 AI skills, 9 agents (+ specialist review/verifier sub-agents), and a governance surface that spans Claude Code, GitHub Copilot, Codex, Antigravity, OpenCode, and Cursor. Targets regulated enterprises (banking, healthcare, investment) that require auditable, governed AI-assisted software delivery.
 
 ### 1.3 Problem Statement
 
@@ -35,7 +35,7 @@ AI coding assistants operate without guardrails. In regulated industries, this c
 
 - Zero secret leaks in committed code
 - >= 80% test coverage enforced at every PR
-- Consistent governance across 4 IDE surfaces from a single source
+- Consistent governance across 6 IDE surfaces from a single source
 - Auditable decision trail with expiry-based lifecycle
 - Environment-aware failure handling: fail fast for runtime integrity, repair framework packaging drift when possible, and block only when security or feed validation cannot be trusted
 
@@ -44,8 +44,8 @@ AI coding assistants operate without guardrails. In regulated industries, this c
 | In scope | Out of scope |
 |----------|-------------|
 | CLI tooling (`ai-eng`) | Runtime application code |
-| AI skill definitions (47) | AI model training or fine-tuning |
-| Agent orchestration (10) | Custom IDE plugin development |
+| AI skill definitions (54) | AI model training or fine-tuning |
+| Agent orchestration (9) | Custom IDE plugin development |
 | Quality gates and hooks | SonarCloud/Snyk platform management |
 | Multi-IDE mirror generation | IDE-specific UI extensions |
 | GitHub + Azure DevOps providers | Other VCS providers |
@@ -83,6 +83,8 @@ C4Context
     System_Ext(copilot, "GitHub Copilot", "Secondary IDE integration")
     System_Ext(codex, "Codex", "Tertiary IDE integration")
     System_Ext(antigravity, "Antigravity", "Google IDE/CLI integration")
+    System_Ext(opencode, "OpenCode", "IDE integration")
+    System_Ext(cursor, "Cursor", "IDE integration")
 
     Rel(dev, framework, "ai-eng CLI + /ai-* skills")
     Rel(framework, github, "gh CLI / REST API")
@@ -94,24 +96,23 @@ C4Context
     Rel(framework, copilot, "Skills, agents, instructions")
     Rel(framework, codex, "Skills, agents")
     Rel(framework, antigravity, "Skills, agents")
+    Rel(framework, opencode, "Skills, agents")
+    Rel(framework, cursor, "Skills, agents")
 ```
 
 ### 2.2 Functional Requirements by Domain
 
-#### Skills (47)
+#### Skills (54)
 
 | Type | Skills | Count |
 |------|--------|-------|
-| Workflow | brainstorm, plan, build, code, test, debug, verify, review, schema | 9 |
-| Delivery | commit, pr, cleanup, gtm | 4 |
-| Enterprise | security, governance, pipeline, docs, board, ide-audit | 6 |
-| Teaching | explain, guide, write, slides, media, video-editing | 6 |
+| Workflow | brainstorm, plan, build, code, test, debug, verify, review, schema, spec-draft | 10 |
+| Delivery | commit, pr, branch-cleanup, resolve-conflicts | 4 |
+| Enterprise | security, governance, pipeline, docs, board, ide-audit, mcp-audit, reliability-eval | 8 |
+| Teaching | explain, prose, slides, media, video-editing, learn | 6 |
 | Design | design, animation, visual | 3 |
-| SDLC | note, standup, sprint, postmortem, support, resolve-conflicts | 6 |
-| Meta | create, learn, prompt, start, analyze-permissions, autopilot, constitution, skill-improve, mcp-audit, observe, simplify-sweep, research, help | 13 |
-
-**Effort distribution** (post spec-122-a): `eval` skill removed with the
-`evals/` directory; net count reflects current `.claude/skills/`.
+| SDLC | note, standup, sprint, postmortem, support, issue, engineering-issue, scaffold | 8 |
+| Meta | advise, prompt-tune, start, onboard, analyze-permissions, autopilot, constitution, skill-improve, simplify, simplify-sweep, session-watch, session-watch-sweep, research, marketing, explore | 15 |
 
 #### Agents (9)
 
@@ -119,65 +120,64 @@ C4Context
 |-------|-------|------|----------|
 | plan | opus | Spec creation, architecture design | Plans but does NOT execute |
 | build | opus | Code implementation | ONLY agent with write permissions |
-| verify | opus | Quality + security assessment | Read-only, dispatches 4 sub-agents |
-| guard | sonnet | Governance advisory | Advisory, never blocking |
-| review | opus | Parallel code review | Read-only, dispatches 8 specialists |
+| verify | opus | Quality + security assessment | Read-only, dispatches verifier sub-agents |
+| review | opus | Parallel code review | Read-only, dispatches reviewer specialists |
 | explore | sonnet | Deep codebase research | Read-only exploration |
-| guide | sonnet | Teaching and onboarding | Read-only, educational |
+| advise | sonnet | Governance + decision advisory | Advisory, never blocking |
+| onboard | sonnet | Teaching and onboarding | Read-only, educational |
 | simplify | sonnet | Code simplification | Proposes changes, build executes |
 | autopilot | opus | Autonomous multi-spec orchestrator + backlog execution | Decomposes, plans, builds, verifies |
 
-**Specialist sub-agents (15):**
+**Specialist sub-agents (10):**
 
 | Sub-agent | Parent | Focus |
 |-----------|--------|-------|
 | review-context | review | Pre-review architectural context |
 | review-validator | review | Adversarial finding disproof |
-| reviewer-architecture | review | Necessity, simplicity, patterns |
-| reviewer-backend | review | API boundaries, persistence |
 | reviewer-compatibility | review | Breaking changes to shipped code |
 | reviewer-correctness | review | Functional correctness |
 | reviewer-frontend | review | React, hooks, accessibility |
-| reviewer-maintainability | review | Readability, clarity |
 | reviewer-performance | review | Bottlenecks, optimization |
 | reviewer-security | review | Vulnerabilities, exploits |
 | reviewer-testing | review | Test coverage, quality |
+| verifier-acceptance | verify | Spec coverage, acceptance criteria |
 | verifier-deterministic | verify | Tool-driven checks (gitleaks, ruff, pytest) |
-| verifier-architecture | verify | Solution-intent alignment |
-| verifier-feature | verify | Spec coverage, acceptance criteria |
-| verifier-governance | verify | Compliance, integrity |
 
-#### CLI Commands (~47)
+#### CLI Commands (24 top-level)
 
 ```mermaid
 mindmap
     root((ai-eng))
-        Top-level
+        Lifecycle
             install
             update
             doctor
-            validate
+            check
             verify
-            version
             release
-            guide
-            sync
-        Groups
-            stack(3)
-            ide(3)
-            gate(5)
-            skill(1)
-            maintenance(8)
-            provider(3)
-            vcs(2)
-            review(1)
-            cicd(1)
-            setup(5)
-            decision(3)
-            scan-report(1)
-            metrics(1)
-            work-item(1)
-            workflow(1)
+            status
+            version
+        Off-chain
+            commit
+            pr
+        Config
+            config
+            gate
+            skill
+            host
+            setup
+        Maintenance
+            cleanup
+            maintenance
+        Governance
+            decision
+            ownership
+            audit
+            risk
+        Work planes
+            spec
+            plan
+            issue
 ```
 
 ### 2.3 Non-Functional Requirements
@@ -213,6 +213,8 @@ flowchart LR
     Skills -->|SKILL.md| Copilot["GitHub Copilot"]
     Skills -->|SKILL.md| Codex
     Skills -->|SKILL.md| Antigravity
+    Skills -->|SKILL.md| OpenCode
+    Skills -->|SKILL.md| Cursor
 ```
 
 | System A | System B | Protocol | Contract | SLA |
@@ -234,7 +236,7 @@ flowchart LR
 graph TB
     subgraph CLI["Interface Layer"]
         cli_preflight["cli_preflight<br/>bootstrap runtime + dependency closure"]
-        cli_commands["cli_commands<br/>16 command groups, ~47 commands"]
+        cli_commands["cli_commands<br/>24 top-level commands"]
         commands["commands<br/>Low-level wrappers"]
     end
 
@@ -687,20 +689,20 @@ sequenceDiagram
 
 | Epic | Description | Priority | Status | Target |
 |------|-------------|----------|--------|--------|
-| Board lifecycle | Full issue lifecycle automation via Projects v2 | P1 | In progress | Q2 2026 |
-| Runbook automation | Scheduled execution via GitHub Agentic Workflows | P1 | In progress (DEC-022) | Q2 2026 |
-| Autopilot maturity | Multi-spec autonomous delivery refinement | P2 | Active (DEC-023) | Q2 2026 |
+| Board lifecycle | Full issue lifecycle automation via Projects v2 | P1 | In progress | Q3 2026 |
+| Runbook automation | Scheduled execution via GitHub Agentic Workflows | P1 | Planned (`.github/aw/` not yet wired) | Q3 2026 |
+| Autopilot maturity | Multi-spec autonomous delivery refinement | P2 | Active (DEC-023) | Q3 2026 |
 
 ### 7.3 KPIs
 
 | Metric | Target | Current |
 |--------|--------|---------|
 | Test coverage | >= 80% | **TBD -- pending measurement** |
-| Skills count | 47 | 47 |
-| Agent count | 10 | 10 |
+| Skills count | 54 | 54 |
+| Agent count | 9 | 9 |
 | Active decisions | Tracked with expiry | 23 active, 5 superseded |
 | Runbook coverage | All operational areas | 14 runbooks |
-| IDE surfaces | 4 | 6 (Claude Code, Copilot, Codex, OpenCode, Cursor, Antigravity) |
+| IDE surfaces | 6 | 6 (Claude Code, Copilot, Codex, OpenCode, Cursor, Antigravity) |
 | Context files | Comprehensive | 39 (14 lang, 15 framework, 10 other) |
 
 ### 7.4 Active Spec
@@ -775,9 +777,9 @@ No active spec. Run `/ai-brainstorm` to start a new spec.
 | Decisions | `.ai-engineering/state/decision-store.json` |
 | Framework events | `.ai-engineering/state/framework-events.ndjson` |
 | Framework capabilities | `.ai-engineering/state/framework-capabilities.json` |
-| Reference (18) | `.ai-engineering/reference/*.md` (spec-136 D-136-03 collapsed contexts/ + framework docs/ into a single flat home) |
+| Reference (19) | `.ai-engineering/reference/*.md` (spec-136 D-136-03 collapsed contexts/ + framework docs/ into a single flat home) |
 | Runbooks (14) | `.ai-engineering/runbooks/` |
 | CLI source | `src/ai_engineering/` |
-| Tests (123 files) | `tests/{unit,integration,e2e}/` |
+| Tests (592 files) | `tests/{unit,integration,e2e,architecture,conformance,perf,mirrors,adapters,docs}/` |
 | Board config | `.ai-engineering/manifest.yml` (work_items section) |
 | This document | `.ai-engineering/solution-intent.md` |

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -4,7 +4,7 @@
 > (engineering principles, plan-mode default, subagent strategy,
 > commit conventions, etc.) live in
 > [CANONICAL.md](src/ai_engineering/templates/project/CANONICAL.md)
-> and its byte-equivalent mirrors (AGENTS.md, CLAUDE.md, GEMINI.md,
+> and its byte-equivalent mirrors (AGENTS.md, CLAUDE.md,
 > .github/copilot-instructions.md). This file owns "what THIS project
 > IS" — Mission, Stakeholders, Vocabulary, Prohibitions, Compliance
 > gates, Anti-goals, Boundaries, Escalation, Language, Lifecycle phase.
@@ -30,7 +30,7 @@ AI authoring is the cost-driver and auditability is the bar.
 ## Stakeholders
 
 - **Operator engineers** consuming the framework through their IDE
-  host (Claude Code, Codex, Gemini CLI, GitHub Copilot, OpenCode, Cursor).
+  host (Claude Code, Codex, Antigravity, GitHub Copilot, OpenCode, Cursor).
 - **Security + compliance reviewers** auditing the deterministic
   plane (policy engine, prompt-injection guard, append-only NDJSON
   audit chain).
@@ -85,7 +85,7 @@ AI authoring is the cost-driver and auditability is the bar.
    one canonical writable store. Derived caches are explicitly
    labelled (named, with a rebuild command) and rebuildable on
    demand. See [docs/persistence-doctrine.md](docs/persistence-doctrine.md)
-   for the four-tier model and the rebuild semantics.
+   for the three-tier files-only model and the rebuild semantics.
 
 ## Compliance gates
 
@@ -133,10 +133,10 @@ AI authoring is the cost-driver and auditability is the bar.
 ## Boundaries
 
 - **Framework-owned** — every file under
-  `.ai-engineering/`, `.claude/`, `.codex/`, `.gemini/`,
-  `.github/skills/`, `.github/agents/`,
+  `.ai-engineering/`, `.claude/`, `.codex/`, `.agents/`, `.opencode/`,
+  `.cursor/`, `.github/skills/`, `.github/agents/`,
   `.github/copilot-instructions.md`, AGENTS.md, CLAUDE.md,
-  GEMINI.md, CANONICAL.md, this CONSTITUTION.md, and
+  CANONICAL.md, this CONSTITUTION.md, and
   `scripts/sync_mirrors/`. Operators MUST NOT hand-edit generated
   mirrors; `sync_command_mirrors.py` regenerates from canonical
   sources.
@@ -173,7 +173,7 @@ written CONSTITUTION.md stays in English for cross-team review.
 ## Lifecycle phase
 
 **Stabilising** — the framework has shipped its canonical chain
-(spec-127 / spec-128 / spec-129) and is now hardening DX (spec-131).
+(spec-127 / spec-128 / spec-129) and is now hardening DX and reliability (spec-131 through spec-182, v0.12.3).
 Breaking changes still land without backwards-compat shims (anti-goal
 above), but the deterministic plane contract (audit chain shape,
 risk-acceptance ledger, hooks manifest) is frozen modulo ADR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
 
 ## Project structure
 
-Top-level: `src/ai_engineering/` (CLI, installer, updater, doctor, hooks, policy, state, git, pipeline, skills, maintenance, detector, and bundled templates); `tests/` (unit, integration, conformance, perf, docs); `.ai-engineering/` (governance root: reference, evals, runtime, scripts, specs, state, team); `.claude/` plus the `.github/`, `.codex/`, `.agents/` IDE mirrors (skills + agents); `templates/` (consumer-project assets); `scripts/` (sync utilities); `tools/` (linters, no-suppression gate); `docs/` (operator dogfooding artifacts only; framework reference content lives under `.ai-engineering/reference/`).
+Top-level: `src/ai_engineering/` (CLI, installer, updater, doctor, hooks, policy, state, git, pipeline, skills, maintenance, detector, and bundled templates); `tests/` (unit, integration, e2e, architecture, conformance, perf, mirrors, adapters, docs); `.ai-engineering/` (governance root: reference, evals, runtime, scripts, specs, state, team); `.claude/` plus the `.github/`, `.codex/`, `.agents/`, `.opencode/` IDE mirrors (skills + agents); consumer-project templates bundled at `src/ai_engineering/templates/project/`; `scripts/` (sync utilities, mirror generation); `tools/` (linters, no-suppression gate); `docs/` (human-facing docs: getting started, architecture, persistence doctrine, CI and supply-chain references; framework reference content lives under `.ai-engineering/reference/`).
 
 See [AGENTS.md](AGENTS.md) for the full architecture map and canonical chain.
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ The ruleset lives in [AGENTS.md](AGENTS.md). Project identity and hard prohibiti
 
 | Project | What we learned |
 |---------|----------------|
-| [Superpowers](https://github.com/NicolasMontworker/superpowers) | Brainstorm hard-gate, TDD-for-skills patterns |
-| [review-code](https://github.com/peterknights1/review-code) | Handler-as-workflow, parallel specialist agents |
-| [dotfiles/ai](https://github.com/ericbuess/dotfiles) | Agent matrix, SDLC coverage |
-| [autoresearch](https://github.com/vgel/autoresearch) | Radical simplicity as a design principle |
-| [SpecKit](https://github.com/speckit/speckit) | Spec-driven workflow inspiration |
-| [Anthropic Skills](https://github.com/anthropics/claude-code-skills) | Frontend-design, skill-creator — absorbed and extended |
+| [Superpowers](https://github.com/obra/superpowers) | Brainstorm hard-gate, TDD-for-skills patterns |
+| review-code | Handler-as-workflow, parallel specialist agents |
+| dotfiles/ai | Agent matrix, SDLC coverage |
+| autoresearch | Radical simplicity as a design principle |
+| [SpecKit](https://github.com/github/spec-kit) | Spec-driven workflow inspiration |
+| [Anthropic Skills](https://github.com/anthropics/skills) | Frontend-design, skill-creator — absorbed and extended |
 
 ## Contributing
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,9 +9,9 @@ Install `{ai} engineering` and get a governed repository in under a minute.
 ## 1 — Install the CLI
 
 ```bash
-pip install ai-engineering
-# or, with uv:
 uv tool install ai-engineering
+# or, with pip:
+pip install ai-engineering
 ```
 
 Verify it:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 ## Get going
 
+- [ai-engineering.arcasiles.com](https://ai-engineering.arcasiles.com) — the website: what it is and how to install.
 - [Getting started](guides/getting-started.md) — install, your first session, the governed workflow.
 - [The architecture](architecture/index.md) — how the pieces fit, for contributors.
 
@@ -17,6 +18,7 @@
 
 ## Project identity
 
+- [SOUL.md](../SOUL.md) — the agent's collaborator values (the judgment layer above the gates).
 - [CONSTITUTION.md](../CONSTITUTION.md) — mission, stakeholders, prohibitions.
 - [CHANGELOG.md](../CHANGELOG.md) — release history and breakage notes.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — development setup and the pull request process.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Derived cache: concatenated user-facing and canonical docs for AI agent ingestion.
 > Regenerate from: README, docs/guides/getting-started, docs/index, docs/architecture/index, docs/architecture/brand-tokens, docs/persistence-doctrine, CONSTITUTION, AGENTS.
-
+> Rebuild command: `python -m scripts.gen_llms_full`.
 
 
 ================================================================
@@ -21,28 +21,48 @@
   <p><strong>Turn AI-assisted delivery into a governed local workflow — in any repo, any IDE.</strong></p>
 
   <p>
-    <a href="https://pypi.org/project/ai-engineering/"><img src="https://img.shields.io/pypi/v/ai-engineering.svg?style=flat-square&color=00D4AA&labelColor=0B1120" alt="PyPI version"></a>
-    <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11%2B-00D4AA.svg?style=flat-square&labelColor=0B1120" alt="Python 3.11+"></a>
+    <a href="https://ai-engineering.arcasiles.com"><img src="https://img.shields.io/badge/Website-ai--engineering.arcasiles.com-2C7E6D?style=flat-square&labelColor=0B1120" alt="Website"></a>
+    <a href="https://pypi.org/project/ai-engineering/"><img src="https://img.shields.io/pypi/v/ai-engineering.svg?style=flat-square&color=2C7E6D&labelColor=0B1120" alt="PyPI version"></a>
+    <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11%2B-2C7E6D.svg?style=flat-square&labelColor=0B1120" alt="Python 3.11+"></a>
     <a href="https://github.com/arcasilesgroup/ai-engineering/actions"><img src="https://img.shields.io/github/actions/workflow/status/arcasilesgroup/ai-engineering/ci-check.yml?branch=main&style=flat-square&labelColor=0B1120" alt="CI"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-00D4AA.svg?style=flat-square&labelColor=0B1120" alt="License: MIT"></a>
+    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/quality_gate/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=2C7E6D" alt="Quality Gate"></a>
+    <a href="https://sonarcloud.io/summary/overall?id=arcasilesgroup_ai-engineering"><img src="https://img.shields.io/sonar/coverage/arcasilesgroup_ai-engineering?server=https%3A%2F%2Fsonarcloud.io&style=flat-square&labelColor=0B1120&color=2C7E6D" alt="Coverage"></a>
+    <a href="https://snyk.io/test/github/arcasilesgroup/ai-engineering"><img src="https://img.shields.io/badge/Snyk-monitored-2C7E6D?style=flat-square&labelColor=0B1120" alt="Snyk security"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-2C7E6D.svg?style=flat-square&labelColor=0B1120" alt="License: MIT"></a>
   </p>
 
   <p><code>54 skills · 9 agents · 6 surfaces · 1 governed flow</code></p>
 
-  <img src="https://raw.githubusercontent.com/arcasilesgroup/ai-engineering/main/.github/assets/demo.gif" alt="Terminal demo: pip install ai-engineering, then ai-eng install . and ai-eng doctor both report [PASS], then open your IDE and run /ai-start" width="760">
+  <br>
+
+  <picture>
+    <source srcset="https://raw.githubusercontent.com/arcasilesgroup/ai-engineering/main/.github/assets/demo.webp" type="image/webp">
+    <img src="https://raw.githubusercontent.com/arcasilesgroup/ai-engineering/main/.github/assets/demo.gif" alt="ai-eng install, then ai-eng doctor (warnings are advisory), then exploring the .ai-engineering tree plus 54 skills and 9 agents in VS Code, ending with /ai-start in Claude Code" width="900">
+  </picture>
 </div>
 
 `{ai} engineering` installs a deterministic governance layer into any repository — specs, decisions, skills, agents, hooks, and an audit trail, all as versioned local files. No hosted control plane. No provider lock-in. Every IDE follows the same rules.
 
 ## Quickstart
 
-Get a governed repo in under a minute:
+Get a governed repo in under a minute — `{ai} engineering` is uv-first:
 
 ```bash
-pip install ai-engineering   # or: uv tool install ai-engineering
-ai-eng install .             # adds governance to your repo
-ai-eng doctor                # [PASS] hooks, mirrors, manifest, required tools
+uv tool install ai-engineering   # install the CLI
+ai-eng install .                 # add governance to your repo
+ai-eng doctor                    # [PASS] hooks, mirrors, manifest, required tools
 ```
+
+<details>
+<summary>Prefer <code>pip</code> or <code>pipx</code>?</summary>
+
+```bash
+pipx install ai-engineering
+# or
+python -m pip install --user ai-engineering
+```
+
+</details>
 
 Then open your editor and type `/ai-start`. Prefer to ease in? Start in observe mode and enforce only what proves useful.
 
@@ -52,9 +72,13 @@ Then open your editor and type `/ai-start`. Prefer to ease in? Start in observe 
 
 You drive the intent and approve each step; the gates catch the rest — no secrets, broken docs, or untested changes reach a merge.
 
+<br>
+
 <div align="center">
   <img src="https://raw.githubusercontent.com/arcasilesgroup/ai-engineering/main/.github/assets/diagrams/workflow.png" alt="The governed workflow: /ai-brainstorm agrees the spec, /ai-plan breaks it down, /ai-build or /ai-autopilot implements it, /ai-pr ships a reviewed and merged pull request. You approve each step; automatic checks (clean diff, tests, docs, review) must pass before merge." width="820">
 </div>
+
+<br>
 
 The canonical chain is **`/ai-brainstorm → /ai-plan → /ai-build → /ai-pr`**. Use it whenever work changes product behavior, framework behavior, security posture, public docs, or release state. `/ai-commit` stays available for WIP checkpoints; it is not part of the chain.
 
@@ -62,9 +86,15 @@ The canonical chain is **`/ai-brainstorm → /ai-plan → /ai-build → /ai-pr`*
 
 Fifty-four skills and nine agents cover the whole delivery loop — and the same commands work in every supported editor.
 
+<br>
+
 <div align="center">
   <img src="https://raw.githubusercontent.com/arcasilesgroup/ai-engineering/main/.github/assets/diagrams/toolkit.png" alt="54 skills and 9 agents grouped by what you do: plan and build, ship safely, design and docs, research and learn. The same commands run in Claude Code, GitHub Copilot, Codex, Antigravity, OpenCode, and Cursor." width="820">
 </div>
+
+<br>
+
+Need evidence? `/ai-research` returns cited findings from local context, the web, and async deep research. And because plans carry ready-to-apply patches, mechanical work routes to a smaller model — routine edits stay cheap.
 
 ## Supported surfaces
 
@@ -81,15 +111,18 @@ One canonical payload is mirrored, byte-for-byte, into every enabled surface.
 
 The ruleset lives in [AGENTS.md](AGENTS.md). Project identity and hard prohibitions live in [CONSTITUTION.md](CONSTITUTION.md). Release history lives in [CHANGELOG.md](CHANGELOG.md).
 
-## Why governance matters
+## Highlights
 
-- **Spec-driven** — every change is tied to an approved scope, so LLM output stays on-task.
-- **Deterministic gates** — secrets, broken mirrors, missing docs, and policy drift are caught before they land.
-- **Local audit trail** — a hash-chained NDJSON log records what happened, with no telemetry by default.
-- **Reviewable everywhere** — skills and agents are file-backed and synchronized across every IDE.
+- **Ship a whole spec in one run** — `/ai-autopilot` decomposes it, builds a dependency DAG, runs parallel waves, and converges on a reviewed PR.
+- **What you approved is what shipped** — a brainstorm hard-gate plus a spec-lifecycle state machine keep every change anchored to the approved spec (Rung 2 SDD — spec and code stay in sync, not just spec-first that drifts).
+- **An audit trail you own** — every AI action lands in a hash-chained NDJSON log you can verify offline, with no telemetry by default.
+- **Every bypass has an owner and an expiry** — no `# noqa` or `@ts-ignore`; findings are refactored or formally risk-accepted with a severity-based TTL.
+- **Every tool call is screened before it runs** — a deterministic guard checks each edit, write, and shell command and stops risky ones.
+- **AI quality is a tested property** — skills are measured with pass@k, and a regression beyond five points blocks the pull request.
 
 ## Documentation
 
+- [ai-engineering.arcasiles.com](https://ai-engineering.arcasiles.com) — the website: what it is, why it's governed, and how to install
 - [docs/](docs/) — architecture, getting started, and the diagram set
 - [CONSTITUTION.md](CONSTITUTION.md) — mission, stakeholders, prohibitions
 - [CHANGELOG.md](CHANGELOG.md) — release history and breakage notes
@@ -100,12 +133,12 @@ The ruleset lives in [AGENTS.md](AGENTS.md). Project identity and hard prohibiti
 
 | Project | What we learned |
 |---------|----------------|
-| [Superpowers](https://github.com/NicolasMontworker/superpowers) | Brainstorm hard-gate, TDD-for-skills patterns |
-| [review-code](https://github.com/peterknights1/review-code) | Handler-as-workflow, parallel specialist agents |
-| [dotfiles/ai](https://github.com/ericbuess/dotfiles) | Agent matrix, SDLC coverage |
-| [autoresearch](https://github.com/vgel/autoresearch) | Radical simplicity as a design principle |
-| [SpecKit](https://github.com/speckit/speckit) | Spec-driven workflow inspiration |
-| [Anthropic Skills](https://github.com/anthropics/claude-code-skills) | Frontend-design, skill-creator — absorbed and extended |
+| [Superpowers](https://github.com/obra/superpowers) | Brainstorm hard-gate, TDD-for-skills patterns |
+| review-code | Handler-as-workflow, parallel specialist agents |
+| dotfiles/ai | Agent matrix, SDLC coverage |
+| autoresearch | Radical simplicity as a design principle |
+| [SpecKit](https://github.com/github/spec-kit) | Spec-driven workflow inspiration |
+| [Anthropic Skills](https://github.com/anthropics/skills) | Frontend-design, skill-creator — absorbed and extended |
 
 ## Contributing
 
@@ -114,6 +147,28 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for developmen
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+## Star history
+
+<div align="center">
+  <a href="https://star-history.com/#arcasilesgroup/ai-engineering&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=arcasilesgroup/ai-engineering&type=Date&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=arcasilesgroup/ai-engineering&type=Date">
+      <img src="https://api.star-history.com/svg?repos=arcasilesgroup/ai-engineering&type=Date" alt="Star history chart for arcasilesgroup/ai-engineering" width="640">
+    </picture>
+  </a>
+</div>
+
+## Contributors
+
+<div align="center">
+  <a href="https://github.com/arcasilesgroup/ai-engineering/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=arcasilesgroup/ai-engineering" alt="ai-engineering contributors">
+  </a>
+</div>
+
+Made with [contrib.rocks](https://contrib.rocks).
 
 
 ================================================================
@@ -131,9 +186,9 @@ Install `{ai} engineering` and get a governed repository in under a minute.
 ## 1 — Install the CLI
 
 ```bash
-pip install ai-engineering
-# or, with uv:
 uv tool install ai-engineering
+# or, with pip:
+pip install ai-engineering
 ```
 
 Verify it:
@@ -197,6 +252,7 @@ Next: [the architecture](../architecture/index.md).
 
 ## Get going
 
+- [ai-engineering.arcasiles.com](https://ai-engineering.arcasiles.com) — the website: what it is and how to install.
 - [Getting started](guides/getting-started.md) — install, your first session, the governed workflow.
 - [The architecture](architecture/index.md) — how the pieces fit, for contributors.
 
@@ -210,6 +266,7 @@ Next: [the architecture](../architecture/index.md).
 
 ## Project identity
 
+- [SOUL.md](../SOUL.md) — the agent's collaborator values (the judgment layer above the gates).
 - [CONSTITUTION.md](../CONSTITUTION.md) — mission, stakeholders, prohibitions.
 - [CHANGELOG.md](../CHANGELOG.md) — release history and breakage notes.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — development setup and the pull request process.
@@ -580,7 +637,7 @@ None of these run on the hot path; all are idempotent and safe to re-run.
 > (engineering principles, plan-mode default, subagent strategy,
 > commit conventions, etc.) live in
 > [CANONICAL.md](src/ai_engineering/templates/project/CANONICAL.md)
-> and its byte-equivalent mirrors (AGENTS.md, CLAUDE.md, GEMINI.md,
+> and its byte-equivalent mirrors (AGENTS.md, CLAUDE.md,
 > .github/copilot-instructions.md). This file owns "what THIS project
 > IS" — Mission, Stakeholders, Vocabulary, Prohibitions, Compliance
 > gates, Anti-goals, Boundaries, Escalation, Language, Lifecycle phase.
@@ -606,7 +663,7 @@ AI authoring is the cost-driver and auditability is the bar.
 ## Stakeholders
 
 - **Operator engineers** consuming the framework through their IDE
-  host (Claude Code, Codex, Gemini CLI, GitHub Copilot, OpenCode, Cursor).
+  host (Claude Code, Codex, Antigravity, GitHub Copilot, OpenCode, Cursor).
 - **Security + compliance reviewers** auditing the deterministic
   plane (policy engine, prompt-injection guard, append-only NDJSON
   audit chain).
@@ -661,7 +718,7 @@ AI authoring is the cost-driver and auditability is the bar.
    one canonical writable store. Derived caches are explicitly
    labelled (named, with a rebuild command) and rebuildable on
    demand. See [docs/persistence-doctrine.md](docs/persistence-doctrine.md)
-   for the four-tier model and the rebuild semantics.
+   for the three-tier files-only model and the rebuild semantics.
 
 ## Compliance gates
 
@@ -709,10 +766,10 @@ AI authoring is the cost-driver and auditability is the bar.
 ## Boundaries
 
 - **Framework-owned** — every file under
-  `.ai-engineering/`, `.claude/`, `.codex/`, `.gemini/`,
-  `.github/skills/`, `.github/agents/`,
+  `.ai-engineering/`, `.claude/`, `.codex/`, `.agents/`, `.opencode/`,
+  `.cursor/`, `.github/skills/`, `.github/agents/`,
   `.github/copilot-instructions.md`, AGENTS.md, CLAUDE.md,
-  GEMINI.md, CANONICAL.md, this CONSTITUTION.md, and
+  CANONICAL.md, this CONSTITUTION.md, and
   `scripts/sync_mirrors/`. Operators MUST NOT hand-edit generated
   mirrors; `sync_command_mirrors.py` regenerates from canonical
   sources.
@@ -749,7 +806,7 @@ written CONSTITUTION.md stays in English for cross-team review.
 ## Lifecycle phase
 
 **Stabilising** — the framework has shipped its canonical chain
-(spec-127 / spec-128 / spec-129) and is now hardening DX (spec-131).
+(spec-127 / spec-128 / spec-129) and is now hardening DX and reliability (spec-131 through spec-182, v0.12.3).
 Breaking changes still land without backwards-compat shims (anti-goal
 above), but the deterministic plane contract (audit chain shape,
 risk-acceptance ledger, hooks manifest) is frozen modulo ADR.

--- a/llms.txt
+++ b/llms.txt
@@ -2,10 +2,11 @@
 
 > An open-source CLI that installs a deterministic governance layer into any repository — specs, decisions, skills, agents, hooks, and a hash-chained audit trail as versioned local files. No hosted control plane, no provider lock-in; every IDE follows the same rules. 54 skills, 9 agents, 6 surfaces, 1 governed flow.
 
-Install with `pip install ai-engineering`, then `ai-eng install .` and `ai-eng doctor`. Drive work through the canonical chain `/ai-brainstorm → /ai-plan → /ai-build → /ai-pr`; `/ai-commit` is an off-chain WIP checkpoint. The same commands run in Claude Code, GitHub Copilot, OpenAI Codex, Antigravity, OpenCode, and Cursor.
+Install with `uv tool install ai-engineering` (pip/pipx also work), then `ai-eng install .` and `ai-eng doctor`. Drive work through the canonical chain `/ai-brainstorm → /ai-plan → /ai-build → /ai-pr`; `/ai-commit` is an off-chain WIP checkpoint. The same commands run in Claude Code, GitHub Copilot, OpenAI Codex, Antigravity, OpenCode, and Cursor.
 
 ## Docs
 
+- [Website](https://ai-engineering.arcasiles.com): what it is, why it is governed, and how to install.
 - [README](README.md): what it is, install, the governed workflow, the toolkit, supported surfaces.
 - [Getting started](docs/guides/getting-started.md): install, first session, and shipping the governed way.
 - [Documentation index](docs/index.md): the full doc map.

--- a/scripts/gen_llms_full.py
+++ b/scripts/gen_llms_full.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Regenerate llms-full.txt — the derived full-corpus cache for AI ingestion.
+
+SSOT-PD (CONSTITUTION Prohibition 8): llms-full.txt is a *derived cache*.
+This script is its named rebuild command. Run it after editing any source
+below; never hand-edit the concatenated body.
+
+    python -m scripts.gen_llms_full
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT = REPO_ROOT / "llms-full.txt"
+
+# Source order is contractual: it matches the header's "Regenerate from" list.
+SOURCES = [
+    "README.md",
+    "docs/guides/getting-started.md",
+    "docs/index.md",
+    "docs/architecture/index.md",
+    "docs/architecture/brand-tokens.md",
+    "docs/persistence-doctrine.md",
+    "CONSTITUTION.md",
+    "AGENTS.md",
+]
+
+RULE = "=" * 64
+
+HEADER = (
+    "# {ai} engineering — full documentation corpus\n"
+    "\n"
+    "> Derived cache: concatenated user-facing and canonical docs for AI "
+    "agent ingestion.\n"
+    "> Regenerate from: README, docs/guides/getting-started, docs/index, "
+    "docs/architecture/index, docs/architecture/brand-tokens, "
+    "docs/persistence-doctrine, CONSTITUTION, AGENTS.\n"
+    "> Rebuild command: `python -m scripts.gen_llms_full`.\n"
+)
+
+
+def build() -> str:
+    parts = [HEADER]
+    for rel in SOURCES:
+        body = (REPO_ROOT / rel).read_text(encoding="utf-8").rstrip("\n")
+        parts.append(f"\n\n{RULE}\n# FILE: {rel}\n{RULE}\n\n{body}\n")
+    return "".join(parts)
+
+
+def main() -> None:
+    OUTPUT.write_text(build(), encoding="utf-8")
+    print(f"Wrote {OUTPUT.relative_to(REPO_ROOT)} from {len(SOURCES)} sources.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Barrido de consistencia documental (sweep de 6 repos del ecosistema Arcasiles).

## Cambios
- **CONSTITUTION**: retira la superficie Gemini eliminada en #535 (`GEMINI.md`/`.gemini/` no existen); corrige `four-tier`→`three-tier` files-only (spec-148).
- **`.ai-engineering/solution-intent.md`**: inventario real verificado — 54 skills / 9 agentes / 6 surfaces / 24 comandos CLI (antes: cifras era 0.10.1).
- **README**: 6 enlaces de créditos 404 → vigentes (los sin slug fiable a texto plano).
- Añade `scripts/gen_llms_full.py` (el `llms-full.txt` se autodeclaraba cache derivado sin comando de rebuild) y regenera `llms-full.txt`.

Mirrors generados (`CLAUDE.md`/`AGENTS.md`/`CANONICAL.md`) y `templates/**` NO tocados. `ai-eng check` 7/7 PASS; suites docs/mirrors/parity verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)