### PR TITLE
Integrate the technical payload of #682 (guards + 3.14) — governance already on main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -488,9 +488,16 @@ jobs:
       # machine that wrote this: green on its own under `-n auto`, red inside the full
       # parallel run. `just check` measures it uninstrumented on Linux, which is where the
       # number means something, and the justfile already says so above its own `test` recipe.
-      - name: the suite, on a machine that is not Linux
+      # 3.14 rather than 3.12, and the version is the second thing this lane measures.
+      # `pyproject.toml` declares `requires-python = ">=3.11"`, and until 2026-08-21 that was
+      # a claim nothing kept: uv picked 3.14.6 here once and one test failed, because it
+      # pinned how argparse wrapped a usage line and 3.14 wraps it differently. The test was
+      # repaired to assert what the command accepts rather than where the line broke. Every
+      # other lane runs the runner's 3.12, so between them the declared range is checked at
+      # both ends by a command instead of by a sentence in a manifest.
+      - name: the suite, on a machine that is not Linux and an interpreter that is not 3.12
         run: >-
-          uv run --python 3.12 --with pytest==9.1.1 --with pytest-xdist==3.8.0 pytest -q -n auto tests/
+          uv run --python 3.14 --with pytest==9.1.1 --with pytest-xdist==3.8.0 pytest -q -n auto tests/
           --deselect tests/test_contracts.py::test_the_guards_start_fast_enough_to_be_guards
 
   ci-result:

--- a/docs/solution-intent.html
+++ b/docs/solution-intent.html
@@ -79,7 +79,7 @@ color:var(--muted);font-size:.88em}
 @media print{body{font-size:11pt}.scroll{overflow:visible}th{position:static}}
 </style>
 </head>
-<body data-inputs-digest="462da854e26801685d126e51a0066400314bc862e53d1507dcdd09649cda392a">
+<body data-inputs-digest="52876e4d6694d7e9f375d34e4755d59ad778a35268326e3b5d245bbd4899f9f8">
 <div class="wrap">
 <header class="hero">
   <h1>Governed agentic engineering</h1>
@@ -88,7 +88,7 @@ color:var(--muted);font-size:.88em}
   repository's files, so it cannot go stale without the gate saying so.</p>
   <div class="stamp">
     <span>Intent status: active</span>
-    <span>inputs-digest 462da854e2680168…</span>
+    <span>inputs-digest 52876e4d6694d7e9…</span>
     <span>no date and no HEAD: what cannot be signed is not printed</span>
   </div>
 </header>
@@ -103,7 +103,7 @@ color:var(--muted);font-size:.88em}
     <div class="card"><span class="n">16</span><span class="k">skills</span><span class="s">80 lines each at most</span></div>
     <div class="card"><span class="n">4</span><span class="k">fail-closed guards</span><span class="s">+2 telemetry</span></div>
     <div class="card"><span class="n">10</span><span class="k">CLI verbs</span><span class="s">src/ai_engineering/cli.py</span></div>
-    <div class="card"><span class="n">2.16:1</span><span class="k">tests against product</span><span class="s">max 2.3:1 · 36.849 / 17.097</span></div>
+    <div class="card"><span class="n">2.16:1</span><span class="k">tests against product</span><span class="s">max 2.3:1 · 36.944 / 17.097</span></div>
     <div class="card"><span class="n">0/8</span><span class="k">production boxes proven</span><span class="s">READINESS_DECLARATION_MISSING</span></div>
   </div>
 </section>

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1945,3 +1945,111 @@ def test_the_event_falls_back_to_the_payload_when_no_argument_names_it(repo, mon
         "the dispatcher could not read an event that arrived in the payload rather than as "
         "an argument, which is how every structured surface sends it"
     )
