### PR TITLE
docs(intent): rebuild the page over the audit typefix tree

### DIFF
--- a/docs/solution-intent.html
+++ b/docs/solution-intent.html
@@ -79,7 +79,7 @@ color:var(--muted);font-size:.88em}
 @media print{body{font-size:11pt}.scroll{overflow:visible}th{position:static}}
 </style>
 </head>
-<body data-inputs-digest="4564c406565593c6da1f892e1316cd3328f89093220144ff0200bd2b9d8c4fd5">
+<body data-inputs-digest="f77655289899886e75533ce0c1d922fe7e271513917fca8e4ae60613e351e41e">
 <div class="wrap">
 <header class="hero">
   <h1>Governed agentic engineering</h1>
@@ -88,7 +88,7 @@ color:var(--muted);font-size:.88em}
   repository's files, so it cannot go stale without the gate saying so.</p>
   <div class="stamp">
     <span>Intent status: active</span>
-    <span>inputs-digest 4564c406565593c6…</span>
+    <span>inputs-digest f77655289899886e…</span>
     <span>no date and no HEAD: what cannot be signed is not printed</span>
   </div>
 </header>
@@ -103,7 +103,7 @@ color:var(--muted);font-size:.88em}
     <div class="card"><span class="n">18</span><span class="k">skills</span><span class="s">80 lines each at most</span></div>
     <div class="card"><span class="n">4</span><span class="k">fail-closed guards</span><span class="s">+2 telemetry</span></div>
     <div class="card"><span class="n">10</span><span class="k">CLI verbs</span><span class="s">src/ai_engineering/cli.py</span></div>
-    <div class="card"><span class="n">2.14:1</span><span class="k">tests against product</span><span class="s">max 2.3:1 · 39.252 / 18.367</span></div>
+    <div class="card"><span class="n">2.14:1</span><span class="k">tests against product</span><span class="s">max 2.3:1 · 39.254 / 18.379</span></div>
     <div class="card"><span class="n">0/8</span><span class="k">production boxes proven</span><span class="s">READINESS_DECLARATION_MISSING</span></div>
   </div>
 </section>


### PR DESCRIPTION
Generated page; the tree moved one typefix ago.