### PR TITLE
fix(tests): clear the two SonarCloud reliability bugs blocking main

### DIFF
--- a/tests/unit/governance/test_decision_log.py
+++ b/tests/unit/governance/test_decision_log.py
@@ -171,4 +171,6 @@ def test_redacts_subject_and_justification(tmp_path: Path) -> None:
 
 def test_should_sample_is_deterministic() -> None:
     cid = "abc123"
-    assert decision_log.should_sample(cid) == decision_log.should_sample(cid)
+    observed = {decision_log.should_sample(cid) for _ in range(10)}
+    assert len(observed) == 1, f"same correlation id yielded both outcomes: {observed}"
+    assert observed <= {True, False}

--- a/tests/unit/test_gate_cache_hit_miss.py
+++ b/tests/unit/test_gate_cache_hit_miss.py
@@ -356,6 +356,7 @@ def test_lookup_handles_concurrent_persist_safely(tmp_path: Path) -> None:
     inputs = _baseline_inputs()
     iterations = 25
     results_observed: list[dict[str, object]] = []
+    outcomes_observed: list[object] = []
     exceptions: list[Exception] = []
 
     def writer() -> None:
@@ -374,8 +375,9 @@ def test_lookup_handles_concurrent_persist_safely(tmp_path: Path) -> None:
                 entry = lookup(cache_dir=cache_dir, **inputs)
                 if entry is not None:
                     # Touch the result dict to force any lazy decoding errors.
-                    outcome = entry.result["outcome"]
-                    assert outcome in {"pass", "fail"}
+                    # Collect only -- the main thread owns every assertion so a
+                    # bad outcome cannot be conflated with a raised exception.
+                    outcomes_observed.append(entry.result["outcome"])
                     results_observed.append(entry.result)
         except Exception as exc:
             exceptions.append(exc)
@@ -391,6 +393,8 @@ def test_lookup_handles_concurrent_persist_safely(tmp_path: Path) -> None:
 
     # Assert
     assert not exceptions, f"Concurrent persist/lookup raised: {exceptions!r}"
+    bad_outcomes = [o for o in outcomes_observed if o not in {"pass", "fail"}]
+    assert not bad_outcomes, f"Reader observed torn/unknown outcomes: {bad_outcomes!r}"
     assert not writer_thread.is_alive()
     assert not reader_thread.is_alive()
     final = lookup(cache_dir=cache_dir, **inputs)


### PR DESCRIPTION
## Why

The SonarCloud quality gate on `main` has been ERROR since spec-192, which
blocks `CI Result` and therefore the release. Querying the gate directly shows
a single failing dimension:

| Condition | Threshold | Actual |
|---|---|---|
| `reliability_rating` | A (1) | **D (4)** |
| `new_reliability_rating` | A (1) | **D (4)** |
| `security_rating` / `new_security_rating` | A | A |
| `sqale_rating` / `new_maintainability_rating` | A | A |
| `coverage` / `new_coverage` | 80 | 85.4 |

Two open bugs account for the whole gap, both in test code.

## What

**`python:S5863`** — `tests/unit/governance/test_decision_log.py`

`test_should_sample_is_deterministic` asserted
`should_sample(cid) == should_sample(cid)`: the same expression on both sides.
That passes even for a function that alternates on every other call, so it did
not test what its name claims. Now samples ten times and asserts a single
distinct outcome.

**`python:S5779`** — `tests/unit/test_gate_cache_hit_miss.py`

The concurrency reader thread asserted inside a `try/except Exception`, so an
`AssertionError` from a torn read landed in the same `exceptions` bucket as a
genuine raise — the two failure modes were indistinguishable in the report.
The reader now only collects observed outcomes; the main thread owns every
assertion and reports bad outcomes separately from exceptions.

## Not done

No `# noqa`, no `# NOSONAR`, no `sonar.issue.ignore` entry. Both findings are
real test defects and are fixed at the source, per CONSTITUTION Hard Rule 2.

Both modules pass locally (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
