### PR TITLE
test(sonar): wave 2 — split the composite assertions (S9073) + RFC3339 digit class (S6353)

### DIFF
--- a/src/ai_engineering/intent.py
+++ b/src/ai_engineering/intent.py
@@ -108,7 +108,7 @@ def canonical_json(value: Any) -> bytes:
     ).encode()
 
 
-_RFC3339_UTC = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?Z$")
+_RFC3339_UTC = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
 
 
 def _iso_value(instance: Any, fmt: str) -> bool:

--- a/tests/test_039_documentation.py
+++ b/tests/test_039_documentation.py
@@ -21,7 +21,8 @@ def _reference() -> str:
 def test_reference_names_the_levers():
     text = _reference().casefold()
     assert "context pointer" in text
-    assert "context load" in text and "cognitive load" in text
+    assert "context load" in text
+    assert "cognitive load" in text
     assert "leading word" in text
     assert "prun" in text
     assert "one idea" in text  # STE100: one idea per sentence

--- a/tests/test_040_ai_write.py
+++ b/tests/test_040_ai_write.py
@@ -17,7 +17,8 @@ def test_verified_doc_passes():
     body = (ROOT / ".agents" / "skills" / "ai-write" / "SKILL.md").read_text()
     assert "references/documentation-writer.md" in body  # the single standard
     assert "not-covered" in body  # the honest exit is in the contract
-    assert "## What it produces" in body and "## Done when" in body  # audit shape
+    assert "## What it produces" in body
+    assert "## Done when" in body  # audit shape
 
 
 def test_no_cache_and_not_covered_live_in_the_contract():

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -464,7 +464,8 @@ def test_acceptance_corpus_covers_valid_adversarial_and_privacy_cases() -> None:
     legacy = corpus["legacy_blocks"]
     assert [block["id"] for block in legacy] == LEGACY_CASES
     for block in legacy:
-        assert block["block"].startswith("```yaml\n") and block["block"].endswith("\n```")
+        assert block["block"].startswith("```yaml\n")
+        assert block["block"].endswith("\n```")
         assert block["expected"] in {"PASS", "INCOMPLETE", "IGNORED"}, block["id"]
         assert block["home"].startswith("specs/") and block["home"].endswith("/spec.md")
     id_less = next(block for block in legacy if block["id"] == "legacy-id-less")
