### PR TITLE
ci(deps): bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,7 +389,7 @@ jobs:
           path: dist
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
@@ -500,7 +500,7 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
 


### PR DESCRIPTION
Supersedes #672.

## What

Both `pypa/gh-action-pypi-publish` pins in `release.yml` move from
`ba38be9e…` (v1.14.1) to `dc37677b…` (v1.14.2) — the TestPyPI step and the
PyPI step. Identical to the Dependabot proposal in the `github-actions` group.

## Why re-homed off the Dependabot branch

`Verify Gate Trailers` is skipped when `github.actor == 'dependabot[bot]'`.
#672 was behind a moved `main`, and updating its branch added a human merge
commit — which lifts that skip and then fails the job on Dependabot's own
untrailered commit. Landing the same two lines as a single locally-gated
commit satisfies the trailer requirement rather than admin-bypassing a
required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)