### PR TITLE
Specification 034: appendix notes, decision frameworks and the constellation rule

### DIFF
--- a/.agents/skills/ai-note/SKILL.md
+++ b/.agents/skills/ai-note/SKILL.md
@@ -17,7 +17,9 @@ disable-model-invocation: true
 
 ## What it produces
 
-`docs/notes/<slug>.md`, committed, with a header that lets rot be detected.
+`docs/notes/<slug>.md`, committed, with a header that lets rot be detected. A note is
+appended to with a fresh date, never rewritten — the history a finding records cannot be
+silently edited.
 
 ## Steps
 

--- a/.agents/skills/ai-report/corpus.md
+++ b/.agents/skills/ai-report/corpus.md
@@ -13,7 +13,11 @@ with their digest shown before anybody confirms anything. It sends nothing by it
 - "prepare that bug report but do not send it anywhere yet" — drafting is the whole default; sending is a separate flag and a typed phrase.
 - "what would we actually send if we reported this" — the preview is the answer, and it is the same bytes, hashed.
 
+- "rank these options by RICE and report which wins" — the named framework is the method: apply it and say which one, so the verdict is repeatable across sessions.
+
 ## Refuses
+
+- "we ranked the options by impact, no method" — use `/ai-spec`, because a decision without a named framework is not a fault report: it needs its options, its evidence and its authority.
 
 - "this is failing, work out why" — use `/ai-debug`, because a symptom needs a cause at `file:line` and a check that fails for it; a report of a fault nobody has diagnosed is a report the other side has to diagnose.
 - "save what we learned about this trap so we do not lose it again" — use `/ai-note`, because that is a finding kept in this repository, and this skill exists to send one out of it.

--- a/.agents/skills/ai-review/corpus.md
+++ b/.agents/skills/ai-review/corpus.md
@@ -14,7 +14,11 @@ the result of a mechanical gate, because those ran in CI, and it says so.
 - "is there anything unsafe in this diff" — the security lens, which files a finding only when it can name the source, the sink and the missing control.
 - "we added this without tests, is that a problem" — the testing lens; a check that fails without the change either exists or the change is untested whatever coverage says.
 
+- "is this the right call, we ranked it with RICE" — judge the decision against its named framework and say which one before the verdict, so the ranking is the argument.
+
 ## Refuses
+
+- "we ranked by impact and picked this, just review it" — use `/ai-spec`, because a ranking with no named method is a decision without its authority, and a review is not where a decision gets made.
 
 - "CI is failing on this branch, find out why" — use `/ai-debug`, because that is a failure with a cause to name at `file:line`, not a diff to judge.
 - "this used to work last week and now it doesn't" — use `/ai-debug`, whose first step is reproducing it and whose output is a check that fails for that reason.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,14 @@ search for.
   unblocks it. The `ai-goal` corpus gains the refusal «record the writer model as a
   decision» → `/ai-spec`, and the `skill-routing` baseline moves 349→350 with the reason
   written beside it in `policy/pilot-register.toml`.
+- A note is now appended to, never rewritten — `contract._appendix_problems` refuses an
+  `ai-note` that would edit its history instead of adding a dated finding. Decisions get a
+  named framework: `decision_fw` applies RICE, Effort/Value or Kano deterministically, and
+  a bare "ranked by impact" with no method is refused. Verdicts get a lens:
+  `constellation` reads ≥2 same-class signals in one context as systemic and a lone
+  signal as isolated — and it never erases a guard's own fail. The `skill-routing`
+  baseline moves 359 → 363 with the reason beside it. Recorded in
+  `specs/034-appendix-notes-decision-frameworks-and-constellation`.
   and simplicity (KISS, YAGNI, DRY, SOLID, BDD, TDD, Clean Code, Clean Architecture) is
   the standing bar. It is the gauntlet-loop half of what `ai-cycle` deliberately is not:
   `/ai-cycle` stops at the brief, `/ai-goal` stops at the green gate. The routing

--- a/docs/requirements.toml
+++ b/docs/requirements.toml
@@ -273,7 +273,7 @@ verdict = "INCOMPLETE"
 mover = "owner"
 subject = "a skill evaluation against an approved corpus, with a named approver, format, location and command"
 evidence = "python tests/skill_eval.py; grep -n 'baseline' policy/pilot-register.toml"
-note = "four of the five exist: the corpus is the labelled cases beside every skill, the format is the two headings the admission gate demands, the location is `corpus.md` in each skill directory, and the command is `python tests/skill_eval.py` with a lower bound of 359 it is compared against. The approver is the fifth and is the same gap as EP-289 — a name nobody typed"
+note = "four of the five exist: the corpus is the labelled cases beside every skill, the format is the two headings the admission gate demands, the location is `corpus.md` in each skill directory, and the command is `python tests/skill_eval.py` with a lower bound of 363 it is compared against. The approver is the fifth and is the same gap as EP-289 — a name nobody typed"
 
 [[requirement]]
 id = "EP-030"
@@ -2108,7 +2108,7 @@ verdict = "INCOMPLETE"
 mover = "owner"
 subject = "a skill-evaluation delta with a baseline, a margin and a named approver"
 evidence = "python tests/skill_eval.py | grep baseline; pytest tests/test_skill_eval.py -k baseline"
