### PR TITLE
chore(specs): backfill PR/branch in _history for spec-183, spec-184

### DIFF
--- a/.ai-engineering/specs/_history.md
+++ b/.ai-engineering/specs/_history.md
@@ -188,7 +188,7 @@ Completed specs. Details in git history.
 | spec-180 | Normalize spec-state ledger and dogfood template parity | shipped | 2026-06-26 | 2026-06-26 | 612 | spec-180-state-ledger-normalization |
 | spec-181 | ai-pr small-model robustness | shipped | 2026-06-26 | 2026-06-26 | 613 | refactor/ai-pr-small-model-robustness |
 | spec-182 | Advisory nudge routing raw git/gh to /ai-commit and /ai-pr | shipped | 2026-06-29 | 2026-06-29 | 617 | feat/spec-182-governed-git-advisory |
-| spec-183 | spec-183 — CLI command audit + functional color-grouped help | shipped | 2026-07-13 | 2026-07-14 | — | — |
-| spec-184 | Field-level manifest ownership + framework version-drift UX | shipped | 2026-07-14 | 2026-07-14 | — | — |
+| spec-183 | spec-183 — CLI command audit + functional color-grouped help | shipped | 2026-07-13 | 2026-07-14 | 637 | spec-manifest-field-ownership |
+| spec-184 | Field-level manifest ownership + framework version-drift UX | shipped | 2026-07-14 | 2026-07-14 | 637 | spec-manifest-field-ownership |
 
 ---


### PR DESCRIPTION
## What

Fill the `PR` and `branch` columns in `.ai-engineering/specs/_history.md` for spec-183 and spec-184 — both were `—` (em-dash).

| spec | PR | branch |
|------|-----|--------|
| spec-183 | 637 | spec-manifest-field-ownership |
| spec-184 | 637 | spec-manifest-field-ownership |

## Why

Both specs shipped **combined** in PR #637 via branch `spec-manifest-field-ownership`. The `mark_shipped` ran direct (not via the PR-aware handler), so the ledger row never captured the PR/branch context that prior specs carry (181→613, 182→617). This completes the shipped-history ledger; no code or behavior change.

Surfaced during `/ai-branch-cleanup` Phase 5 reconcile — the specs are fully formalized (shipped, archived, slot cleared); this is ledger-completeness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)