+
+
+def test_an_adapter_whose_translation_table_is_not_a_table_costs_only_itself(tmp_path, monkeypatch):
+    """`payload_field` is declared as an object, and a hand-written adapter can spell it as
+    anything. The loop that reads it calls `.items()`, so a list — or a string, or a number —
+    reaches that call and raises `AttributeError` outside every handler: the shape check two
+    lines above it is the only thing standing between a malformed data file and a dispatcher
+    that cannot normalise a payload at all.
+
+    That is the failure this whole function is written to avoid, and its own docstring says
+    so: an adapter somebody broke should cost its surface's extra spellings, not every call
+    on every surface. A guard that crashes is a guard that denies.
+
+    A generated mutant lived on that check through every run of the lane.
+    """
+
+    adapters = tmp_path / "adapters"
+    adapters.mkdir()
+    (adapters / "wrong-shape.adapter.json").write_text(
+        json.dumps({"translations": {"payload_field": ["tool_name", "toolName"]}}),
+        encoding="utf-8",
+    )
+    (adapters / "fine.adapter.json").write_text(
+        json.dumps({"translations": {"payload_field": {"tool_name": "aDialect"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(chain, "ADAPTERS", adapters)
+
+    assert chain.normalise({"aDialect": "Bash"})["tool_name"] == "Bash"
+    assert chain.normalise({"toolName": "Edit"})["tool_name"] == "Edit"
+
+
+@pytest.mark.parametrize(
+    ("hook", "declares", "because"),
+    [
+        ("no_such_hook", False, "could not even be loaded"),
+        ("injection_guard", True, "does not declare"),
+    ],
+)
+def test_a_denial_the_guard_never_reached_is_remembered_like_any_other(
+    repo, monkeypatch, capsys, hook, declares, because
+):
+    """Two denials are decided by the dispatcher itself rather than by a guard: one when the
+    guard cannot be imported, one when the hook on a blocking event declares no class. Both
+    write the same cache entry every guard's denial writes, and each `if dedup` is its own
+    line.
+
+    Without it the second delivery of the same call re-runs the whole line and re-decides —
+    and this repository already has the receipt for what that costs, in the comment beside
+    both lines: a remembered verdict keyed without the event once overwrote a PreToolUse
+    answer with a PostToolUse one. A denial that is not written down is a denial the next
+    delivery asks again, which is the dedup this module exists for failing on exactly the
+    two calls nobody wrote a guard for.
+
+    Two generated mutants lived on these two lines through every run of the lane.
+    """
+
+    class Undeclared:
+        @staticmethod
+        def run(payload):
+            raise AssertionError("a hook with no class must never be run")
+
+    monkeypatch.setattr(chain, "TABLE", {"PreToolUse": [(hook, r".*")]})
+    # The first case must reach a real failing import, so only the second one is handed a
+    # module: patching the import for both would make `no_such_hook` load fine and test the
+    # other arm twice.
+    if declares:
+        monkeypatch.setattr(chain.importlib, "import_module", lambda name: Undeclared)
+    call = {"tool_name": "Bash", "tool_input": {"command": "ls"}, "tool_use_id": "t-dedup"}
+
+    with pytest.raises(SystemExit) as stop:
+        dispatch(monkeypatch, "PreToolUse", json.dumps(call))
+    assert stop.value.code == 2
+    assert because in capsys.readouterr().err
+
+    remembered = chain.cached(chain.fingerprint(chain.normalise(call)))
+    assert remembered is not None and remembered["deny"] is True, (
+        "the dispatcher denied this call and wrote nothing down, so the next delivery of the "
+        "same call runs the whole line again to reach the same answer"
+    )
+
+
+def test_a_hot_path_over_the_budget_says_so_in_the_record(repo, monkeypatch):
+    """The dispatcher runs before every tool call on every surface, so its own latency is a
+    product property and not a curiosity: `AGENTS.md` says a slow guard is a disabled guard,
+    and the 110 ms import this whole half is written to avoid is the same budget.
+
+    Nothing but this line can notice the day it is exceeded. It is the only place the elapsed
+    time is compared to anything, and with the comparison forced false the record stays
+    silent while the hot path takes as long as it likes — which reads exactly like a hot path
+    that is fast.
+
+    A generated mutant lived on this branch through every run of the lane.
+    """
+
+    monkeypatch.setitem(chain.TABLE, "PreToolUse", [])
+    ticks = iter([0.0, 0.5])
+    monkeypatch.setattr(chain.time, "perf_counter", lambda: next(ticks))
+
+    said = []
+    monkeypatch.setattr(chain, "emit", lambda *a, **kw: said.append((a, kw)))
+    assert dispatch(monkeypatch, "PreToolUse", '{"tool_name": "Bash"}') == 0
+
+    slow = [kw for _, kw in said if kw.get("error") == "hot path over 200 ms"]
+    assert slow and slow[0]["ms"] == 500, (
+        "a dispatcher run that took half a second left nothing in the record, so the one "
+        "measurement that can notice this hot path slowing down is not being taken"
+    )

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -381,13 +381,26 @@ def test_no_eleventh_verb_and_the_stub_sentence_is_gone():
 
 
 def _report_help(monkeypatch, capsys, *argv: str) -> list[str]:
-    """One subcommand's whole help block, at a fixed width so it is comparable."""
+    """One subcommand's whole help block, with the usage sentence on a single line.
+
+    The usage block is unwrapped before it is returned, because how argparse breaks it is
+    argparse's business and it changed in 3.14: a surface that fits on one line at that
+    version's arithmetic and two at 3.12's is the same surface. Pinning the break made
+    `pyproject.toml`'s `requires-python = ">=3.11"` false — one assertion, and the only
+    thing in 2,236 tests that did not survive 3.14.
+
+    What is pinned is what the command accepts, which is the thing a mutant can move.
+    """
     from ai_engineering import report
 
     monkeypatch.setenv("COLUMNS", "90")
     with pytest.raises(SystemExit):
         report.main([*argv, "--help"])
-    return capsys.readouterr().out.rstrip("\n").splitlines()
+    lines = capsys.readouterr().out.rstrip("\n").splitlines()
+    usage = []
+    while lines and lines[0].strip():
+        usage.append(lines.pop(0).strip())
+    return [" ".join(usage), *lines]
 
 
 def test_the_report_verb_declares_exactly_these_five_subcommands(monkeypatch, capsys):
@@ -438,8 +451,8 @@ def test_the_issue_subcommand_requires_all_five_fields_and_offers_one_flag(monke
     public route is offered at all. The other four are the payload, and `--submit` is the one
     flag that turns a draft into something that leaves."""
     assert _report_help(monkeypatch, capsys, "issue") == [
-        "usage: ai-eng report issue [-h] --kind {bug,security} --title TITLE --what-happened",
-        "                           WHAT_HAPPENED --expected EXPECTED --step STEP [--submit]",
+        "usage: ai-eng report issue [-h] --kind {bug,security} --title TITLE --what-happened "
+        "WHAT_HAPPENED --expected EXPECTED --step STEP [--submit]",
         "",
         "options:",
         "  -h, --help            show this help message and exit",


### PR DESCRIPTION
The technical half of pull request #682, taken up after the owner closed it as subsumed.

#682 ("Specification 023: the seven decisions the owner handed back") carried a real technical payload, but its own spec 023 and its ADR run 0021–0024 collided with the council lineage that `main` already holds from #683. The owner picked option A: close the PR and bring in only the technical pieces `main` did not already have — nothing from its governance records.

What lands here:

- **`tests/test_hooks.py`** — three tests that pin the dispatcher's own decisions, covering the four surviving mutants: a malformed translation table costs only its surface; a denial a guard never reached is remembered like any other (both the cannot-import and no-declared-class rows); and the hot path over 200 ms says so in the record. `hooks/chain.py` already carries all four fixes on `main`; these are the readers that keep them honest.
- **`tests/test_issue.py`** — stops pinning *where* argparse wraps a usage line and pins *what* the command accepts instead, so the suite survives Python 3.14.
- **`.github/workflows/check.yml`** — the non-Linux suite lane now runs **3.14** instead of 3.12, which checks the declared `requires-python = ">=3.11"` at both ends by a command rather than by a sentence in a manifest.

Deliberately **not** brought over (they belong to the closed seven-decisions branch, and `main`'s council lineage already occupies the same numbers/slots): `docs/adr/0021–0024` of that branch, `specs/023-seven-decisions-the-owner-handed-back/`, and `tests/test_record.py`'s "latest approval wins" rewrite (its whole point is a re-approval record `main` does not have).

Gate is green locally: `just check` EXIT=0, tests=2251, lint=258, skilleval=332. PR #682 is closed and `finish-subtraction` deleted; this is the branch that carries the merged output forward.
PRBODY
gh pr create --base main --head integrate-682-technical --title "Integrate the technical payload of #682 (guards + 3.14) — governance already on main" --body-file /tmp/pr-integral.md 2>&1 | tail -2