-note = "two of the three exist and execute. The baseline is 359 in policy/pilot-register.toml and the run prints its delta; the margin is zero, argued rather than assumed — the evaluation is deterministic, so a band around the number would be a tolerance for variance that does not exist and what it would hide is deleted cases. Before this the corpus could have fallen from 254 to 3 and the run would have exited zero. The third half is a named approver: the field is empty on purpose rather than carrying a name nobody typed, and the row reopens when somebody with authority puts theirs there"
+note = "two of the three exist and execute. The baseline is 363 in policy/pilot-register.toml and the run prints its delta; the margin is zero, argued rather than assumed — the evaluation is deterministic, so a band around the number would be a tolerance for variance that does not exist and what it would hide is deleted cases. Before this the corpus could have fallen from 254 to 3 and the run would have exited zero. The third half is a named approver: the field is empty on purpose rather than carrying a name nobody typed, and the row reopens when somebody with authority puts theirs there"
 
 [[requirement]]
 id = "EP-290"

--- a/policy/pilot-register.toml
+++ b/policy/pilot-register.toml
@@ -69,7 +69,7 @@ wave = "P0"
 id = "skill_eval_delta"
 # The third absence this row recorded is gone. `just skilleval` is an evaluation runner
 # inside the gate, the labelled cases sit beside every skill, and there is a baseline now:
-# 359, margin zero, delta printed on every run. A register with no baseline is refused rather
+# 363, margin zero, delta printed on every run. A register with no baseline is refused rather
 # than passed.
 #
 # What is still missing is the named approver, which `EP-289` asks for and which nobody can
@@ -332,7 +332,7 @@ enforced_by = "ai_engineering.report.BYPASSES_WORTH_A_LOOK, printed by `ai-eng r
 
 [[baseline]]
 id = "skill-routing"
-measured = 359
+measured = 363
 margin = 0
 command = "python tests/skill_eval.py"
 approved_by = ""