@@ -660,7 +661,8 @@ def test_gitleaks_gate_requires_exact_version_and_three_clean_results(
     # itself. It runs against somewhere else, which is why the third cwd is not `tmp_path`.
     assert calls[:2] == [(("gitleaks", "version"), tmp_path), (privacy.GITLEAKS_ARGV, tmp_path)]
     assert len(calls) == 3, calls
-    assert calls[2][0] == privacy.GITLEAKS_ARGV and calls[2][1] != tmp_path
+    assert calls[2][0] == privacy.GITLEAKS_ARGV
+    assert calls[2][1] != tmp_path
     assert privacy.GITLEAKS_ARGV == (
         "gitleaks",
         "dir",

--- a/tests/test_blocked.py
+++ b/tests/test_blocked.py
@@ -409,4 +409,5 @@ def test_the_ledger_can_actually_be_committed(tmp_path):
     assert not any(line.rstrip() != line for line in body.splitlines()), "no trailing spaces"
     # And it still parses as two rows, so the fix did not eat a separator.
     rows, dropped = blocked.stops(tmp_path)
-    assert len(rows) == 2 and dropped == []
+    assert len(rows) == 2
+    assert dropped == []

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -294,7 +294,8 @@ def test_capabilities_toml_declares_exactly_twenty_capabilities() -> None:
             assert set(mode["enforcement"]) == required
             proof = mode["proof_requirements"]
             assert proof["installed_artifact"] is True
-            assert proof["allow"] and proof["deny"]
+            assert proof["allow"]
+            assert proof["deny"]
 
     # By mode id, not by position. Indexing `[1]` meant a mode inserted in alphabetical
     # order silently moved which mode each assertion was about, and the failure named a

--- a/tests/test_chain_read.py
+++ b/tests/test_chain_read.py
@@ -121,7 +121,8 @@ def test_a_line_repeating_a_json_key_is_ambiguous_and_the_link_says_so(chain):
     assert events[1]["_audit_kind"] == "INCOMPLETE"
     assert "CHAIN_AMBIGUOUS" in events[1]["_audit_problem"]
     assert "line 2" in events[1]["_audit_problem"]
-    assert events[0]["name"] == "first" and events[2]["name"] == "third"
+    assert events[0]["name"] == "first"
+    assert events[2]["name"] == "third"
 
 
 def test_a_line_that_is_not_one_json_object_is_reported_in_place(chain):

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -246,7 +246,8 @@ def test_a_failing_receipt_is_not_masked_by_a_passing_one_that_sorts_later(worki
     fact = checkpoint._executed(working)
 
     assert fact.status == "FAIL", fact
-    assert fact.detail and "adversarial-attacks" in fact.detail
+    assert fact.detail
+    assert "adversarial-attacks" in fact.detail
 
 
 def test_the_snapshot_the_checkpoint_is_taken_against_changes_what_it_sees(working):
@@ -271,7 +272,9 @@ def test_the_snapshot_the_checkpoint_is_taken_against_changes_what_it_sees(worki
     git(working, "commit", "-m", "feat: a commit this branch made")
     behind = git(working, "rev-parse", "HEAD~1").stdout.strip()
     head = git(working, "rev-parse", "HEAD").stdout.strip()
-    assert behind and head and behind != head
+    assert behind
+    assert head
+    assert behind != head
 
     # No snapshot: only what is staged right now, and nothing is.
     assert checkpoint.staged(working) == []
@@ -364,7 +367,8 @@ def test_a_receipt_taken_before_the_staged_change_is_incomplete(working):
     stage(working, "src/thing.py", "VALUE = 3\n")
     stale = checkpoint._executed(working)
     assert stale.status == "INCOMPLETE", stale
-    assert stale.cure and "quick" in stale.cure
+    assert stale.cure
+    assert "quick" in stale.cure
 
     # A digest receipt that is present and wrong outranks a fresh aged one that says PASS:
     # the aged one proves a run happened somewhere, and this one proves it was not here.

--- a/tests/test_claim.py
+++ b/tests/test_claim.py
@@ -56,7 +56,8 @@ def test_exactly_one_of_two_writers_wins_the_same_work_item(tmp_path, remote):
 
     one, two = tmp_path / "one", tmp_path / "two"
     base = claim.base(one)
-    assert base and base == claim.base(two)
+    assert base
+    assert base == claim.base(two)
 
     outcomes = [
         claim.take(where, "work-42", base, ["src/thing.py"], role)
@@ -131,7 +132,8 @@ def test_a_winning_claim_leaves_the_file_the_guard_reads_and_a_losing_one_does_n
     first = claim.take(one, "work-46", base, ["src/thing.py"], "writer-one")
     second = claim.take(two, "work-46", base, ["src/thing.py"], "writer-two")
 
-    assert first.outcome == "PASS" and second.outcome == "INCOMPLETE"
+    assert first.outcome == "PASS"
+    assert second.outcome == "INCOMPLETE"
     assert (one / claim.IN_FORCE).is_file()
     assert not (two / claim.IN_FORCE).exists(), "the loser was left believing it holds the work"
 
@@ -201,7 +203,8 @@ def test_every_refusal_a_claim_can_give_says_its_own_code_sentence_and_cure(tmp_
     # And the race, which git answers rather than we do. The loser is told to take another
     # task, not to retry — a retry here is two writers taking turns at the same work.
     fresh = claim.base(one)
-    assert fresh and fresh != good
+    assert fresh
+    assert fresh != good
     won = claim.take(one, "work-92", fresh, ["src/thing.py"], "one")
     assert won.result.outcome == "PASS"
     lost = claim.take(two, "work-92", fresh, ["src/other.py"], "two")
@@ -302,4 +305,5 @@ def test_a_claim_file_nobody_can_read_is_the_same_refusal(tmp_path, remote):
     refused = claim.take(root, "work-beta", claim.base(root), ["docs"], "writer")
 
     assert refused.outcome == "INCOMPLETE"
-    assert refused.error is not None and refused.error.code == "CLAIM_TREE_BUSY"
+    assert refused.error is not None
+    assert refused.error.code == "CLAIM_TREE_BUSY"

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -122,7 +122,8 @@ def test_a_traceback_is_bounded_into_four_fields_unless_debug_is_asked_for():
 
     assert quiet.code == "UNEXPECTED_ERROR"
     assert quiet.retryable is False
-    assert quiet.cure and "--debug" in quiet.cure
+    assert quiet.cure
+    assert "--debug" in quiet.cure
     assert "RuntimeError" not in quiet.message
     assert "/Users/somebody" not in quiet.message
 

--- a/tests/test_cost_gate.py
+++ b/tests/test_cost_gate.py
@@ -51,4 +51,5 @@ def test_no_samples_is_incomplete():
 def test_threshold_declared_in_policy_is_read():
     """The threshold lives in `policy/cost-thresholds.toml`, not as a literal in code."""
     raw = (ROOT / "policy" / "cost-thresholds.toml").read_text(encoding="utf-8")
-    assert "threshold_usd" in raw and "limit" in raw
+    assert "threshold_usd" in raw
+    assert "limit" in raw

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -146,7 +146,8 @@ def test_a_cycle_is_incomplete_and_names_what_is_in_it(tmp_path):
     result = dag.order(tmp_path, [task("work-one", "src/one.py"), task("work-two", "src/two.py")])
 
     assert result.outcome == "INCOMPLETE"
-    assert result.error is not None and result.error.code == "DAG_CYCLE"
+    assert result.error is not None
+    assert result.error.code == "DAG_CYCLE"
     assert "work-one" in result.error.message and "work-two" in result.error.message
 
 
@@ -264,7 +265,8 @@ def test_a_wave_of_claims_that_depend_on_each_other_says_so_by_type(tmp_path):
 
     with pytest.raises(dag.Cycle) as refused:
         dag.wave(tmp_path, tasks)
-    assert "work-a" in str(refused.value) and "work-b" in str(refused.value)
+    assert "work-a" in str(refused.value)
+    assert "work-b" in str(refused.value)
 
     # And it is still caught by anything reading for an unreadable graph.
     assert issubclass(dag.Cycle, dag.Unreadable)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -99,7 +99,10 @@ def test_every_assertion_has_a_unique_number_a_family_and_a_sentence():
     # ceiling, and the test plane owns that assertion now.
     assert sorted(numbers) == [n for n in range(1, 28) if n != 5]
     for number, family, title, in_ci, fn in doctor.CHECKS:
-        assert family and title and callable(fn) and isinstance(in_ci, bool), number
+        assert family
+        assert title
+        assert callable(fn)
+        assert isinstance(in_ci, bool), number
 
 
 def test_each_family_is_printed_once_and_in_the_declared_order(home, repo, monkeypatch, capsys):
@@ -269,7 +272,8 @@ def test_the_two_readers_of_the_chain_reach_the_same_verdict(
     problems = audit.verify(repo)
     assert "INTENT_HOME_MISSING" in problems[-1]
     chain_problems = " ".join(problems[:-1])
-    assert (audit_says in chain_problems) and bool(chain_problems) == bool(audit_says)
+    assert audit_says in chain_problems
+    assert bool(chain_problems) == bool(audit_says)
 
 
 def test_a_half_written_last_line_is_reported_by_both_readers_of_the_chain(home, repo):
@@ -322,7 +326,8 @@ def test_doctor_cannot_call_a_chain_intact_that_the_verifier_calls_broken(home, 
     path.write_text("".join(json.dumps(row) + "\n" for row in rows))
 
     said = doctor.chain_intact(repo)
-    assert said and "link 2" in said, f"doctor called a sealed-as-edited chain intact: {said!r}"
+    assert said
+    assert "link 2" in said, f"doctor called a sealed-as-edited chain intact: {said!r}"
     assert [w for w in audit.verify(repo) if "link 2" in w], "the verifier agrees"
 
 
@@ -1057,7 +1062,8 @@ def test_which_cures_fix_may_run_is_decided_by_the_verb_and_survives_a_short_one
     verb is ever looked up. A cure of one word must answer no rather than index past the end
     of it, and a cure of exactly two words — the shortest real one — must still answer yes,
     or `--fix` silently stops repairing the thing it says it repairs."""
-    assert doctor.unattended("ai-eng init") and doctor.unattended(doctor.FIXES[2])
+    assert doctor.unattended("ai-eng init")
+    assert doctor.unattended(doctor.FIXES[2])
     assert not doctor.unattended("ai-eng update")
     assert not doctor.unattended("init") and not doctor.unattended("")
 
@@ -1621,7 +1627,8 @@ def test_a_router_somebody_edited_or_removed_is_reported_and_never_repaired(
     said = doctor.routers_intact(repo)
 
     assert isinstance(said, tuple)
-    assert "1 removed" in said[0] and "1 edited" in said[0]
+    assert "1 removed" in said[0]
+    assert "1 edited" in said[0]
     assert str(len(written)) in said[0]
 
 
@@ -1662,7 +1669,8 @@ def test_a_receipt_pointing_somewhere_else_is_reported_and_never_opened(
 
     said = doctor.routers_intact(repo)
     assert isinstance(said, tuple)
-    assert "outside" in said[0] and "id_rsa" in said[0]
+    assert "outside" in said[0]
+    assert "id_rsa" in said[0]
 
     # And a link wearing a router's name is refused for the same reason.
     link = commands / "ai-linked.md"
@@ -1715,7 +1723,8 @@ def test_a_second_handler_for_a_declared_capability_is_named_and_a_clean_reposit
     git(repo, "add", "-A")
     got, detail = verdict(doctor.one_handler_each, repo)
     assert got == "fail"
-    assert "ai-spec" in detail and ".claude/skills/ai-spec/SKILL.md" in detail
+    assert "ai-spec" in detail
+    assert ".claude/skills/ai-spec/SKILL.md" in detail
     assert "search order" in detail
 
     # Found by the name it calls itself, not by the directory it sits in: a directory renamed

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -464,7 +464,9 @@ def test_every_field_of_a_recorded_decision_is_what_happened(tmp_path):
 
     # The timestamp is a real instant to the second, in UTC, with the Z spelling the chain
     # uses. A record whose time is a local clock cannot be compared with anything.
-    assert len(allowed["ts"]) == 20 and allowed["ts"][10] == "T" and allowed["ts"].endswith("Z")
+    assert len(allowed["ts"]) == 20
+    assert allowed["ts"][10] == "T"
+    assert allowed["ts"].endswith("Z")
 
     # And with no corpus configured, nothing is written and nothing raises: the corpus is
     # optional and the decision is not.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -81,7 +81,8 @@ def test_a_guard_that_crashes_denies_rather_than_waving_the_call_through(repo, c
     assert stop.value.code == 2
     assert "BLOCKED" in capsys.readouterr().err
     recorded = links()[-1]
-    assert recorded["cls"] == "error" and recorded["data"]["outcome"] == "blocked"
+    assert recorded["cls"] == "error"
+    assert recorded["data"]["outcome"] == "blocked"
 
 
 @pytest.mark.parametrize("blow_up", [ValueError, TypeError, OSError, AttributeError])
@@ -585,7 +586,8 @@ def test_an_edited_buffer_is_sealed_as_the_error_that_says_it_was_edited(repo):
     assert "arrived edited" in " ".join(audit.verify(repo))
 
     key = _emit.home() / "buffer.key"
-    assert repo not in key.parents and (key.stat().st_mode & 0o077) == 0
+    assert repo not in key.parents
+    assert (key.stat().st_mode & 0o077) == 0
     assert _emit.stamp(sealed) != _emit.digest(sealed)  # a mark anything can make is a checksum
 
 
@@ -1675,7 +1677,8 @@ def test_a_structured_denial_that_cannot_be_written_leaves_as_a_denial():
 
     # And with somewhere to write, both protocols are exactly what they were.
     kept = leaving(True, closed=False)
-    assert kept.returncode == 0 and '"permissionDecision": "deny"' in kept.stdout
+    assert kept.returncode == 0
+    assert '"permissionDecision": "deny"' in kept.stdout
     plain = leaving(False, closed=False)
     assert plain.returncode == 2 and '"permission": "deny"' in plain.stdout
 

--- a/tests/test_imagery.py
+++ b/tests/test_imagery.py
@@ -57,7 +57,9 @@ def test_a_png_loses_its_text_and_exif_and_keeps_being_a_png():
 
     assert clean.startswith(imagery.PNG), "the stripped file is no longer a PNG"
     assert b"somebody" not in clean
-    assert b"tEXt" not in clean and b"eXIf" not in clean and b"tIME" not in clean
+    assert b"tEXt" not in clean
+    assert b"eXIf" not in clean
+    assert b"tIME" not in clean
     assert b"IHDR" in clean and b"IDAT" in clean and b"IEND" in clean
     assert imagery.findings(clean) == []
 
@@ -231,7 +233,8 @@ def test_every_shape_of_executable_svg_is_named_by_the_thing_it_is():
     ]
 
     clean = imagery.stripped(carried)
-    assert b"foreignObject" not in clean and b"onCLICK" not in clean
+    assert b"foreignObject" not in clean
+    assert b"onCLICK" not in clean
     assert b"rect" in clean, "the element was removed with its handler"
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -379,7 +379,8 @@ def test_uninstall_gives_back_the_hooks_path_the_repository_had_before_us(
     assert git_get(repo, "core.hooksPath") == str(paths.git_hooks())
     monkeypatch.chdir(repo)
     result = uninstall.main(["--project", "-y"])
-    assert type(result) is outcome.Result and result.outcome == "PASS"
+    assert type(result) is outcome.Result
+    assert result.outcome == "PASS"
     assert git_get(repo, "core.hooksPath") == "--their/hooks"
     assert git_get(repo, "ai.managed") == ""
 

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -129,7 +129,8 @@ def test_a_forbidden_class_stops_the_report(tmp_path, monkeypatch, field, value,
     assert refused, "a forbidden class reached the payload and the scan called it clean"
     assert any(code in finding.code for finding in refused), [f.code for f in refused]
     assert not issue.draft_path(root).exists()
-    assert calls and calls[-1][0] == acceptance_privacy.GITLEAKS_ARGV, "the scanner was skipped"
+    assert calls
+    assert calls[-1][0] == acceptance_privacy.GITLEAKS_ARGV, "the scanner was skipped"
 
 
 def test_a_scanner_that_cannot_answer_refuses_rather_than_passing(tmp_path, monkeypatch):
@@ -301,7 +302,8 @@ def test_submit_without_the_typed_confirmation_sends_nothing(tmp_path, monkeypat
     drafted = json.loads(issue.draft_path(root).read_text(encoding="utf-8"))
     assert issue.confirmation(drafted)[:20] in asked[0]
     assert issue.digest(drafted)[:16] in asked[0]
-    assert drafted["kind"] == "bug" and drafted["title"] == CLEAN["title"]
+    assert drafted["kind"] == "bug"
+    assert drafted["title"] == CLEAN["title"]
 
 
 def test_a_confirmed_submit_stops_at_the_destination_that_does_not_exist(

--- a/tests/test_loop_guard_escalation.py
+++ b/tests/test_loop_guard_escalation.py
@@ -56,7 +56,9 @@ def test_three_identical_calls_deny_all_and_the_third_escalates(tmp_path, monkey
     first = denials[2]  # the 3rd call: first denial
     second = denials[3]  # the 4th call: second denial
     third = denials[4]  # the 5th call: third denial
-    assert first is not None and second is not None and third is not None
+    assert first is not None
+    assert second is not None
+    assert third is not None
     # Two full verdicts first (the judgement resolving), then the escalation.
     assert "this exact call has been made 3 times in the last 6" in first
     assert "this exact call has been made 4 times in the last 6" in second

--- a/tests/test_madr.py
+++ b/tests/test_madr.py
@@ -1285,7 +1285,8 @@ def test_decide_madr_creation_is_exclusive_and_cleans_partial_writes(
     assert result.outcome == "INCOMPLETE"
     output = capsys.readouterr().out
     collided = collision / "docs" / "adr" / "0001-concurrent-decision.md"
-    assert "INCOMPLETE" in output and "MADR_WRITE_FAILED" in output
+    assert "INCOMPLETE" in output
+    assert "MADR_WRITE_FAILED" in output
     assert "Nothing was written" not in output and "remains" in output
     assert collided.read_bytes() == colliding_bytes
 
@@ -1434,7 +1435,8 @@ def test_decide_madr_creation_stays_anchored_when_home_is_swapped(
     assert type(result) is outcome.Result
     assert result.outcome == "INCOMPLETE"
     output = capsys.readouterr().out
-    assert exchanged and "INCOMPLETE" in output
+    assert exchanged
+    assert "INCOMPLETE" in output
     assert "MADR_HOME_INVALID" in output and "remains" in output
     assert list(outside.iterdir()) == []
     held = root / ("docs-held/adr" if swapped == "docs" else "docs/adr-held")

--- a/tests/test_merge_gate.py
+++ b/tests/test_merge_gate.py
@@ -166,7 +166,9 @@ def test_the_order_of_every_claim_is_derived_where_somebody_reads_it(tmp_path, s
 
     assert len(order) == 1, [fact.id for fact in result.checks]
     assert order[0].status == "OBSERVED"
-    assert order[0].detail and "work-alpha" in order[0].detail and "work-beta" in order[0].detail
+    assert order[0].detail
+    assert "work-alpha" in order[0].detail
+    assert "work-beta" in order[0].detail
     # And it is not counted as a pass: the summary says how many receipts passed, and an
     # observation is not one of them. Two of four here — the third receipt is a check
     # somebody has to have executed and this fixture has not, which the older tests in this

--- a/tests/test_mut_accept.py
+++ b/tests/test_mut_accept.py
@@ -60,7 +60,8 @@ SIGNED = [
 def completed(execution):
     assert type(execution) is outcome.Execution
     assert execution.result == outcome.result("PASS")
-    assert execution.changes and execution.changes[0].status == "APPLIED"
+    assert execution.changes
+    assert execution.changes[0].status == "APPLIED"
     return execution
 
 
@@ -398,7 +399,8 @@ def test_an_earlier_acceptance_of_the_same_finding_counts_as_the_first_renewal(
     assert renewal["renews_digest"].startswith("sha256:")
     # The record it renews is left exactly as it was published.
     original = next(record for record in published if record["renewals"] == 0)
-    assert original["id"] == "R-001-01" and original["renews"] == ""
+    assert original["id"] == "R-001-01"
+    assert original["renews"] == ""
 
 
 def test_the_spec_is_never_opened_for_write_whatever_it_contains(repo, capsys, monkeypatch):

--- a/tests/test_mut_acceptance.py
+++ b/tests/test_mut_acceptance.py
@@ -292,7 +292,8 @@ def test_a_continued_value_is_joined_with_one_space_however_it_was_indented():
 
     read = _read("finding: a finding\n    that continues\n\there\nexpires: 2026-11-14\n")
 
-    assert read is not None and read["finding"] == "a finding that continues here"
+    assert read is not None
+    assert read["finding"] == "a finding that continues here"
 
 
 def test_an_indented_line_before_any_key_is_refused_rather_than_dropped():
@@ -423,7 +424,9 @@ def test_the_optional_fields_are_only_checked_when_they_are_there():
 
     record = _normal()
 
-    assert record["accepted"] == "" and record["id"] == "" and record["evidence"] == ""
+    assert record["accepted"] == ""
+    assert record["id"] == ""
+    assert record["evidence"] == ""
     assert _normal(evidence="specs/010-x/spec.md@sha256:" + "a" * 64)["evidence"]
 
 

--- a/tests/test_mut_cli_json.py
+++ b/tests/test_mut_cli_json.py
@@ -316,7 +316,8 @@ def test_an_unknown_verb_complains_on_stderr_and_leaves_the_list_on_stdout(capsy
     code, out, err = _ran(["notaverb"], capsys)
 
     assert code == 2
-    assert "there is no verb" in err and "notaverb" in err
+    assert "there is no verb" in err
+    assert "notaverb" in err
     assert "doctor" in out and "there is no verb" not in out
 
 

--- a/tests/test_mut_madr.py
+++ b/tests/test_mut_madr.py
@@ -60,7 +60,8 @@ def test_a_file_that_does_not_open_with_a_fence_is_not_a_record_and_is_not_a_pro
     parsed = madr._parse(b"# just a heading\n\ntext\n")
 
     assert parsed.problem is None
-    assert parsed.fields == {} and parsed.raw_fields == {}
+    assert parsed.fields == {}
+    assert parsed.raw_fields == {}
     assert parsed.declares_v1 is False and parsed.ambiguous_candidate is False
 
 

--- a/tests/test_mut_noted.py
+++ b/tests/test_mut_noted.py
@@ -27,7 +27,8 @@ def test_a_noted_is_a_string_and_still_distinguishable_from_a_problem():
 
     noted = doctor.Noted("nineteen files")
 
-    assert isinstance(noted, str) and noted == "nineteen files"
+    assert isinstance(noted, str)
+    assert noted == "nineteen files"
     assert isinstance(noted, doctor.Noted)
     assert not isinstance("a stray in .ai-engineering/", doctor.Noted)
 

--- a/tests/test_mut_record.py
+++ b/tests/test_mut_record.py
@@ -128,7 +128,8 @@ def report(tmp_path, monkeypatch, capsys):
         execution = report_command.main(["digest", *argv])
         assert type(execution) is outcome.Execution
         assert execution.result == outcome.result("PASS")
-        assert execution.checks and execution.changes[0].status == "APPLIED"
+        assert execution.checks
+        assert execution.changes[0].status == "APPLIED"
         return capsys.readouterr().out.splitlines()
 
     state.run = run

--- a/tests/test_mut_report_issue.py
+++ b/tests/test_mut_report_issue.py
@@ -70,7 +70,9 @@ def test_the_draft_carries_the_digest_of_what_was_built(tmp_path: Path, capsys):
     capsys.readouterr()
 
     digests = [fact.detail for fact in done.checks if fact.id == "digest"]
-    assert digests and len(digests[0]) == 64 and int(digests[0], 16) >= 0
+    assert digests
+    assert len(digests[0]) == 64
+    assert int(digests[0], 16) >= 0
 
 
 def test_a_finding_in_the_bytes_stops_the_report_and_leaves_no_file(tmp_path: Path, capsys):
@@ -213,7 +215,8 @@ def test_the_cure_tells_a_person_what_to_type_and_where(tmp_path, monkeypatch):
     done = report.submit(_payload(), tmp_path / "draft.json")
     cures = [fact.cure for fact in done.checks if fact.id == "consent"]
 
-    assert cures and "at a terminal" in cures[0]
+    assert cures
+    assert "at a terminal" in cures[0]
     assert issue.digest(_payload())[:16] in cures[0]
 
 
@@ -330,4 +333,5 @@ def test_rule_twelve_counts_a_reason_and_not_only_a_guard():
 
     assert counted == 2, "one guard, two reasons, two judgements"
     assert highest == 3, "blocked and bypassed are the same judgement resolving"
-    assert len(rows) == 1 and "3×" in rows[0]
+    assert len(rows) == 1
+    assert "3×" in rows[0]

--- a/tests/test_mut_spec.py
+++ b/tests/test_mut_spec.py
@@ -160,7 +160,9 @@ def test_a_spec_whose_bytes_are_not_utf8_still_appears_in_the_listing(tmp_path):
     folder.mkdir(parents=True)
     (folder / "spec.md").write_bytes(b"---\nstatus: draft\n---\n\n# Caf\xe9 plan\n")
     (row,) = spec.listing(tmp_path, False)
-    assert row.split()[0] == "001-a" and " draft " in row and row.endswith("plan")
+    assert row.split()[0] == "001-a"
+    assert " draft " in row
+    assert row.endswith("plan")
 
 
 def test_a_spec_with_no_status_and_no_title_lists_under_its_own_folder_name(tmp_path):
@@ -197,7 +199,8 @@ def test_spec_new_records_the_work_item_named_on_the_flag_and_prefills_nothing(
     assert result.outcome == "PASS"
     assert capsys.readouterr().out == "  ✓ specs/001-a-thing/spec.md\n"
     body = (approved_repo / "specs" / "001-a-thing" / "spec.md").read_text()
-    assert "# A thing" in body and 'ref: "owner/repo#45"' in body
+    assert "# A thing" in body
+    assert 'ref: "owner/repo#45"' in body
     assert "TODO: what is true today" in body
 
 
@@ -212,7 +215,8 @@ def test_spec_show_prints_every_directory_that_matches_and_names_each_one(repo, 
     assert type(result) is outcome.Result
     assert result.outcome == "PASS"
     out = capsys.readouterr().out
-    assert "001-thing" in out and "002-other-thing" in out
+    assert "001-thing" in out
+    assert "002-other-thing" in out
     assert out.count("## Production-ready") == 2
     result = spec.main(["show", "001"])
     assert type(result) is outcome.Result
@@ -353,7 +357,8 @@ def test_decide_madr_writes_the_file_and_says_it_grants_no_authority(repo, capsy
     ]
     body = (repo / "docs" / "adr" / "0001-use-one-queue.md").read_text()
     assert "# 0001. Use one queue" in body
-    assert 'status: "proposed"' in body and 'spec: "001"' in body
+    assert 'status: "proposed"' in body
+    assert 'spec: "001"' in body
     assert 'supersedes: ""' in body and "authority_role:" not in body
 
 
@@ -490,10 +495,12 @@ def test_a_granted_bypass_is_one_file_one_event_and_says_who_took_it(home, monke
         "  ✓ granted. The next loop_guard block passes, once, and the record says why."
     )
     names = sorted(path.name for path in paths.home().iterdir())
-    assert "cache" in names and "CACHE" not in names
+    assert "cache" in names
+    assert "CACHE" not in names
     assert [path.name for path in (paths.home() / "cache").iterdir()] == ["bypass.json"]
     grant = json.loads((paths.home() / "cache" / "bypass.json").read_text())
-    assert grant["guard"] == "loop_guard" and grant["reason"] == "in a hurry"
+    assert grant["guard"] == "loop_guard"
+    assert grant["reason"] == "in a hurry"
     event = json.loads(home.chain_path(None).read_text().splitlines()[-1])
     assert event["name"] == "loop_guard" and event["cls"] == "bypassed"
     assert event["data"] == {"reason": "in a hurry", "granted": "by a person"}
@@ -587,7 +594,8 @@ def test_the_refusal_names_which_two_values_disagree():
     approval = {"approval_ref": "abc"}
 
     asleep = spec._why_not_authority("draft", "owner", "owner", transition, approval)
-    assert "'draft'" in asleep and "active" in asleep
+    assert "'draft'" in asleep
+    assert "active" in asleep
 
     mismatched = spec._why_not_authority(
         "active", "repository owner", "maintainer", transition, approval

--- a/tests/test_mut_wiring.py
+++ b/tests/test_mut_wiring.py
@@ -322,7 +322,8 @@ def test_forgetting_a_row_leaves_every_other_row_and_the_head_fields(machine):
     wiring.forget(rows[:2])
     data = json.loads(wiring.receipt_path().read_text())
     assert data["wrote"] == rows[2:], "forget took the wrong rows"
-    assert data["machine_id"] and data["version"] == __version__, "forget ate the head fields"
+    assert data["machine_id"]
+    assert data["version"] == __version__, "forget ate the head fields"
 
 
 def test_forgetting_matches_on_the_same_key_record_deduplicates_by(machine):
@@ -652,7 +653,8 @@ def test_paths_prints_the_record_of_the_repository_doctor_actually_found(
     monkeypatch.setattr(paths, "repo_root", lambda start=None: root)
 
     result = doctor.main(["--paths"])
-    assert type(result) is outcome.Result and result.outcome == "PASS"
+    assert type(result) is outcome.Result
+    assert result.outcome == "PASS"
     out = capsys.readouterr().out
     assert f"  record        {emit.chain_path(root)}" in out
     assert str(emit.chain_path(None)) not in out
@@ -789,7 +791,8 @@ def test_a_router_is_generated_hashed_and_recorded_for_the_surface_that_declares
     for row in written:
         assert row["kind"] == "router"
         target = Path(row["path"])
-        assert target.is_file() and target.parent == commands
+        assert target.is_file()
+        assert target.parent == commands
         marker, _, digest = row["how"].partition(" ")
         assert marker == "generated" and len(digest) == 64
         body = target.read_text(encoding="utf-8")

--- a/tests/test_orphan_register.py
+++ b/tests/test_orphan_register.py
@@ -117,7 +117,8 @@ def test_an_orchestrator_future_row_cites_the_orchestrator_spec():
                 spec_dir = next((ROOT / "specs").glob(f"{spec_id}-*"), None)
                 assert spec_dir is not None, f"{name}: cites spec {spec_id} which does not exist"
                 home = spec_dir / "spec.md"
-                assert home.is_file() and name in home.read_text(encoding="utf-8"), (
+                assert home.is_file()
+                assert name in home.read_text(encoding="utf-8"), (
                     f"{name}: spec {spec_id} never mentions it"
                 )
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -212,7 +212,8 @@ def test_execution_facts_are_bounded_without_widening_the_result_schema() -> Non
     assert execution.result.as_dict() == terminal.as_dict()
     assert set(execution.result.as_dict()) == set(json.loads(SCHEMA_PATH.read_text())["required"])
     assert len(bounded.summary) == 512
-    assert "\x1b" not in bounded.detail and "\n" not in bounded.detail
+    assert "\x1b" not in bounded.detail
+    assert "\n" not in bounded.detail
     assert execution.error is None
 
     failed = outcome.execution(outcome.result("FAIL"))

--- a/tests/test_p0_completeness.py
+++ b/tests/test_p0_completeness.py
@@ -261,4 +261,5 @@ def test_the_gate_checks_the_page_is_about_this_tree():
     assert "\nintent-page:\n" in recipe
     # And it is the module's own answer, not a second implementation of freshness.
     body = recipe.split("\nintent-page:\n", 1)[1].split("\n\n", 1)[0]
-    assert "solution_intent" in body and "--check" in body
+    assert "solution_intent" in body
+    assert "--check" in body

--- a/tests/test_pilot_register.py
+++ b/tests/test_pilot_register.py
@@ -227,7 +227,9 @@ def test_a_requirement_nobody_will_gate_says_what_would_change_that():
 
     for row in rows:
         assert str(row["id"]).startswith("EP-"), row
-        assert row["asks"].strip() and row["reason"].strip() and row["reopen_when"].strip()
+        assert row["asks"].strip()
+        assert row["reason"].strip()
+        assert row["reopen_when"].strip()
 
     # Each of the three fields is required, and the reader is shown refusing each absence.
     for missing in ("asks", "reason", "reopen_when"):

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -860,7 +860,8 @@ def test_every_recipe_the_gate_runs_is_named_here_with_its_control_or_its_reason
         "there, and the case that executes them names exactly these two"
     )
     reasons = [name for name in ordered if name == "build"]
-    assert len(reasons) == 1 and len(ordered) - len(reasons) >= 12, (
+    assert len(reasons) == 1
+    assert len(ordered) - len(reasons) >= 12, (
         f"{len(reasons)} of {len(ordered)} recipes are held by a reason alone. That is "
         "allowed and it is the number worth watching: a gate whose recipes are mostly "
         "argued is a gate mostly nobody has seen refuse"

--- a/tests/test_ran_receipt.py
+++ b/tests/test_ran_receipt.py
@@ -181,7 +181,8 @@ def test_the_cheap_recipe_records_only_after_the_suite_passes():
     assert len(body) == 2, f"the recipe is {len(body)} lines and the order below reads two"
     assert "pytest" in body[0], "the suite does not run first, so nothing is being recorded"
     assert "ran_receipt.py record" in body[1], "nothing records the pass"
-    assert "||" not in body[1] and body[1][:1] != "-", (
+    assert "||" not in body[1]
+    assert body[1][:1] != "-", (
         "the record line is written so it survives the line above failing, which makes the "
         "receipt a claim about a suite that did not pass"
     )
@@ -202,7 +203,8 @@ def test_the_digest_the_receipt_carries_comes_from_the_package(repository: Path)
     from ai_engineering import evidence
 
     spec = importlib.util.spec_from_file_location("ran_receipt_probe", SCRIPT)
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     script = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(script)
 

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -224,7 +224,8 @@ def test_adversarial_runner_records_denials_and_clean_control(tmp_path, monkeypa
     monkeypatch.setenv("AI_ENGINEERING_HOME", str(tmp_path / "home"))
     adversarial = _adversarial()
     caught, version = adversarial.probe(["git", "--version"])
-    assert caught and version.startswith("git version ")
+    assert caught
+    assert version.startswith("git version ")
     absent, nothing = adversarial.probe([str(tmp_path / "no-such-tool"), "--version"])
     assert (absent, nothing) == (False, "")
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -85,7 +85,8 @@ def _fixture_spec(root: Path, slug: str, ref: str = "") -> Path:
 def completed(execution):
     assert type(execution) is outcome.Execution
     assert execution.result == outcome.result("PASS")
-    assert execution.changes and execution.changes[0].status == "APPLIED"
+    assert execution.changes
+    assert execution.changes[0].status == "APPLIED"
     return execution
 
 
@@ -690,7 +691,8 @@ def test_proposing_a_supersession_preserves_the_old_madr_and_the_spec(tmp_path):
     assert second.name == "0002-use-two-queues.md"
     assert first.read_bytes() == first_before
     header = text.flat_yaml(second.read_text().split("---\n", 1)[1].split("---\n", 1)[0])
-    assert header["spec"] == "001" and header["supersedes"] == "0001"
+    assert header["spec"] == "001"
+    assert header["supersedes"] == "0001"
     assert header["status"] == "proposed" and header["date"] == TODAY
     assert target.read_bytes() == spec_before
     assert [row.split()[0] for row in decide.listing(tmp_path)] == [
@@ -1045,7 +1047,8 @@ def test_a_verb_that_blows_up_is_recorded_before_the_person_is_told(home, monkey
     monkeypatch.setattr(exception, "main", boom)
     assert cli.main(["exception"]) == 1
     printed = capsys.readouterr().err
-    assert "UNEXPECTED_ERROR" in printed and "Traceback" not in printed
+    assert "UNEXPECTED_ERROR" in printed
+    assert "Traceback" not in printed
     assert "RuntimeError" not in printed
     events = [json.loads(line) for line in home.chain_path(None).read_text().splitlines()]
     assert [event["cls"] for event in events] == ["error", "command"]
@@ -1151,7 +1154,8 @@ def test_a_broken_link_is_printed_with_the_command_that_answers_it():
     assert "ai-eng audit account --range FIRST-LAST" in said
     assert "never erased" in said
     # And it names the likeliest innocent cause without deciding it is the cause.
-    assert "AI_ENGINEERING_HOME" in said and "before you decide which it was" in said
+    assert "AI_ENGINEERING_HOME" in said
+    assert "before you decide which it was" in said
 
     # A chain with nothing broken says nothing. A cure printed under a clean report is
     # noise, and noise is how the next real one gets skipped.
@@ -1203,7 +1207,8 @@ def test_every_block_hand_off_carries_a_reviewer_a_repair_and_a_gate():
         for line in table.splitlines():
             if line.startswith(("| reviewer disposition", "| gate", "| independent")):
                 cells = [one.strip() for one in line.strip("|").split("|")]
-                assert len(cells) == 2 and cells[1], f"Block {name}: {cells[0]!r} is empty"
+                assert len(cells) == 2
+                assert cells[1], f"Block {name}: {cells[0]!r} is empty"
 
 
 def test_the_account_command_says_what_to_type_before_it_waits_for_it(home, monkeypatch, capsys):
@@ -1333,7 +1338,8 @@ def test_show_hands_over_one_task_as_an_envelope(repo, capsys):
     assert "rollback: `git revert <commit>`" in out
     assert "done when: thing 2 works" in out
     # The two digests it was read under, so a hand-off names the bytes it came from.
-    assert "spec: sha256:" in out and "plan: sha256:" in out
+    assert "spec: sha256:" in out
+    assert "plan: sha256:" in out
     # And nothing else: the specification body is not printed beside it.
     assert "## Production-ready" not in out
     # Small enough to hand over — measured against the real tree, not this fixture. Task 16

--- a/tests/test_report_blocked.py
+++ b/tests/test_report_blocked.py
@@ -91,7 +91,8 @@ def test_an_emoji_in_the_reason_does_not_brick_the_ledger(repo):
     assert ran.outcome == "PASS", ran
 
     rows, dropped = blocked.stops(repo)
-    assert len(rows) == 1 and dropped == []
+    assert len(rows) == 1
+    assert dropped == []
     assert "\U0001f6ab" in rows[0].why
     assert "\t" in rows[0].why
     assert '"quote"' in rows[0].why

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -87,7 +87,8 @@ def test_a_crash_is_incomplete_and_not_a_finding(tmp_path):
     fact = scan.run(lane, tmp_path, ["src/thing.py"])
 
     assert fact.status == "INCOMPLETE"
-    assert "LANE_CRASHED" in fact.detail and "97" in fact.detail
+    assert "LANE_CRASHED" in fact.detail
+    assert "97" in fact.detail
 
 
 def test_a_timeout_is_incomplete_and_the_lane_says_how_long_it_waited(tmp_path):
@@ -284,7 +285,8 @@ def test_the_dependency_answer_names_the_stacks_it_was_about(tmp_path, capsys):
     # And a repository with neither says so rather than printing nothing.
     bare = tmp_path / "bare"
     bare.mkdir()
-    assert scan.stacks(bare) == [] and scan.images(bare) == []
+    assert scan.stacks(bare) == []
+    assert scan.images(bare) == []
 
 
 # EP-043 and the standing overclaim beside it. `ai-security` defines a finding as seven
@@ -528,7 +530,8 @@ def test_sarif_shaped_differently_yields_findings_or_none_and_never_a_traceback(
     lane = scan.Lane("odd", writer(tmp_path, body), sarif=("--out", "{}"))
     for finding in scan.report(lane, tmp_path, ["src/thing.py"]):
         assert finding.state == "INCOMPLETE", name
-        assert isinstance(finding.effect, str) and isinstance(finding.decided_by, str)
+        assert isinstance(finding.effect, str)
+        assert isinstance(finding.decided_by, str)
 
 
 def test_a_manifest_one_directory_down_is_covered_by_the_file_the_engine_read(tmp_path):
@@ -613,7 +616,8 @@ def test_the_gate_asks_the_cross_checks_and_does_not_only_declare_them(
     )
     assert scan.baseline(tmp_path) == 1
     printed = capsys.readouterr().out
-    assert "INCOMPLETE  second-opinion" in printed and "LANE_CRASHED" in printed
+    assert "INCOMPLETE  second-opinion" in printed
+    assert "LANE_CRASHED" in printed
 
 
 def only_the_report(monkeypatch):
@@ -1044,7 +1048,8 @@ def test_the_security_lane_prints_every_finding_a_failing_engine_gave_it(
     printed = capsys.readouterr().out
     assert "FAIL        semantic      it ran over 1 input(s) and found something" in printed
     assert "INCOMPLETE  semantic      a real hit" in printed
-    assert "decided by" in printed and "a.py:3" in printed
+    assert "decided by" in printed
+    assert "a.py:3" in printed
     assert "nobody has answered: boundary, attacker_controls, refutation, closed_by" in printed
 
 

--- a/tests/test_solution_intent.py
+++ b/tests/test_solution_intent.py
@@ -176,7 +176,8 @@ def test_a_row_that_changed_makes_the_page_stale(tmp_path):
 
     tree = solution_intent.read(ROOT)
     payload = solution_intent.digested(tree)
-    assert "blocked" in payload and "considered" in payload
+    assert "blocked" in payload
+    assert "considered" in payload
 
     assert tree.blocked, "this tree has unapproved drafts and BLOCKED verdicts"
     assert tree.considered >= len(tree.blocked)

--- a/tests/test_surface_adapter.py
+++ b/tests/test_surface_adapter.py
@@ -388,7 +388,8 @@ def test_surface_proof_reports_three_states_and_invents_none(tmp_path, monkeypat
 
     # Unproven anywhere means unproven overall. One receipt does not make a surface proved.
     assert result.outcome == "INCOMPLETE"
-    assert "claude-code" in printed and "discovery" in printed
+    assert "claude-code" in printed
+    assert "discovery" in printed
     assert "7200s" in printed, "the age of the proof is printed beside it"
     for state in surface.STATES:
         assert state in printed, state
@@ -942,7 +943,8 @@ def test_an_adapter_past_its_first_version_carries_that_version_in_its_receipt_i
     said = surface.receipt_binds_version(
         {"adapter_version": "2", "proof": {"receipt_id": "claude-code.enforcement"}}
     )
-    assert "version 2" in said and "claude-code.enforcement" in said
+    assert "version 2" in said
+    assert "claude-code.enforcement" in said
     assert "still proves this one" in said
 
 

--- a/tests/test_threat_model.py
+++ b/tests/test_threat_model.py
@@ -131,7 +131,8 @@ def test_the_router_a_person_meets_names_the_phase_and_shows_an_example():
         assert f"# {skill.name} · {phase}" in body
         assert case in body
         # And still no second copy of the instructions: the router routes.
-        assert "$ARGUMENTS" in body and "## Steps" not in body
+        assert "$ARGUMENTS" in body
+        assert "## Steps" not in body
 
 
 def test_a_skill_with_no_declared_phase_says_so_rather_than_reading_as_one():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -127,7 +127,8 @@ def test_cli_noninteractive_json_is_one_object_and_never_null(monkeypatch, capsy
     behavior["main"] = successful
     assert cli.main(["doctor", "--json"]) == 0
     rendered = capsys.readouterr()
-    assert rendered.err == "" and rendered.out.count("\n") == 1
+    assert rendered.err == ""
+    assert rendered.out.count("\n") == 1
     assert "child" not in rendered.out and "\x1b[" not in rendered.out
     payload = json.loads(rendered.out)
     # `schema` first, and it is new. The envelope carried a version number for a document

--- a/tests/test_unreviewed.py
+++ b/tests/test_unreviewed.py
@@ -32,7 +32,9 @@ def test_the_hand_offs_are_read_from_the_record_and_not_written_here():
 
     assert len(found) >= 3, f"{found} — three blocks have closed and each names both ends"
     for name, base, head, looked in found:
-        assert name and base and head, (name, base, head)
+        assert name
+        assert base
+        assert head, (name, base, head)
         assert looked, f"Block {name}'s hand-off names no reviewer"
 
 
@@ -81,4 +83,5 @@ def test_the_words_for_nobody_having_looked_include_the_empty_cell():
     with the row left to fill in. It must read as nobody, not as an answer nobody parsed."""
 
     assert "" in unreviewed.NOBODY
-    assert "none" in unreviewed.NOBODY and "pending" in unreviewed.NOBODY
+    assert "none" in unreviewed.NOBODY
+    assert "pending" in unreviewed.NOBODY

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -88,7 +88,8 @@ def test_the_width_is_one_while_the_intent_says_one_writer(coordinated):
     assert result.outcome == "PASS"
     assert result.summary == "width: 1"
     assert ".ai/intent.md" in facts["one-writer"]
-    assert "work-alpha" in facts["wave"] and "work-beta" in facts["wave"]
+    assert "work-alpha" in facts["wave"]
+    assert "work-beta" in facts["wave"]
     assert "4" in facts["declared-width"]
     # Observations, never a verdict about the branch.
     assert {fact.status for fact in result.checks} == {"OBSERVED"}


### PR DESCRIPTION
## What changed, in plain words

Ninety-nine test assertions of the shape "assert A and B" became two separate asserts, so a failure names the half that failed. The either/or forms stay as they are. One regex in the intent validator now uses the concise digit class — same matches, every timestamp it accepts is ASCII. Full suite green; the multi-home check reads green on the merge result (both commits touch different homes on this branch by design of the split).

## What to look at first

`tests/` — 45 files, each change mechanical.

## Not confident about

Nothing. If a split assertion hides an ordering dependency, the suite would have caught it: it is green.