### PR TITLE
test(ui): control the simulated terminal

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,16 @@ def undecorated(monkeypatch):
     ui.reset()
     yield
     ui.reset()
+
+
+@pytest.fixture
+def coloured(monkeypatch):
+    """A terminal that asks for decoration even when the test runner is behind a pipe."""
+    from ai_engineering import ui
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    ui.reset()
+    yield
+    ui.reset()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -795,13 +795,12 @@ def test_the_whole_report_is_data_and_none_of_it_is_chrome(monkeypatch, capsys):
     ) in caught.out
 
 
-def test_the_three_muted_kinds_of_line_under_the_report_are_dressed_as_such(monkeypatch, capsys):
+def test_the_three_muted_kinds_of_line_under_the_report_are_dressed_as_such(
+    monkeypatch, capsys, coloured
+):
     """The legend, the reasons under the unanswered rows and the sentence that says none of
     them is a pass. Undecorated all three are ordinary text in a screen that is mostly
     ordinary text, and the last one is a warning — the whole point of printing it."""
-    monkeypatch.delenv("NO_COLOR", raising=False)
-    monkeypatch.setenv("FORCE_COLOR", "1")
-    doctor.ui.reset()
     stub(monkeypatch, [(3, "The context", "refused", True, raises(doctor.Undecidable("why")))])
     monkeypatch.setattr(doctor, "coverage", lambda root: ["  T2  a  BLOCKS  a denial ran here"])
     doctor.main([])
@@ -819,12 +818,11 @@ def test_the_three_muted_kinds_of_line_under_the_report_are_dressed_as_such(monk
 @pytest.mark.parametrize(
     ("problem", "colour"), [(lambda root: "broken", "red"), (lambda root: None, "#00D4AA")]
 )
-def test_the_verdict_frame_takes_its_colour_from_the_answer(monkeypatch, capsys, problem, colour):
+def test_the_verdict_frame_takes_its_colour_from_the_answer(
+    monkeypatch, capsys, problem, colour, coloured
+):
     """Undecorated the two verdicts are the same box, so the colour is the one part of this
     that the rest of the suite cannot see — and it is the part read first."""
-    monkeypatch.delenv("NO_COLOR", raising=False)
-    monkeypatch.setenv("FORCE_COLOR", "1")
-    doctor.ui.reset()
     stub(monkeypatch, [(4, "The context", "b", True, problem)])
     doctor.main([])
     assert Style.parse(colour).render("─").split("─")[0] in capsys.readouterr().out
@@ -946,13 +944,12 @@ def test_a_cure_that_exits_non_zero_stops_the_rest_instead_of_reporting_a_clean_
     assert out.count("   2  FAIL     a") == 1, "it asked again after a repair that failed"
 
 
-def test_the_command_a_repair_runs_and_the_one_that_failed_are_dressed_apart(monkeypatch, capsys):
+def test_the_command_a_repair_runs_and_the_one_that_failed_are_dressed_apart(
+    monkeypatch, capsys, coloured
+):
     """`--fix` prints two kinds of line: the command it is about to run, which is what a
     person re-runs by hand when it goes wrong, and the sentence saying one exited non-zero.
     Undecorated they are two runs of ordinary text, and the second is the one that matters."""
-    monkeypatch.delenv("NO_COLOR", raising=False)
-    monkeypatch.setenv("FORCE_COLOR", "1")
-    doctor.ui.reset()
     monkeypatch.setattr(cli, "main", lambda argv: 3)
     stub(monkeypatch, [(11, "The pin", "a", True, lambda root: "broken")])
     assert doctor.main(["--fix"]) == 3

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -21,19 +21,6 @@ from rich.style import Style
 from ai_engineering import __version__, ui
 
 
-@pytest.fixture
-def coloured(monkeypatch):
-    """A terminal that wants decoration. FORCE_COLOR is the convention for saying so past a
-    pipe, and it is what a person debugging their own colours reaches for, so exercising
-    the decorated path through it exercises a path users actually take."""
-    monkeypatch.delenv("NO_COLOR", raising=False)
-    monkeypatch.setenv("TERM", "xterm-256color")
-    monkeypatch.setenv("FORCE_COLOR", "1")
-    ui.reset()
-    yield
-    ui.reset()
-
-
 def test_messaging_goes_to_stderr_and_data_goes_to_stdout(capsys):
     """`ai-eng doctor > report.txt` has to yield the report and not the report with every
     line of chrome still attached. This is that split, at the only place that decides it."""


### PR DESCRIPTION
## What changed

The decorated-terminal fixture now lives in the shared pytest configuration and explicitly controls `NO_COLOR`, `TERM`, and `FORCE_COLOR`. Doctor's colour assertions reuse that fixture instead of inheriting the caller's terminal.

## Why

A fresh checkout run from a headless shell inherited `TERM=dumb`. Four tests requested colour with `FORCE_COLOR` but left that conflicting value in place, so the local gate failed while GitHub CI passed.

## Verification

- `just check` — 817 tests, 14/14 adversarial, 97% coverage, security scanners clean
- targeted decorated rendering suite — 61 passed
- repository lines: 17,807 / 17,810

No package release or PyPI publication is part of this PR.