@@ -340,6 +340,8 @@ reopen_when = "somebody with authority names themselves here, which closes EP-28
 why = """The count is claims plus refusals plus the labelled cases on both sides. Falling \
 means a skill stopped declaring what it routes or a corpus lost cases; rising means the \
 opposite. Both are worth a sentence, and neither should happen without one.
+
+359 to 363: spec 034 adds named decision frameworks to `/ai-report` and `/ai-review`. Situations routed 81 to 81, hand-offs 42 to 42, labelled cases 236 to 240 — one route and one refusal each added: a ranking that names a framework (RICE, Effort/Value, Kano) is applied and the framework said; a bare "ranked by impact" with no method is refused into `/ai-spec`. 81+42+240 is 363. Nothing was withdrawn; the four rows are the named-framework routing the methodless-decision gap was missing.
 
 355 to 359: spec 033 adds context economy to `/ai-note`, `/ai-review` and `/ai-security`. Situations routed 81 to 81, hand-offs 42 to 42, labelled cases 232 to 236 — two routes (trim the evidence with `trim`; turn this session into a skill with `skillify`) and one refusal each on `/ai-review` and `/ai-security` (a version claim contradicting the installed bytes is unverified) added: attention is spent on failure lines, sessions become skills, and reviews trust the installed distribution, never memory. 81+42+236 is 359. Nothing was withdrawn; the four rows are the context-economy and installed-version routing the memory/chat/flood gaps were missing.
 

--- a/specs/034-appendix-notes-decision-frameworks-and-constellation/approval.md
+++ b/specs/034-appendix-notes-decision-frameworks-and-constellation/approval.md
@@ -1,0 +1,65 @@
+---
+schema: "urn:ai-engineering:spec-approval:1"
+schema_version: "1"
+type: "approval"
+id: "034"
+title: "Specification 034 and its plan are approved at exact digests"
+date: "2026-08-26"
+spec: "034"
+status: "accepted"
+authority_role: "repository owner"
+approval_ref: "conversation-2026-08-26-034"
+---
+
+# Specification 034 and its plan are approved at exact digests
+
+## What is approved
+
+`specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md` extends spec 010's
+target with the three behaviours the research marked (N26, N27, N29) and this repository
+did not yet supply — B-034-1 appendix-only notes (a contract rule `_appendix_problems` over
+the `ai-note` skill: a note is appended to with a fresh date, never rewritten), B-034-2
+named decision frameworks (a `decision_fw` module with the deterministic RICE,
+Effort/Value and Kano verdicts, plus the named-framework rule in the `ai-report` and
+`ai-review` corpora), B-034-3 the constellation rule (`classify`: ≥2 same-class signals in
+one context read systemic, a lone signal reads isolated, and a guard's fail is never
+erased) — and `specs/034-appendix-notes-decision-frameworks-and-constellation/plan.md`
+sequences them into seven atomic TDD tasks, each with its red fixture first.
+
+The repository owner approved this record in conversation on 2026-08-26 (the same
+instruction that directed specs 028-033) and directed this plan's execution. Approved at
+these exact bytes:
+
+| file | SHA-256 |
+|---|---|
+| `specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md` | `9981a4be26ff99ed32d1d10135f9cb3f83a624de9257c51a9b6ce2978795e598` |
+| `specs/034-appendix-notes-decision-frameworks-and-constellation/plan.md` | `efa1a5a233134b37798d9945f3e3eb2f0dd52b987121b3140ae0f4436fd23b6b` |
+
+## The one gated step
+
+As with specs 028-033, the canonical approval record for this repository is a Structured
+MADR under `docs/adr/`; creation is gated on `madr.validate` returning PASS, which on this
+tree returns `INCOMPLETE [MADR_SCHEMA_INVALID]` from ADR 0025 of spec 026. Spec 034 does not
+authorise rewriting that history. This record is the dossier-level approval at exact
+digests; the MADR promotion is the single re-runnable step after an approved block repairs
+ADR 0025.
+
+Task 7 ran the gate on the block: `2347 passed` (2338 at spec 033 plus the nine new 034
+fixtures), with only the four inherited `tests/test_madr.py` failures — no fifth failure
+introduced. The post-`cover` recipes (`security`, `evals`, `intent-page`, `map`) fail
+exactly as they did on `774c79ac` before this block, except that `map` reports the 034
+dossier's prose mention of Loop-Engineering's `NOTES.md` as one more real reference, which
+joins the accepted set already queued on the repository owner's ADR 0027 work (the
+prose-mention class ADR 0027 accepts); the mention belongs to that record and is not
+rewritten to satisfy the analyzer.
+
+## What this approval does not do
+
+- It is not an acceptance of any risk (the spec's `## Accepted risks` stays empty until a
+  named owner accepts).
+- It is not a standing autonomous grant: the plan's seven tasks are the exact authorized
+  work, one atomic commit each, nothing past task 7 opened by this record.
+- It does not add a new skill (the fifteen-skill target is unchanged), does not modify
+  `.ai/intent.md`, `CONSTITUTION.md` or the one-writer rule, and does not touch the
+  repository owner's uncommitted ADR 0027 work (`justfile`, `test_quality_gate.py`,
+  `policy/skill-map-accepted.toml`).

--- a/specs/034-appendix-notes-decision-frameworks-and-constellation/plan.md
+++ b/specs/034-appendix-notes-decision-frameworks-and-constellation/plan.md
@@ -1,0 +1,111 @@
+# Plan: appendix notes, decision frameworks and constellation — 034 atomic execution
+
+## Authority and atomicity gate
+
+No implementation starts until the accountable role approves **this exact `spec.md` and this
+exact `plan.md`**, recorded at their digests in their own record. One repository writer, on a
+branch carrying the whole 034 change. Each task is one atomic commit touching one primary
+production, policy or skill file plus only the files that task names. Rollback for every task
+is `git revert <commit>`.
+
+**This plan is not edited while it is executed.** Every commit runs the whole gate in the same
+chain as the commit itself. `ai-eng spec show 034 --task <n>` refuses any task whose digests
+have moved.
+
+## The order, and why
+
+The three behaviours are independent modules plus one contract rule and corpus routes; they
+land appendix first (it is a checked rule over ai-note, the smallest), then the two modules
+(decision frameworks and constellation). The repair task brings the touched skills under the
+rules, and the gate proves the tree clean. Each task starts with its red fixture exactly as
+specs 028-033 did.
+
+## What this plan is not doing, and why
+
+- **No change to `.ai/intent.md`, `CONSTITUTION.md`, or the one-writer rule.**
+- **No new skill.** The three behaviours are modules, one contract rule and corpus routes;
+  the fifteen-skill target is unchanged.
+- **No acceptance of ADR 0025 / no history rewrite of spec 026.**
+- **No change to `justfile`/`test_quality_gate.py`** (the repository owner's uncommitted
+  work sits there); the new suites join the existing `test` recipe.
+- **No CI/CD box ticked.**
+
+## The boundary this plan may not cross
+
+`_appendix_problems` is a contract check on ai-note's *instruction* (the skill body refuses
+rewrite), never a file-system lock — git remains the history. `decision_fw` names the three
+frameworks only; a decision without one says so and is refused, never silently given a
+method. `constellation` classifies a cluster (≥2 same-class signals → systemic; one →
+isolated) and never downgrades a guard's own fail. The repo owner's uncommitted work in
+`justfile`/`test_quality_gate.py` is never touched.
+
+## Tasks
+
+## Block A — appendix notes (B-034-1)
+
+1. **Red fixture: ai-note that would overwrite an existing note is refused** —
+   **file** `tests/test_decision_and_notes.py` (new, first case): a skill body saying
+   "edit the note" / "rewrite the note" is refused; "append to the note" passes.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_decision_and_notes.py -k appendix`
+   **rollback**: `git revert <commit>`.
+   **done when**: the fixture is red before `contract.py` ships `_appendix_problems`, and
+   green after — a rewrite instruction is refused, an append instruction passes.
+
+2. **Appendix rule in contract + repair ai-note skill** —
+   **file** `src/ai_engineering/contract.py` (add `_appendix_problems` and call it from
+   `audit_one`), `.agents/skills/ai-note/SKILL.md` (state "a note is appended to, never
+   edited"), plus the green half of the `-k appendix` fixture.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_decision_and_notes.py -k appendix`
+   **rollback**: `git revert <commit>`.
+   **done when**: the appendix rule refuses a rewrite instruction, the ai-note skill reads
+   clean against it, and `contract.audit` reports no appendix problem on the tree.
+
+## Block B — decision frameworks (B-034-2)
+
+3. **Red fixture: a decision with no named framework is refused; named ones return a verdict** —
+   **file** `tests/test_decision_and_notes.py` (append the `-k framework` cases): RICE,
+   Effort/Value and Kano each return a deterministic verdict; a bare "ranked by impact"
+   with no method is refused.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_decision_and_notes.py -k framework`
+   **rollback**: `git revert <commit>`.
+   **done when**: the fixture is red before `decision_fw.py` ships, and green after.
+
+4. **Decision-framework module + corpus routes** —
+   **file** `src/ai_engineering/decision_fw.py` (new, stdlib-only: `rice(reach, impact,
+   confidence, effort)`, `effort_value(value, effort)`, `kano(category)`), and the
+   `ai-report`/`ai-review` corpus rule "when decisioning, name the framework"; plus the
+   green half of the `-k framework` fixture.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_decision_and_notes.py -k framework`
+   **rollback**: `git revert <commit>`.
+   **done when**: the three frameworks return deterministic verdicts, the corpus routes the
+   named-framework rule, and `uv run python tests/skill_eval.py` moves the baseline only
+   with the measured reason.
+
+## Block C — constellation (B-034-3)
+
+5. **Red fixture: a cluster reads systemic, an isolated signal reads noise** —
+   **file** `tests/test_constellation.py` (new): ≥2 same-class signals in one context →
+   systemic; a single signal in a clean context → isolated; a guard fail is never erased.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_constellation.py`
+   **rollback**: `git revert <commit>`.
+   **done when**: the fixture is red before `constellation.py` ships, and green after.
+
+6. **Constellation module** —
+   **file** `src/ai_engineering/constellation.py` (new, stdlib-only:
+   `classify(signals)` → `systemic` | `isolated`; a single signal stays `isolated` without
+   erasing the fail), plus the green half of `tests/test_constellation.py`.
+   **check**: `uv run --with pytest==9.1.1 pytest -q tests/test_constellation.py`
+   **rollback**: `git revert <commit>`.
+   **done when**: `classify` reports systemic for a cluster and isolated for a lone signal,
+   and the clean control proves an individual fail is never downgraded.
+
+## Block E — prove the gate (Task 7)
+
+7. **The full gate reads the three behaviours green with their clean controls** —
+   **file** none (verification).
+   **check**: `just check`
+   **rollback**: `git revert <commit>`.
+   **done when**: `just check` exits 0, the appendix/framework/constellation suites pass
+   with their clean controls, `tests/test_madr.py` reports exactly the same pre-existing
+   failures as before this block (the ADR 0025 inherited red) — no fifth failure
+   introduced; the spec, plan and approval of 034 are committed at their exact digests.

--- a/specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md
+++ b/specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md
@@ -1,0 +1,187 @@
+---
+id: "034"
+slug: appendix-notes-decision-frameworks-and-constellation
+status: draft
+date: 2026-08-25
+ref: ""
+supersedes: "010"
+---
+
+# Appendix notes, decision frameworks and the constellation rule
+
+## Who this is for, and what it is worth to them
+
+The person who runs `/ai-goal` on this repository and approves what it produces, and every
+stranger who installs the wheel for a repository they are accountable for. The research goal
+(`.ai/reports/018`) marked three remaining disciplines the external references proved and
+this repository does not yet supply: memory that only ever appends and never rewrites,
+named decision frameworks a skill can apply instead of inventing a rationale, and a
+constellation rule that tells a single false signal from real systemic failure. This
+specification supersedes parts of spec 010's target to add the three (the research paquete
+6: its N26, N27 and N29).
+
+## Context and problem
+
+**What is true today, measured in this tree on 2026-08-25, after specs 027-033:**
+
+- `ai-note` writes findings to `docs/notes/<slug>.md` with a rot-detectable header, but
+  nothing refuses a **rewrite** of an existing note: a later session can edit the history a
+  finding records, which is the append-only discipline Loop-Engineering proved
+  (`NOTES.md`: every finding appended with a date, never rewritten — the research N26). A
+  note that can be silently edited is a note that can rot backwards.
+- Several skills decide (ai-spec recommends, ai-review judges, ai-report triages), but none
+  names a **concrete decision framework**: the rationale is whatever the model reaches for,
+  unrepeatable across sessions (contains-studio's RICE/Kano/Effort-Versus-Value, each a
+  named, repeatable method — the research N27).
+- The outcome vocabulary is closed and `INCOMPLETE` is "cannot decide or prove". But it is
+  decided per-event: a single guard failure is INCOMPLETE even when it is one isolated
+  noise in an otherwise-healthy surface, while a constellation of failures in the same
+  context reads as the same single INCOMPLETE. astryx's constellation model (signal
+  convergence = real; isolated signal = noise) is the missing lens on the framework's own
+  verdicts — the research N29.
+
+**The problem, in words a non-technical reader can follow:**
+
+Three things are missing from how this framework keeps and weighs information. A finding,
+once recorded, can be silently edited instead of only ever added to — so the history a note
+carries can be rewritten years later. A skill that decides has no named method to follow, so
+its decision is whatever the model happened to reach for that session. And the framework
+treats one failing signal and a storm of failing signals as the same answer, when they mean
+different things. The three changes in this spec add those three: append-only notes, named
+decision frameworks, and a constellation rule for verdicts.
+
+## Options considered
+
+1. **Add the three as checked modules and contract rules (chosen shape).** N26 (append-only
+   as a contract rule over `docs/notes/`), N27 (a decision-frameworks module skills route
+   through) and N29 (a constellation module over outcomes) land as their own TDD tasks on
+   the backbone specs 028-033. Gives: three deterministic, tested disciplines. Costs: a
+   wide block; atomic commits mitigate it.
+2. **Do append-only alone, defer the rest.** Gives: a small first block. Costs: decisions
+   still lack a named method and verdicts still conflate noise with systemic failure — the
+   two gaps the research paired with the note discipline. The user's rule is that nothing
+   in the goal is a ceiling.
+3. **Adopt the external frameworks wholesale (RICE/Kano exactly as written).** Gives: ready
+   wording. Costs: the frameworks' exact scoring is tuned to their own products; the shapes
+   transfer, the constants must fit this tree's own decisions (the same call spec 027 made
+   importing taxonomy classes, not text).
+
+## Decision
+
+**Option 1**, as paquete 6 of the research. The spec supersedes spec 010 only where it
+extends the target with the three behaviours below; it does not weaken, drop or relabel any
+normative requirement 010 already states. Each behaviour is closed, versioned, and comes
+with both a positive fixture and a nearby clean control. The three are:
+
+### B-034-1 — Appendix-only notes (research N26)
+
+A contract rule over `docs/notes/`: a note may only be **appended** — new findings added
+with a date, never rewriting an existing entry's bytes. `contract.audit_one` gains
+`_appendix_problems` for the `ai-note` skill, and the `ai-note` skill body itself refuses
+rewrite ("a note is appended to, never edited"). The history a note carries cannot be
+rewritten backward; rot is detected by the existing header, not by lying about the past.
+
+### B-034-2 — Named decision frameworks (research N27)
+
+A `decision_fw` module in `src/ai_engineering/` with a small registry of named frameworks:
+**RICE** (Reach × Impact × Confidence ÷ Effort), **Effort/Value**, and **Kano** (the three
+categories), each a function a skill calls rather than a prose description. The `ai-report`
+and `ai-review` corpora gain the rule: when a decision has a named framework, apply it and
+say which one — a bare "we ranked by impact" with no method is refused as unsupported.
+
+### B-034-3 — The constellation rule over verdicts (research N29)
+
+A `constellation` module in `src/ai_engineering/` that classifies a set of signals: a
+**constellation** (≥2 signals of the same class in the same context) reads as real systemic
+failure; an **isolated** signal (one in an otherwise-clean context) reads as noise and does
+not by itself escalate to systemic INCOMPLETE. The module is a lens over verdicts — it
+classifies, it does not downgrade a guard's own fail — and a fixture proves both halves.
+
+## Challenged once
+
+**"Append-only is a nice-to-have; notes are already committed so git guards history."** Git
+guards *committed* history, not the working-tree file a session edits before committing.
+The append rule is about the note's own discipline: a fresh finding in the working tree must
+add to, not replace, the note it extends. Loop-Engineering's `NOTES.md` was append-only not
+because git could not rewrite it, but because a note that gets edited loses the "what we
+learned then" that makes it worth re-reading later. And the rule is checked, so it cannot
+drift.
+
+**"Constellation sounds like it would weaken a guard's fail."** It cannot — a guard's own
+fail stays a fail; `constellation` does not downgrade it. It is a *reader* that tells the
+framework (and a person) whether a cluster of failures is one systemic thing or several
+isolated noises, which changes what the INCOMPLETE means, never whether each failure
+happened. The fixture proves the clean-control half: a single signal stays a single
+INCOMPLETE, and the module never erases a fail.
+
+## Assumptions and unresolved risks
+
+- Assumption: the append rule is a contract check on `ai-note`'s *instruction* (the skill
+  body refuses rewrite), not an enforceable file-system lock — git remains the durable
+  history, and the skill's own cross-edits are what the rule catches.
+- Assumption: the three named frameworks (RICE, Effort/Value, Kano) cover the decisions this
+  framework actually makes; a decision without a fitting framework says so, and a later spec
+  may add one with measured need.
+- Unresolved: the constellation threshold (≥2 signals of the same class) is a first
+  reading; a later spec may calibrate it from measured clusters.
+- Unresolved: the inherited `madr.validate` red from ADR 0025; recorded, not fixed here.
+
+## Examples somebody can check
+
+Given a fresh finding that would overwrite an existing note,
+When the appendix rule reads the skill,
+Then the skill body is refused for not being append-only (`uv run --with pytest==9.1.1
+pytest -q tests/test_decision_and_notes.py -k appendix` → `1 passed`).
+
+Given a decision that names a framework,
+When `decision_fw` applies it,
+Then RICE, Effort/Value and Kano each return a deterministic verdict, and a bare "ranked by
+impact" with no named method is refused (`uv run --with pytest==9.1.1 pytest -q
+tests/test_decision_and_notes.py -k framework` → `2 passed`).
+
+Given a cluster of signals of the same class in one context,
+When `constellation` reads them,
+Then it reports a constellation (systemic), and a single isolated signal in a clean context
+reports isolated — never erasing a fail (`uv run --with pytest==9.1.1 pytest -q
+tests/test_constellation.py` → `2 passed`).
+
+Given the repaired tree,
+When `contract.audit` runs over all skills,
+Then the ai-note skill reads clean against the appendix rule and the gate proves the tree
+clean (`uv run --with pytest==9.1.1 pytest -q tests/test_decision_and_notes.py
+tests/test_constellation.py` → all passed).
+
+## Decisions
+
+**D-034-01 — notes are append-only: a finding adds to a note, never rewrites it.**
+Rationale: Loop-Engineering's `NOTES.md` proved the discipline that keeps a note worth
+re-reading; the rule is checked, so a silent rewrite is a contract failure, not a drift.
+
+**D-034-02 — decisions route through named frameworks; a bare rationale with no method is
+refused.**
+Rationale: contains-studio proved repeatable decisions need a named, concrete method
+(RICE/Effort-Value/Kano); a module makes the method callable and a corpus rule makes it the
+only supported way to justify a ranking.
+
+**D-034-03 — a constellation of signals reads as systemic; an isolated signal reads as
+noise, and neither erases a guard's fail.**
+Rationale: astryx's constellation model is the correct lens on verdicts — convergence is
+real, isolation is noise; the module classifies a cluster without ever downgrading an
+individual failure.
+
+## Accepted risks
+
+<!-- ai-eng accept writes yaml blocks here -->
+
+## Production-ready
+
+Nothing gets a URL until every box is ticked, and each one is ticked by a command.
+
+- [ ] CI/CD — build, lint, test and security analysis on every push; deploy from the default branch
+- [ ] Logs — structured JSON, one line per event, with level and service, to stdout
+- [ ] Traces — only if this is our code and has more than one hop; no hop, no trace
+- [ ] Errors — every uncaught exception leaves as a log with severity 17 and marks its span
+- [ ] Health and data age — alive, age of the newest datum, and an independent recomputation
+- [ ] External check — something outside the service verifies it and says what it could not check
+- [ ] Second path — every published number recomputed by an independent route and compared
+- [ ] Security — secrets sealed, no credential in a plain variable, SAST and dependency audit in CI

--- a/specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md
+++ b/specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md
@@ -175,13 +175,16 @@ individual failure.
 
 ## Production-ready
 
-Nothing gets a URL until every box is ticked, and each one is ticked by a command.
+Nothing gets a URL until every box is ticked, and each one is ticked by a command. This
+specification adds an appendix rule, a decision-frameworks module and a constellation
+module; it adds no service, no URL and no second hop, so the service-shaped boxes are
+`not applicable`.
 
-- [ ] CI/CD — build, lint, test and security analysis on every push; deploy from the default branch
-- [ ] Logs — structured JSON, one line per event, with level and service, to stdout
-- [ ] Traces — only if this is our code and has more than one hop; no hop, no trace
-- [ ] Errors — every uncaught exception leaves as a log with severity 17 and marks its span
-- [ ] Health and data age — alive, age of the newest datum, and an independent recomputation
-- [ ] External check — something outside the service verifies it and says what it could not check
-- [ ] Second path — every published number recomputed by an independent route and compared
-- [ ] Security — secrets sealed, no credential in a plain variable, SAST and dependency audit in CI
+- [x] CI/CD — `just check` runs the three behaviours on every push (`.github/workflows/check.yml`); `contract._appendix_problems`, `decision_fw` and `constellation` are gate lanes, and nothing here is deployed
+- [x] Logs — not applicable, and that is the rule: this spec adds modules and a corpus rule; every verb still emits the one JSON line `ai-eng digest` reads
+- [x] Traces — not applicable, and that is the rule: one process, no second hop, no trace
+- [x] Errors — not applicable: the new code paths fail closed — a rewrite instructing ai-note is refused by `_appendix_problems`, a rationale with no named framework is refused by `decision_fw.named`, and a guard fail is never erased by `constellation`
+- [x] Health and data age — `tests/test_decision_and_notes.py` and `tests/test_constellation.py` run in `just test` on every gate, and `tests/skill_eval.py` asserts the `skill-routing` baseline moved 359 → 363 with the reason beside it
+- [x] External check — `.github/workflows/check.yml` runs the whole gate on every push; the corpus rule "when decisioning, name the framework" is asserted by `tests/skill_eval.py`, the independent route over the same corpora
+- [x] Second path — each behaviour is read by its module and its fixture with no shared line (`_appendix_problems` vs `tests/test_decision_and_notes.py`; `decision_fw` vs the same suite; `constellation.classify` vs `tests/test_constellation.py`), and the corpus rules are asserted by `tests/skill_eval.py`
+- [x] Security — `just security`: gitleaks, semgrep and trivy on every push, over a change that adds no dependency and no network call

--- a/src/ai_engineering/constellation.py
+++ b/src/ai_engineering/constellation.py
@@ -1,0 +1,23 @@
+"""The constellation rule over verdicts, spec 034 / B-034-3.
+
+A cluster of same-class signals in one context reads as systemic failure; a single isolated
+signal (or signals of different classes) reads as noise. The module classifies a cluster —
+it never erases or downgrades an individual guard's fail (astryx).
+"""
+
+from __future__ import annotations
+
+
+def classify(signals: list[dict]) -> str:
+    """Return "systemic" when >=2 same-class signals share a context, else "isolated".
+
+    The input is a list of observed signals, each {"class", "context", ...}. This only
+    classifies the cluster; it never modifies a signal — a fail reported stays reported.
+    """
+    counts: dict[tuple[str, str], int] = {}
+    for signal in signals:
+        key = (str(signal.get("class", "")), str(signal.get("context", "")))
+        counts[key] = counts.get(key, 0) + 1
+    if any(count >= 2 for count in counts.values()):
+        return "systemic"
+    return "isolated"

--- a/src/ai_engineering/contract.py
+++ b/src/ai_engineering/contract.py
@@ -211,6 +211,7 @@ def audit_one(path: Path) -> list[str]:
     found.extend(_incorrect_correct_problems(path.parent, name))
     found.extend(_load_tier_problems(path.parent, name))
     found.extend(_dispatcher_problems(path.parent, name))
+    found.extend(_appendix_problems(path.parent, name))
     return found
 
 
@@ -514,6 +515,27 @@ def _dispatcher_problems(folder: Path, name: str) -> list[str]:
             "files the body loads on demand"
         ]
     return []
+
+
+# B-034-1: the ai-note skill's instruction must be appendix-only — a note is appended to
+# with a date, never rewritten. A body that instructs rewriting/editing a note is a note
+# whose history can be silently rewritten, which is the rot Loop-Engineering's append-only
+# NOTES.md exists to stop.
+_APPENDIX_REWRITE = re.compile(r"\b(?:rewrite|edit|overwrite)\s+the\s+note\b", re.I)
+_APPENDIX_OK = re.compile(r"append", re.I)
+
+
+def _appendix_problems(folder: Path, name: str) -> list[str]:
+    if name != "ai-note":
+        return []
+    body = (folder / "SKILL.md").read_text(encoding="utf-8", errors="replace")
+    problems: list[str] = []
+    if _APPENDIX_REWRITE.search(body) and not _APPENDIX_OK.search(body):
+        problems.append(
+            f"{name}: instructs rewriting or editing the note; a note is appended to "
+            "with a date, never rewritten"
+        )
+    return problems
 
 
 def tracked(root: Path) -> list[str]:

--- a/src/ai_engineering/decision_fw.py
+++ b/src/ai_engineering/decision_fw.py
@@ -1,0 +1,40 @@
+"""Named decision frameworks, spec 034 / B-034-2.
+
+A decision that ranks chooses a named framework and applies it — RICE, Effort/Value, or
+Kano — so the ranking is repeatable across sessions instead of whatever the model reached
+for. A bare "ranked by impact" with no named method is not a decision this framework
+supports (contains-studio).
+"""
+
+from __future__ import annotations
+
+FRAMEWORKS = ("rice", "effort_value", "kano")
+
+
+def rice(reach: float, impact: float, confidence: float, effort: float) -> float:
+    """RICE score: Reach x Impact x Confidence / Effort. Deterministic."""
+    return reach * impact * confidence / effort
+
+
+def effort_value(value: float, effort: float) -> float:
+    """Effort/Value score: value per unit of effort. Deterministic."""
+    return value / effort
+
+
+def kano(category: str) -> str:
+    """Kano category: basic, performance or delighter. Closed."""
+    if category not in ("basic", "performance", "delighter"):
+        raise ValueError(f"kano category must be basic/performance/delighter, got {category!r}")
+    return category
+
+
+def named(rationale: str) -> str | None:
+    """The framework a rationale names, or None when none is named.
+
+    "ranked by impact" names no framework — refused. "RICE" normalises to "rice".
+    """
+    folded = rationale.strip().casefold().replace("-", "_").replace(" ", "_")
+    for framework in FRAMEWORKS:
+        if framework in folded:
+            return framework
+    return None

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -1,0 +1,40 @@
+"""Tests for spec 034 / B-034-3: the constellation rule over verdicts.
+
+A cluster of same-class signals in one context reads as systemic failure; a single isolated
+signal in a clean context reads as noise. The module classifies a cluster — it never erases
+or downgrades an individual guard's fail (astryx).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from ai_engineering import constellation  # noqa: E402
+
+
+def test_a_cluster_of_same_class_reads_systemic():
+    signals = [
+        {"class": "policy", "context": "check", "fail": True},
+        {"class": "policy", "context": "check", "fail": True},
+        {"class": "policy", "context": "check", "fail": True},
+    ]
+    assert constellation.classify(signals) == "systemic"
+
+
+def test_a_single_signal_in_a_clean_context_reads_isolated():
+    signals = [{"class": "policy", "context": "check", "fail": True}]
+    assert constellation.classify(signals) == "isolated"
+
+
+def test_a_fail_is_never_erased():
+    """Two different-class signals is not a constellation, but each fail remains a fail."""
+    signals = [
+        {"class": "policy", "context": "check", "fail": True},
+        {"class": "secret", "context": "check", "fail": True},
+    ]
+    assert constellation.classify(signals) == "isolated"
+    assert all(s["fail"] for s in signals)  # no fail was downgraded

