### PR TITLE
docs(doctrine): rule 1 names the approved spec and plan everywhere it is delivered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ once per session. `CLAUDE.md` is one line that imports this file.
 
 ## The twelve rules
 
-1. No code before an approved plan (more than 3 files).
+1. No code before an approved spec and plan (more than 3 files).
 2. One commit, one change.
 3. Never `--no-verify`. Never silence a linter (`noqa`, `@ts-ignore`, `nosec`).
 4. No compatibility shims. Hard rename, hard delete; say it in the changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,17 @@ search for.
   liked. If you keep a package by that name in a repository, the diagnosis now reads the
   installed product instead of yours.
 
+### Changes
+
+- Rule 1 of `AGENTS.md` now reads "No code before an approved spec and plan", and the
+  delivered doctrine matches it: the `AGENTS.md` skeleton `init` writes, the `EP-324`
+  ledger subject and the `test_record` docstring that quotes it. The rule had always
+  meant both documents — the approval records name a digest for `spec.md` and `plan.md`
+  alike — but the short form "approved plan" let the spec pass on a reading of the plan
+  alone. The two historical records that quote the older wording (`docs/adr/0016`,
+  `specs/024`) are left as written, because an approval record describes the rule as it
+  was when it approved that work.
+
 ## 1.0.0 — 2026-08-10
 
 ### Breaking changes

--- a/docs/requirements.toml
+++ b/docs/requirements.toml
@@ -2367,7 +2367,7 @@ note = '''the fourteen prohibitions are now proved to be the report's own list, 
 [[requirement]]
 id = "EP-324"
 verdict = "PROVEN"
-subject = "no code before an approved plan"
+subject = "no code before an approved spec and plan"
 evidence = "pytest tests/test_record.py -k 'approval_record or approval_digests'; python tests/adversarial/run.py | grep -E 'no plan|control . change_scope_guard'"
 note = '''both halves execute and the row's claim that no plan here has an approved digest was wrong. `docs/adr/0009` has recorded the approved digest of `spec.md` and `plan.md` since 2026-08-17, outside the files it approves for the reason it states — an approval naming the digest of the file it is written in changes that digest by existing, so the number never settles. What was missing was a reader: the record had the same standing as the prose it replaced, true when written and unable to notice the day it stopped being true. It is read now, row by row, and both files still hash to what was approved. An edit to either turns the gate red naming which file moved and by how much, proved by appending one comment to the plan and reading the refusal. The weaker half — that a plan exists on the branch at all — remains `hooks/change_scope_guard.py`.'''
 

--- a/src/ai_engineering/skeletons.py
+++ b/src/ai_engineering/skeletons.py
@@ -29,7 +29,7 @@ Project identity, vocabulary and prohibitions live in CONSTITUTION.md. Read it f
 
 ## The rules
 
-1. No code before an approved plan (more than 3 files).
+1. No code before an approved spec and plan (more than 3 files).
 2. One commit, one change.
 3. Never `--no-verify`. Never silence a linter, in any language.
 4. No compatibility shims. Hard rename, hard delete; say it in the changelog.

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1472,7 +1472,7 @@ def test_the_command_the_staleness_message_names_is_one_that_runs(repo, monkeypa
 
 
 def test_the_approval_record_still_names_the_bytes_that_are_there():
-    """`EP-324`: no code before an approved plan, where approval means a record naming an
+    """`EP-324`: no code before an approved spec and plan, where approval means a record naming an
     exact digest.
 
     The row said no plan in this repository has one. It has had one since 2026-08-17:


### PR DESCRIPTION
## What changed

Rule 1 of the doctrine that every installed project receives now says you need **both** an approved spec and an approved plan before code (more than three files) — not just an approved plan. The list of twelve rules in `AGENTS.md` already named both; this makes the wording that actual projects get on `ai-eng init` say the same thing, so nobody reading the shipped doctrine sees a rule that differs from the author's own.

Concretely, three places that quoted the old short form "approved plan" now read "approved spec and plan":
- the `AGENTS.md` skeleton written by `ai-eng init` (`src/ai_engineering/skeletons.py`)
- the `EP-324` ledger subject in `docs/requirements.toml`
- the `test_record` docstring that quotes it

Plus a changelog entry explaining the change. The two historical records quoting the older wording (`docs/adr/0016`, `specs/024`) are deliberately left as written, because an approval record describes the rule as it was when it approved that work.

## Why

The registro already behaved this way — the approval records name an exact digest for both `spec.md` and `plan.md`, and `ai-build` refuses when the plan digest no longer matches disk. "Approved plan" alone let the spec (the step that chooses the option and the authority) pass on a reading of just the plan. This converges the delivered text with the machinery that already enforces it.

## What to look at first

- `src/ai_engineering/skeletons.py` — the delivered rule 1
- `CHANGELOG.md` under "Changes"

## What I'm not confident about

- Whether any other delivered artifact quotes "approved plan" that I did not catch; I grepped the tree and found only the two historical records, which I intentionally left.