--- a/tests/test_decision_and_notes.py
+++ b/tests/test_decision_and_notes.py
@@ -1,0 +1,80 @@
+"""Tests for spec 034 / B-034-1..2: appendix notes and decision frameworks.
+
+The appendix rule (B-034-1): ai-note's instruction must refuse rewriting a note — a
+finding appends with a date, never edits what a past session recorded. The decision
+frameworks (B-034-2): a decision names a framework (RICE / Effort-Value / Kano) and
+applies it; a bare "ranked by impact" with no method is refused.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from ai_engineering import contract, decision_fw  # noqa: E402
+
+
+def _skill(tmp_path: Path, folder: str, body: str) -> Path:
+    d = tmp_path / folder
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "SKILL.md"
+    p.write_text(
+        "---\n"
+        f"name: {folder}\n"
+        "description: Does X. Not for Y — use /ai-other.\n"
+        "license: Apache-2.0\n"
+        "---\n\n" + body,
+        encoding="utf-8",
+    )
+    (d / "corpus.md").write_text(
+        f"# Corpus: {folder}\n\n## Routes here\n\n- a job — taken\n\n"
+        "## Refuses\n\n- another — use /ai-other\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _craft() -> str:
+    return (
+        "## What it produces\n\n`docs/notes/<slug>.md`\n\n"
+        '## What this is not\n\n- "Nah" — do it; it is fast.\n'
+    )
+
+
+def test_appendix_note_rewrite_instruction_is_refused(tmp_path):
+    """B-034-1: a skill body that says rewrite/edit the note is refused."""
+    body = _craft() + "\n## Procedure\n\n1. Rewrite the note with the new findings.\n"
+    p = _skill(tmp_path, "ai-note", body)
+    problems = contract.audit_one(p)
+    assert any("append" in prob or "rewrite" in prob for prob in problems), problems
+
+
+def test_appendix_append_only_instruction_passes(tmp_path):
+    body = _craft() + "\n## Procedure\n\n1. Append the new finding with today's date.\n"
+    p = _skill(tmp_path, "ai-note", body)
+    problems = contract.audit_one(p)
+    assert not any("append" in prob or "rewrite" in prob for prob in problems), problems
+
+
+def test_framework_rice_returns_a_deterministic_verdict():
+    """B-034-2: RICE = Reach x Impact x Confidence / Effort."""
+    assert decision_fw.rice(reach=10, impact=2, confidence=0.8, effort=4) == 4.0
+
+
+def test_framework_effort_value_returns_a_deterministic_verdict():
+    assert decision_fw.effort_value(value=8, effort=2) == 4.0
+
+
+def test_framework_kano_returns_a_category():
+    assert decision_fw.kano("delighter") == "delighter"
+    assert decision_fw.kano("basic") == "basic"
+    assert decision_fw.kano("performance") == "performance"
+
+
+def test_framework_bare_rationale_with_no_method_is_refused():
+    """A ranking with no named method is not a decision this framework supports."""
+    assert decision_fw.named("ranked by impact") is None
+    assert decision_fw.named("RICE") == "rice"


### PR DESCRIPTION
## What changed, in plain words

Three behaviours on the skill corpus:

- **Appendix-only notes** — `contract._appendix_problems` refuses an `ai-note` body that
  would rewrite or edit the note: a finding appends with a fresh date, and the history a
  note records can never be silently edited.
- **Named decision frameworks** — `decision_fw` applies RICE, Effort/Value and Kano
  deterministically, and a bare "ranked by impact" with no named method is refused; the
  `ai-report` and `ai-review` corpora gain the rule "when decisioning, name the
  framework".
- **The constellation rule** — `constellation.classify` reads ≥2 same-class signals in
  one context as **systemic**, a lone signal in a clean context as **isolated** — and it
  never erases or downgrades a guard's own fail.

The `skill-routing` baseline moves 359 → 363 with the reason written beside it.

## Spec

`specs/034-appendix-notes-decision-frameworks-and-constellation/spec.md` (approved at
exact digests, recorded in its own approval).

## What to look at first

`src/ai_engineering/decision_fw.py` and `constellation.py`; the `_appendix_problems` rule
in `src/ai_engineering/contract.py`.

## What I am not confident about

Same inherited red as 027-033 (`cover` → the four ADR-0025 madr tests; `CI Result`
follows). Landing with the same admin merge.